### PR TITLE
Fix for an edge case where angle brackets were not escaped properly.

### DIFF
--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -906,7 +906,7 @@ class CrossrefXML(object):
         tag_converted_string = self.clean_tags(original_string)
         tag_converted_string = etoolsutils.escape_ampersand(tag_converted_string)
         tag_converted_string = etoolsutils.escape_unmatched_angle_brackets(
-            tag_converted_string, utils.allowed_tags())
+            tag_converted_string)
         tagged_string = ('<' + tag_name + namespaces + '>' +
                          tag_converted_string + '</' + tag_name + '>')
         reparsed = minidom.parseString(tagged_string.encode('utf-8'))

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -315,5 +315,27 @@ class TestGenerateCrossrefDataCitation(unittest.TestCase):
         self.assertTrue(expected_contains in crossref_xml_string)
 
 
+class TestAddCleanTag(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_add_clean_tag(self):
+        "test add_clean_tag to check edge cases"
+        # start with creating a Crossref object with a basic article object
+        doi = "10.7554/eLife.00666"
+        title = "Test article"
+        article = Article(doi, title)
+        c_xml = generate.build_crossref_xml([article])
+        root = Element('root')
+        # add the element
+        c_xml.add_clean_tag(root, 'p', '<test>')
+        self.assertEqual(ElementTree.tostring(root), '<root><p>&lt;test&gt;</p></root>')
+        # strange example based on eLife 28716 v2 Figure 2 caption
+        root = Element('root')
+        c_xml.add_clean_tag(root, 'subtitle', '...polarization, <<italic>p</italic>>, and its variance...')
+        self.assertEqual(ElementTree.tostring(root), '<root><subtitle>...polarization, &lt;p&gt;, and its variance...</subtitle></root>')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I noticed ``elife-28716-v2.xml`` has remained in the Crossref outbox since Nov 17th, and it was not approved for Crossref delivery. I downloaded it to test locally, and it had an issue with a subtitle having an unmatched angle bracket.

The situation presented itself in a figure caption had

```<<italic>p</italic>>```

Adding this to a Crossref component subtitle, it strips out known tags first. italic is a known tag so after stripping it ended up with

```<p>```

Shortly after it escapes unmatched angle brackets, but ``<p>`` is on the list of allowed tags that were passed in. In this situation, no allowed tags should have been passed in (since all the allowed tags were already stripped out, all the remaining angle brackets should be escaped).

We want the output in the Crossref deposit escaped as

```&lt;p&gt;```

This change should fix it and there's a test to support it.

For @giorgiosironi beyond reviewing the code, if you would like to, this merged version of elifecrossref should get updated in the ``elife-bot`` project and deployed. I can prepare that PR too for review after this is merged.