### PR TITLE
Pinpointed test case for component caption inline tagging

### DIFF
--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -256,7 +256,7 @@ class crossrefXML(object):
             self.set_abstract_tag(parent, abstract, type="abstract")
 
     def set_digest(self, parent, poa_article):
-        if poa_article.digest:
+        if hasattr(poa_article, 'digest') and poa_article.digest:
             self.set_abstract_tag(parent, poa_article.digest, type="executive-summary")
 
     def set_abstract_tag(self, parent, abstract, type):
@@ -337,7 +337,8 @@ class crossrefXML(object):
 
         applies_to = self.crossref_config.get("access_indicators_applies_to")
 
-        if len(applies_to) > 0 and poa_article.license.href:
+        if (len(applies_to) > 0 and hasattr(poa_article, 'license')
+            and poa_article.license and poa_article.license.href):
 
             self.ai_program = SubElement(parent, 'ai:program')
             self.ai_program.set('name', 'AccessIndicators')

--- a/tests/test_generate_component_list.py
+++ b/tests/test_generate_component_list.py
@@ -1,0 +1,33 @@
+import unittest
+import time
+import os
+import re
+from elifecrossref import generate
+from elifecrossref.conf import config
+from elifearticle.article import Article, Component
+
+class TestGenerateComponentList(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_component_subtitle(self):
+        "build an article object and component, generate Crossref XML"
+        doi = "10.7554/eLife.00666"
+        title = "Test article"
+        article = Article(doi, title)
+        component = Component()
+        component.title = "A component"
+        component.subtitle = "A <sc>STRANGE</sc> <italic>subtitle</italic>, and this tag is <not_allowed>!</not_allowed>"
+        expected_subtitle = "A <sc>STRANGE</sc> <i>subtitle</i>, and this tag is &lt;not_allowed&gt;!&lt;/not_allowed&gt;"
+        article.component_list = [component]
+        # generate the crossrefXML
+        cXML = generate.build_crossref_xml([article])
+        crossref_xml_string = cXML.output_XML()
+        self.assertIsNotNone(crossref_xml_string)
+        # A quick test just look for the expected string to test for tags and escape characters
+        self.assertTrue(expected_subtitle in crossref_xml_string)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Test for caption subtitle by programmatically building an object, and small tweaks to make generating from partial objects easier.