### PR TITLE
Simplify author sequence value, does not need their corresponding aut…

### DIFF
--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -383,10 +383,7 @@ class CrossrefXML(object):
 
                 self.person_name.set("contributor_role", contributor_role)
 
-                if contributor.corresp is True or contributor.equal_contrib is True:
-                    self.person_name.set("sequence", sequence)
-                else:
-                    self.person_name.set("sequence", sequence)
+                self.person_name.set("sequence", sequence)
 
                 self.given_name = SubElement(self.person_name, "given_name")
                 self.given_name.text = contributor.given_name


### PR DESCRIPTION
…hor or equal contribution status to always set just one author as first, the first author.

Fixes https://github.com/elifesciences/elife-crossref-feed/issues/122.