### PR TITLE
Include epub-ppub as a valid pub-date type in the default settings.

### DIFF
--- a/crossref.cfg
+++ b/crossref.cfg
@@ -15,7 +15,7 @@ elife_style_component_doi: false
 archive_locations: ["CLOCKSS"]
 elocation_id: true
 access_indicators_applies_to: ["vor", "am", "tdm"]
-pub_date_types: ["pub", "publication", "epub"]
+pub_date_types: ["pub", "publication", "epub", "epub-ppub"]
 reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-crossref-feed/issues/124