### PR TITLE
Feature crossref parsing tweaks

### DIFF
--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -52,6 +52,11 @@ class CrossrefXML(object):
                                    ' from version ' + self.last_commit)
             self.root.append(self.comment)
 
+        # namespaces for when reparsing XML strings
+        self.reparsing_namespaces = (''' xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1"
+                                     xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                                     xmlns:xlink="http://www.w3.org/1999/xlink" ''')
+
         # Build out the Crossref XML
         self.build(poa_articles)
 
@@ -428,9 +433,6 @@ class CrossrefXML(object):
     def set_abstract_tag(self, parent, abstract, abstract_type):
 
         tag_name = 'jats:abstract'
-        namespaces = (''' xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1"
-                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                      xmlns:xlink="http://www.w3.org/1999/xlink" ''')
 
         attributes = []
         attributes_text = ''
@@ -471,7 +473,7 @@ class CrossrefXML(object):
             tag_converted_abstract = eautils.replace_tags(tag_converted_abstract, 'p', 'jats:p')
             tag_converted_abstract = tag_converted_abstract
 
-        tagged_string = '<' + tag_name + namespaces + attributes_text + '>'
+        tagged_string = '<' + tag_name + self.reparsing_namespaces + attributes_text + '>'
         tagged_string += tag_converted_abstract
         tagged_string += '</' + tag_name + '>'
         reparsed = minidom.parseString(tagged_string.encode('utf-8'))
@@ -917,13 +919,11 @@ class CrossrefXML(object):
 
     def add_clean_tag(self, parent, tag_name, original_string):
         "remove allowed tags and then add a tag the parent"
-        namespaces = (''' xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                      xmlns:xlink="http://www.w3.org/1999/xlink" ''')
         tag_converted_string = self.clean_tags(original_string)
         tag_converted_string = etoolsutils.escape_ampersand(tag_converted_string)
         tag_converted_string = etoolsutils.escape_unmatched_angle_brackets(
             tag_converted_string)
-        tagged_string = ('<' + tag_name + namespaces + '>' +
+        tagged_string = ('<' + tag_name + self.reparsing_namespaces + '>' +
                          tag_converted_string + '</' + tag_name + '>')
         reparsed = minidom.parseString(tagged_string.encode('utf-8'))
         root_xml_element = xmlio.append_minidom_xml_to_elementtree_xml(
@@ -932,10 +932,8 @@ class CrossrefXML(object):
 
     def add_inline_tag(self, parent, tag_name, original_string):
         "replace inline tags found in the original_string and then add a tag the parent"
-        namespaces = (''' xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                      xmlns:xlink="http://www.w3.org/1999/xlink" ''')
         tag_converted_string = self.convert_inline_tags(original_string)
-        tagged_string = '<' + tag_name + namespaces + '>' + tag_converted_string + '</' + tag_name + '>'
+        tagged_string = '<' + tag_name + self.reparsing_namespaces + '>' + tag_converted_string + '</' + tag_name + '>'
         reparsed = minidom.parseString(tagged_string.encode('utf-8'))
         root_xml_element = xmlio.append_minidom_xml_to_elementtree_xml(
             parent, reparsed

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -236,10 +236,12 @@ class CrossrefXML(object):
         root_tag_name = 'titles'
         tag_name = 'title'
         root_xml_element = Element(root_tag_name)
+        # remove unwanted tags
+        tag_converted_title = eautils.remove_tag('ext-link', poa_article.title)
         if self.crossref_config.get('face_markup') is True:
-            self.add_inline_tag(root_xml_element, tag_name, poa_article.title)
+            self.add_inline_tag(root_xml_element, tag_name, tag_converted_title)
         else:
-            self.add_clean_tag(root_xml_element, tag_name, poa_article.title)
+            self.add_clean_tag(root_xml_element, tag_name, tag_converted_title)
         parent.append(root_xml_element)
 
     def set_doi_data(self, parent, poa_article):
@@ -915,7 +917,8 @@ class CrossrefXML(object):
 
     def add_clean_tag(self, parent, tag_name, original_string):
         "remove allowed tags and then add a tag the parent"
-        namespaces = ' xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+        namespaces = (''' xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink" ''')
         tag_converted_string = self.clean_tags(original_string)
         tag_converted_string = etoolsutils.escape_ampersand(tag_converted_string)
         tag_converted_string = etoolsutils.escape_unmatched_angle_brackets(
@@ -929,8 +932,10 @@ class CrossrefXML(object):
 
     def add_inline_tag(self, parent, tag_name, original_string):
         "replace inline tags found in the original_string and then add a tag the parent"
+        namespaces = (''' xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink" ''')
         tag_converted_string = self.convert_inline_tags(original_string)
-        tagged_string = '<' + tag_name + '>' + tag_converted_string + '</' + tag_name + '>'
+        tagged_string = '<' + tag_name + namespaces + '>' + tag_converted_string + '</' + tag_name + '>'
         reparsed = minidom.parseString(tagged_string.encode('utf-8'))
         root_xml_element = xmlio.append_minidom_xml_to_elementtree_xml(
             parent, reparsed

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -427,7 +427,8 @@ class CrossrefXML(object):
 
         tag_name = 'jats:abstract'
         namespaces = (''' xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1"
-                      xmlns:mml="http://www.w3.org/1998/Math/MathML" ''')
+                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink" ''')
 
         attributes = []
         attributes_text = ''
@@ -456,6 +457,7 @@ class CrossrefXML(object):
             tag_converted_abstract = eautils.replace_tags(
                 tag_converted_abstract, 'sc', 'jats:sc')
             tag_converted_abstract = eautils.remove_tag('inline-formula', tag_converted_abstract)
+            tag_converted_abstract = eautils.remove_tag('ext-link', tag_converted_abstract)
         else:
             # Strip inline tags, keep the p tags
             tag_converted_abstract = abstract

--- a/elifecrossref/utils.py
+++ b/elifecrossref/utils.py
@@ -12,6 +12,7 @@ def allowed_tags():
         '<sc>', '</sc>',
         '<inline-formula>', '</inline-formula>',
         '<mml:', '</mml:',
+        '<ext-link', '</ext-link>',
     )
 
 def clean_string(string):

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -315,6 +315,47 @@ class TestGenerateCrossrefDataCitation(unittest.TestCase):
         self.assertTrue(expected_contains in crossref_xml_string)
 
 
+class TestGenerateAbstract(unittest.TestCase):
+
+    def setUp(self):
+        self.abstract = '<p><bold><italic><underline><sub><sup>An abstract. <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1601/nm.3602">Desulfocapsa sulfexigens</ext-link>.</sup></sub></underline></italic></bold></p>'
+
+    def test_set_abstract(self):
+        "test stripping unwanted tags from abstract"
+        doi = "10.7554/eLife.00666"
+        title = "Test article"
+        article = Article(doi, title)
+        article.abstract = self.abstract
+        expected_contains = '<jats:abstract><jats:p>An abstract. Desulfocapsa sulfexigens.</jats:p></jats:abstract>'
+        # generate
+        crossref_object = generate.build_crossref_xml([article])
+        crossref_xml_string = crossref_object.output_xml()
+        # test assertion
+        self.assertTrue(expected_contains in crossref_xml_string)
+
+    def test_set_abstract_jats_abstract_format(self):
+        "test the abstract using jats abstract format set to true"
+        doi = "10.7554/eLife.00666"
+        title = "Test article"
+        article = Article(doi, title)
+        article.abstract = self.abstract
+        expected_contains = '<jats:abstract><jats:p><jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>An abstract. Desulfocapsa sulfexigens.</jats:sup></jats:sub></jats:underline></jats:italic></jats:bold></jats:p></jats:abstract>'
+        # generate
+        raw_config = config['elife']
+        jats_abstract = raw_config.get('jats_abstract')
+        face_markup = raw_config.get('face_markup')
+        raw_config['jats_abstract'] = 'true'
+        raw_config['face_markup'] = 'true'
+        crossref_config = parse_raw_config(raw_config)
+        crossref_object = generate.CrossrefXML([article], crossref_config, None, True)
+        crossref_xml_string = crossref_object.output_xml()
+        # test assertion
+        self.assertTrue(expected_contains in crossref_xml_string)
+        # now set the config back to normal
+        raw_config['jats_abstract'] = jats_abstract
+        raw_config['face_markup'] = face_markup
+
+
 class TestAddCleanTag(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -356,6 +356,40 @@ class TestGenerateAbstract(unittest.TestCase):
         raw_config['face_markup'] = face_markup
 
 
+class TestGenerateTitles(unittest.TestCase):
+
+    def setUp(self):
+        self.title = '<bold>Test article</bold> for <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1601/nm.3602">Desulfocapsa sulfexigens</ext-link>'
+
+    def test_set_titles(self):
+        "test stripping unwanted tags from title"
+        doi = "10.7554/eLife.00666"
+        article = Article(doi, self.title)
+        expected_contains = '<titles><title>Test article for Desulfocapsa sulfexigens</title></titles>'
+        # generate
+        crossref_object = generate.build_crossref_xml([article])
+        crossref_xml_string = crossref_object.output_xml()
+        # test assertion
+        self.assertTrue(expected_contains in crossref_xml_string)
+
+    def test_set_titles_face_markup_format(self):
+        "test the title using face markup set to true"
+        doi = "10.7554/eLife.00666"
+        article = Article(doi, self.title)
+        expected_contains = '<titles><title><b>Test article</b> for Desulfocapsa sulfexigens</title></titles>'
+        # generate
+        raw_config = config['elife']
+        face_markup = raw_config.get('face_markup')
+        raw_config['face_markup'] = 'true'
+        crossref_config = parse_raw_config(raw_config)
+        crossref_object = generate.CrossrefXML([article], crossref_config, None, True)
+        crossref_xml_string = crossref_object.output_xml()
+        # test assertion
+        self.assertTrue(expected_contains in crossref_xml_string)
+        # now set the config back to normal
+        raw_config['face_markup'] = face_markup
+
+
 class TestAddCleanTag(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-crossref-feed/issues/125.

When ``<ext-link>`` tags appear in title or abstract values, strip them out of the Crossref file created.

Also some more explicit tests for ``set_abstract()`` and ``set_titles()`` to illustrate the conversion of tags.