### PR TITLE
Feature install requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/elifesciences/elifearticle.git@aa9ee22091821f19b655b0d0b22c998f3318d21d#egg=elifearticle
+git+https://github.com/elifesciences/elife-article.git@aa9ee22091821f19b655b0d0b22c998f3318d21d#egg=elifearticle
 GitPython==0.3.2.1
 configparser==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-elifearticle==0.1.1
+git+https://github.com/elifesciences/elifearticle.git@aa9ee22091821f19b655b0d0b22c998f3318d21d#egg=elifearticle
 GitPython==0.3.2.1
 configparser==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,12 @@ import elifecrossref
 with open('README.rst') as fp:
     readme = fp.read()
 
-with open('requirements.txt') as f:
-    install_requires = f.read().splitlines()
-
 setup(name='elifecrossref',
     version=elifecrossref.__version__,
     description='eLife Crossref deposit of journal articles.',
     long_description=readme,
     packages=['elifecrossref'],
     license = 'MIT',
-    install_requires=install_requires,
     url='https://github.com/elifesciences/elife-crossref-xml-generation',
     maintainer='eLife Sciences Publications Ltd.',
     maintainer_email='py@elifesciences.org',


### PR DESCRIPTION
Run with this for a while to use specific commits of elife-article code, removing ``install_requires`` from ``setup.py``. This is rather than also specifying ``dependency_links`` in ``setup.py`` with the specific commit, since it would be duplicated and this is not used as a pypi library itself yet.