### PR TITLE
Feature crossref parsing tweaks

### DIFF
--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -262,7 +262,7 @@ class CrossrefXML(object):
 
         # only add text and data mining details if the article has a license
         if (hasattr(poa_article, 'license')
-            and poa_article.license.href):
+            and poa_article.license and poa_article.license.href):
             self.set_collection(self.doi_data, poa_article, "text-mining")
 
 

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -260,7 +260,10 @@ class CrossrefXML(object):
         resource = self.generate_resource_url(poa_article, poa_article)
         self.resource.text = resource
 
-        self.set_collection(self.doi_data, poa_article, "text-mining")
+        # only add text and data mining details if the article has a license
+        if (hasattr(poa_article, 'license')
+            and poa_article.license.href):
+            self.set_collection(self.doi_data, poa_article, "text-mining")
 
 
     def set_collection(self, parent, poa_article, collection_property):

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -302,9 +302,7 @@ class CrossrefXML(object):
     def do_set_collection(self, poa_article, collection_property):
         "decide whether to set collection tags"
         # only add text and data mining details if the article has a license
-        if not(hasattr(poa_article, 'license')):
-            return False
-        if poa_article.license and not poa_article.license.href:
+        if not self.has_license(poa_article):
             return False
         if collection_property == "text-mining":
             if (self.do_set_collection_text_mining_xml(poa_article) is True
@@ -312,6 +310,13 @@ class CrossrefXML(object):
                 return True
         return False
 
+    def has_license(self, poa_article):
+        "check if the article has the minimum requirements of a license"
+        if not poa_article.license:
+            return False
+        if not poa_article.license.href:
+            return False
+        return True
 
     def generate_resource_url(self, obj, poa_article, pattern_type=None):
         # Generate a resource value for doi_data based on the object provided
@@ -534,8 +539,7 @@ class CrossrefXML(object):
 
         applies_to = self.crossref_config.get("access_indicators_applies_to")
 
-        if (len(applies_to) > 0 and hasattr(poa_article, 'license')
-                and poa_article.license and poa_article.license.href):
+        if (len(applies_to) > 0 and self.has_license(poa_article) is True):
 
             self.ai_program = SubElement(parent, 'ai:program')
             self.ai_program.set('name', 'AccessIndicators')

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -260,10 +260,7 @@ class CrossrefXML(object):
         resource = self.generate_resource_url(poa_article, poa_article)
         self.resource.text = resource
 
-        # only add text and data mining details if the article has a license
-        if (hasattr(poa_article, 'license')
-            and poa_article.license and poa_article.license.href):
-            self.set_collection(self.doi_data, poa_article, "text-mining")
+        self.set_collection(self.doi_data, poa_article, "text-mining")
 
 
     def set_collection(self, parent, poa_article, collection_property):
@@ -304,6 +301,11 @@ class CrossrefXML(object):
 
     def do_set_collection(self, poa_article, collection_property):
         "decide whether to set collection tags"
+        # only add text and data mining details if the article has a license
+        if not(hasattr(poa_article, 'license')):
+            return False
+        if poa_article.license and not poa_article.license.href:
+            return False
         if collection_property == "text-mining":
             if (self.do_set_collection_text_mining_xml(poa_article) is True
                     or self.do_set_collection_text_mining_pdf(poa_article) is True):

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -2,7 +2,7 @@ import unittest
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-from elifearticle.article import Article, Component, Citation, Dataset, Contributor, Affiliation
+from elifearticle.article import Article, Component, Citation, Dataset, Contributor, Affiliation, License
 
 from elifecrossref import generate
 from elifecrossref.conf import config, parse_raw_config
@@ -388,6 +388,60 @@ class TestGenerateTitles(unittest.TestCase):
         self.assertTrue(expected_contains in crossref_xml_string)
         # now set the config back to normal
         raw_config['face_markup'] = face_markup
+
+
+class TestSetCollection(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def create_aricle_object(self):
+        "create a basic article object"
+        doi = "10.7554/eLife.00666"
+        title = "Test article"
+        article = Article(doi, title)
+        return article
+
+    def create_crossref_object(self, article):
+        "utility to create the crossref object"
+        raw_config = config['elife']
+        crossref_config = parse_raw_config(raw_config)
+        crossref_object = generate.CrossrefXML([article], crossref_config, None, True)
+        return crossref_object
+
+    def test_do_set_collection_no_license(self):
+        "test when an article has no license"
+        # create CrossrefXML object to test
+        article = self.create_aricle_object()
+        crossref_object = self.create_crossref_object(article)
+        # test assertion
+        collection_property = "text-mining"
+        self.assertFalse(crossref_object.do_set_collection(article, collection_property))
+
+    def test_do_set_collection_empty_license(self):
+        "test when an article has no license"
+        article = self.create_aricle_object()
+        # create an empty license
+        license_object = License()
+        article.license = license_object
+        # create CrossrefXML object to test
+        crossref_object = self.create_crossref_object(article)
+        # test assertion
+        collection_property = "text-mining"
+        self.assertFalse(crossref_object.do_set_collection(article, collection_property))
+
+    def test_do_set_collection_with_license(self):
+        "test when an article has no license"
+        article = self.create_aricle_object()
+        # create a license with a href value
+        license_object = License()
+        license_object.href = "http://example.org/license.txt"
+        article.license = license_object
+        # create CrossrefXML object to test
+        crossref_object = self.create_crossref_object(article)
+        # test assertion
+        collection_property = "text-mining"
+        self.assertTrue(crossref_object.do_set_collection(article, collection_property))
 
 
 class TestAddCleanTag(unittest.TestCase):


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-crossref-feed/issues/129

If an article has no license, and therefore no Crossref AccessIndicators, then do not include text and data mining links.

Includes refactoring the check for whether an article has a license, and tests for when to set test and data mining links.