### PR TITLE
Peer review deposits

### DIFF
--- a/elifecrossref/body.py
+++ b/elifecrossref/body.py
@@ -1,10 +1,13 @@
 from xml.etree.ElementTree import SubElement
-from elifecrossref import journal
+from elifecrossref import journal, peer_review
 
 
-def set_body(parent, poa_articles, crossref_config, default_pub_date):
+def set_body(parent, poa_articles, crossref_config, default_pub_date, submission_type):
     body_tag = SubElement(parent, 'body')
 
     for poa_article in poa_articles:
-        # Create a new journal record for each article
-        journal.set_journal(body_tag, poa_article, crossref_config, default_pub_date)
+        if submission_type == 'journal':
+            # Create a new journal record for each article
+            journal.set_journal(body_tag, poa_article, crossref_config, default_pub_date)
+        elif submission_type == 'peer_review':
+            peer_review.set_peer_review(body_tag, poa_article, crossref_config, default_pub_date)

--- a/elifecrossref/body.py
+++ b/elifecrossref/body.py
@@ -10,4 +10,4 @@ def set_body(parent, poa_articles, crossref_config, default_pub_date, submission
             # Create a new journal record for each article
             journal.set_journal(body_tag, poa_article, crossref_config, default_pub_date)
         elif submission_type == 'peer_review':
-            peer_review.set_peer_review(body_tag, poa_article, crossref_config, default_pub_date)
+            peer_review.set_peer_review(body_tag, poa_article, crossref_config)

--- a/elifecrossref/contributor.py
+++ b/elifecrossref/contributor.py
@@ -1,22 +1,28 @@
 from xml.etree.ElementTree import SubElement
 
 
-def set_contributors(parent, poa_article, contrib_types=None):
+def set_article_contributors(parent, poa_article, contrib_types=None):
     # First check for any contributors
     if not poa_article.contributors:
         return
+    article_contributors = []
+    for contributor in poa_article.contributors:
+        if contrib_types:
+            # Filter by contrib_type if supplied
+            if contributor.contrib_type not in contrib_types:
+                continue
+        article_contributors.append(contributor)
+    set_contributors(parent, article_contributors)
+
+
+def set_contributors(parent, contributors):
     # If contrib_type is None, all contributors will be added regardless of their type
     contributors_tag = SubElement(parent, "contributors")
 
     # Ready to add to XML
     # Use the natural list order of contributors when setting the first author
     sequence = "first"
-    for contributor in poa_article.contributors:
-        if contrib_types:
-            # Filter by contrib_type if supplied
-            if contributor.contrib_type not in contrib_types:
-                continue
-
+    for contributor in contributors:
         set_contributor(contributors_tag, contributor, sequence)
 
         # Reset sequence value after the first sucessful loop

--- a/elifecrossref/dates.py
+++ b/elifecrossref/dates.py
@@ -1,0 +1,14 @@
+from xml.etree.ElementTree import SubElement
+
+
+def set_publication_date(parent, pub_date):
+    # pub_date is a python time object
+    if pub_date:
+        publication_date_tag = SubElement(parent, 'publication_date')
+        publication_date_tag.set("media_type", "online")
+        month_tag = SubElement(publication_date_tag, "month")
+        month_tag.text = str(pub_date.tm_mon).zfill(2)
+        day_tag = SubElement(publication_date_tag, "day")
+        day_tag.text = str(pub_date.tm_mday).zfill(2)
+        year_tag = SubElement(publication_date_tag, "year")
+        year_tag.text = str(pub_date.tm_year)

--- a/elifecrossref/dates.py
+++ b/elifecrossref/dates.py
@@ -6,9 +6,13 @@ def set_publication_date(parent, pub_date):
     if pub_date:
         publication_date_tag = SubElement(parent, 'publication_date')
         publication_date_tag.set("media_type", "online")
-        month_tag = SubElement(publication_date_tag, "month")
-        month_tag.text = str(pub_date.tm_mon).zfill(2)
-        day_tag = SubElement(publication_date_tag, "day")
-        day_tag.text = str(pub_date.tm_mday).zfill(2)
-        year_tag = SubElement(publication_date_tag, "year")
-        year_tag.text = str(pub_date.tm_year)
+        set_date_detail(publication_date_tag, pub_date)
+
+
+def set_date_detail(parent, pub_date):
+    month_tag = SubElement(parent, "month")
+    month_tag.text = str(pub_date.tm_mon).zfill(2)
+    day_tag = SubElement(parent, "day")
+    day_tag.text = str(pub_date.tm_mday).zfill(2)
+    year_tag = SubElement(parent, "year")
+    year_tag.text = str(pub_date.tm_year)

--- a/elifecrossref/doi.py
+++ b/elifecrossref/doi.py
@@ -1,0 +1,22 @@
+from xml.etree.ElementTree import SubElement
+from elifecrossref import collection, resource_url
+
+
+def set_article_doi_data(parent, poa_article, crossref_config):
+    doi_data_tag = set_doi_data(parent, poa_article, crossref_config)
+    collection.set_collection(doi_data_tag, poa_article, "text-mining", crossref_config)
+
+
+def set_doi_data(parent, poa_article, crossref_config):
+    doi_data_tag = SubElement(parent, 'doi_data')
+
+    doi_tag = SubElement(doi_data_tag, 'doi')
+    doi_tag.text = poa_article.doi
+
+    resource_tag = SubElement(doi_data_tag, 'resource')
+
+    resource = resource_url.generate_resource_url(
+        poa_article, poa_article, crossref_config)
+    resource_tag.text = resource
+
+    return doi_data_tag

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -113,13 +113,13 @@ def build_crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_co
 
 
 def crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_comment=True,
-                 submission_type='journal'):
+                 submission_type='journal', pretty=False, indent=""):
     """build crossref xml and return output as a string"""
     if not crossref_config:
         crossref_config = parse_raw_config(raw_config(None))
     c_xml = build_crossref_xml(poa_articles, crossref_config, pub_date, add_comment,
                                submission_type)
-    return c_xml.output_xml()
+    return c_xml.output_xml(pretty=pretty, indent=indent)
 
 
 def crossref_xml_to_disk(poa_articles, crossref_config=None, pub_date=None, add_comment=True):

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -17,7 +17,8 @@ TMP_DIR = 'tmp'
 
 class CrossrefXML(object):
 
-    def __init__(self, poa_articles, crossref_config, pub_date=None, add_comment=True):
+    def __init__(self, poa_articles, crossref_config, pub_date=None, add_comment=True,
+                 submission_type='journal'):
         """
         Set the root node
         set default values for dates and batch id
@@ -33,13 +34,8 @@ class CrossrefXML(object):
         else:
             self.pub_date = pub_date
 
-        # Generate batch id
-        batch_doi = ''
-        if poa_articles:
-            # If only one article is supplied, then add the doi to the batch file name
-            batch_doi = str(utils.clean_string(poa_articles[0].manuscript)) + '-'
-        self.batch_id = (str(crossref_config.get('batch_file_prefix')) + batch_doi +
-                         time.strftime("%Y%m%d%H%M%S", self.pub_date))
+        self.batch_id = get_batch_id(
+            crossref_config.get('batch_file_prefix'), self.pub_date, poa_articles, submission_type)
 
         # set comment
         if add_comment:
@@ -51,11 +47,11 @@ class CrossrefXML(object):
             self.root.append(comment)
 
         # Build out the Crossref XML
-        self.build(poa_articles, crossref_config)
+        self.build(poa_articles, crossref_config, submission_type)
 
-    def build(self, poa_articles, crossref_config):
+    def build(self, poa_articles, crossref_config, submission_type):
         head.set_head(self.root, self.batch_id, self.pub_date, crossref_config)
-        body.set_body(self.root, poa_articles, crossref_config, self.pub_date)
+        body.set_body(self.root, poa_articles, crossref_config, self.pub_date, submission_type)
 
     def output_xml(self, pretty=False, indent=""):
         encoding = 'utf-8'
@@ -89,21 +85,40 @@ def set_root(root, schema_version):
     root.set('xmlns:jats', 'http://www.ncbi.nlm.nih.gov/JATS1')
 
 
-def build_crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_comment=True):
+def get_batch_id(batch_file_prefix, pub_date, poa_articles, submission_type):
+    """generate a doi_batch_id value for the Crossref deposit"""
+    batch_id_parts = []
+    # add detail about submission type
+    if submission_type != 'journal':
+        batch_id_parts.append(submission_type)
+    # add detail about articles
+    if poa_articles:
+        # If only one article is supplied, then add the doi to the batch file name
+        batch_id_parts.append(str(utils.clean_string(poa_articles[0].manuscript)))
+    # add detail about the date
+    batch_id_parts.append(time.strftime("%Y%m%d%H%M%S", pub_date))
+    # concatenate and return the final batch id
+    return str(batch_file_prefix) + '-'.join([part for part in batch_id_parts if part])
+
+
+def build_crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_comment=True,
+                       submission_type='journal'):
     """
     Given a list of article article objects
     generate crossref XML from them
     """
     if not crossref_config:
         crossref_config = parse_raw_config(raw_config(None))
-    return CrossrefXML(poa_articles, crossref_config, pub_date, add_comment)
+    return CrossrefXML(poa_articles, crossref_config, pub_date, add_comment, submission_type)
 
 
-def crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_comment=True):
+def crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_comment=True,
+                 submission_type='journal'):
     """build crossref xml and return output as a string"""
     if not crossref_config:
         crossref_config = parse_raw_config(raw_config(None))
-    c_xml = build_crossref_xml(poa_articles, crossref_config, pub_date, add_comment)
+    c_xml = build_crossref_xml(poa_articles, crossref_config, pub_date, add_comment,
+                               submission_type)
     return c_xml.output_xml()
 
 

--- a/elifecrossref/journal.py
+++ b/elifecrossref/journal.py
@@ -1,6 +1,6 @@
 from xml.etree.ElementTree import SubElement
 from elifearticle import utils as eautils
-from elifecrossref import journal_article
+from elifecrossref import dates, journal_article
 
 
 def set_journal(parent, poa_article, crossref_config, default_pub_date):
@@ -11,7 +11,7 @@ def set_journal(parent, poa_article, crossref_config, default_pub_date):
     journal_issue_tag = SubElement(journal_tag, 'journal_issue')
 
     pub_date = get_pub_date(poa_article, crossref_config, default_pub_date)
-    journal_article.set_publication_date(journal_issue_tag, pub_date)
+    dates.set_publication_date(journal_issue_tag, pub_date)
 
     journal_volume_tag = SubElement(journal_issue_tag, 'journal_volume')
     volume_tag = SubElement(journal_volume_tag, 'volume')

--- a/elifecrossref/journal_article.py
+++ b/elifecrossref/journal_article.py
@@ -17,8 +17,8 @@ def set_journal_article(parent, poa_article, pub_date, crossref_config):
     # Set the title with italic tag support
     set_titles(journal_article_tag, poa_article, crossref_config)
 
-    contributor.set_contributors(journal_article_tag, poa_article,
-                                 crossref_config.get("contrib_types"))
+    contributor.set_article_contributors(
+        journal_article_tag, poa_article, crossref_config.get("contrib_types"))
 
     abstract.set_abstract(journal_article_tag, poa_article, crossref_config)
     abstract.set_digest(journal_article_tag, poa_article, crossref_config)

--- a/elifecrossref/journal_article.py
+++ b/elifecrossref/journal_article.py
@@ -2,7 +2,7 @@ from xml.etree.ElementTree import Element, SubElement
 from elifearticle import utils as eautils
 from elifecrossref import (
     abstract, access_indicators, citation, collection, component, contributor,
-    dataset, funding, related, resource_url, title)
+    dataset, dates, funding, related, resource_url, title)
 
 
 def set_journal_article(parent, poa_article, pub_date, crossref_config):
@@ -24,7 +24,7 @@ def set_journal_article(parent, poa_article, pub_date, crossref_config):
     abstract.set_digest(journal_article_tag, poa_article, crossref_config)
 
     # Journal publication date
-    set_publication_date(journal_article_tag, pub_date)
+    dates.set_publication_date(journal_article_tag, pub_date)
 
     publisher_item_tag = SubElement(journal_article_tag, 'publisher_item')
     if crossref_config.get("elocation_id") and poa_article.elocation_id:
@@ -59,19 +59,6 @@ def set_journal_article(parent, poa_article, pub_date, crossref_config):
         journal_article_tag, poa_article, relations_program_tag, crossref_config)
 
     component.set_component_list(journal_article_tag, poa_article, crossref_config)
-
-
-def set_publication_date(parent, pub_date):
-    # pub_date is a python time object
-    if pub_date:
-        publication_date_tag = SubElement(parent, 'publication_date')
-        publication_date_tag.set("media_type", "online")
-        month_tag = SubElement(publication_date_tag, "month")
-        month_tag.text = str(pub_date.tm_mon).zfill(2)
-        day_tag = SubElement(publication_date_tag, "day")
-        day_tag.text = str(pub_date.tm_mday).zfill(2)
-        year_tag = SubElement(publication_date_tag, "year")
-        year_tag.text = str(pub_date.tm_year)
 
 
 def set_doi_data(parent, poa_article, crossref_config):

--- a/elifecrossref/journal_article.py
+++ b/elifecrossref/journal_article.py
@@ -2,7 +2,7 @@ from xml.etree.ElementTree import Element, SubElement
 from elifearticle import utils as eautils
 from elifecrossref import (
     abstract, access_indicators, citation, collection, component, contributor,
-    dataset, funding, related, resource_url, tags)
+    dataset, funding, related, resource_url, title)
 
 
 def set_journal_article(parent, poa_article, pub_date, crossref_config):
@@ -15,7 +15,7 @@ def set_journal_article(parent, poa_article, pub_date, crossref_config):
             crossref_config.get("reference_distribution_opts"))
 
     # Set the title with italic tag support
-    set_titles(journal_article_tag, poa_article, crossref_config)
+    title.set_titles(journal_article_tag, poa_article, crossref_config)
 
     contributor.set_article_contributors(
         journal_article_tag, poa_article, crossref_config.get("contrib_types"))
@@ -59,22 +59,6 @@ def set_journal_article(parent, poa_article, pub_date, crossref_config):
         journal_article_tag, poa_article, relations_program_tag, crossref_config)
 
     component.set_component_list(journal_article_tag, poa_article, crossref_config)
-
-
-def set_titles(parent, poa_article, crossref_config):
-    """
-    Set the titles and title tags allowing sub tags within title
-    """
-    root_tag_name = 'titles'
-    tag_name = 'title'
-    root_xml_element = Element(root_tag_name)
-    # remove unwanted tags
-    tag_converted_title = eautils.remove_tag('ext-link', poa_article.title)
-    if crossref_config.get('face_markup') is True:
-        tags.add_inline_tag(root_xml_element, tag_name, tag_converted_title)
-    else:
-        tags.add_clean_tag(root_xml_element, tag_name, tag_converted_title)
-    parent.append(root_xml_element)
 
 
 def set_publication_date(parent, pub_date):

--- a/elifecrossref/journal_article.py
+++ b/elifecrossref/journal_article.py
@@ -1,8 +1,7 @@
-from xml.etree.ElementTree import Element, SubElement
-from elifearticle import utils as eautils
+from xml.etree.ElementTree import SubElement
 from elifecrossref import (
-    abstract, access_indicators, citation, collection, component, contributor,
-    dataset, dates, funding, related, resource_url, title)
+    abstract, access_indicators, citation, component, contributor,
+    dataset, dates, doi, funding, related, title)
 
 
 def set_journal_article(parent, poa_article, pub_date, crossref_config):
@@ -53,27 +52,12 @@ def set_journal_article(parent, poa_article, pub_date, crossref_config):
     set_archive_locations(journal_article_tag,
                           crossref_config.get("archive_locations"))
 
-    set_doi_data(journal_article_tag, poa_article, crossref_config)
+    doi.set_article_doi_data(journal_article_tag, poa_article, crossref_config)
 
     citation.set_citation_list(
         journal_article_tag, poa_article, relations_program_tag, crossref_config)
 
     component.set_component_list(journal_article_tag, poa_article, crossref_config)
-
-
-def set_doi_data(parent, poa_article, crossref_config):
-    doi_data_tag = SubElement(parent, 'doi_data')
-
-    doi_tag = SubElement(doi_data_tag, 'doi')
-    doi_tag.text = poa_article.doi
-
-    resource_tag = SubElement(doi_data_tag, 'resource')
-
-    resource = resource_url.generate_resource_url(
-        poa_article, poa_article, crossref_config)
-    resource_tag.text = resource
-
-    collection.set_collection(doi_data_tag, poa_article, "text-mining", crossref_config)
 
 
 def set_access_indicators(parent, poa_article, crossref_config):

--- a/elifecrossref/peer_review.py
+++ b/elifecrossref/peer_review.py
@@ -1,7 +1,35 @@
 from xml.etree.ElementTree import SubElement
-from elifearticle import utils as eautils
+from elifecrossref import contributor, dates, doi, related, title
 
 
-def set_peer_review(parent, poa_article, crossref_config, default_pub_date):
-    # Add peer_review for each article
-    peer_review_tag = SubElement(parent, 'peer_review')
+def set_peer_review(parent, poa_article, crossref_config):
+    for review_article in poa_article.review_articles:
+        # Add peer_review for each review
+        peer_review_tag = SubElement(parent, 'peer_review')
+        peer_review_tag.set('stage', 'pre-publication')
+        peer_review_tag.set('type', review_article.article_type)
+
+        if review_article.contributors:
+            contributor.set_contributors(peer_review_tag, review_article.contributors)
+
+        if review_article.title:
+            title.set_titles(peer_review_tag, review_article, crossref_config)
+
+        set_review_date(peer_review_tag, review_article.get_date('review_date'))
+
+        if review_article.related_articles:
+            # set the related article DOI to the first of the related_articles doi
+            related_article_doi = review_article.related_articles[0].doi
+            relations_program_tag = related.set_relations_program(peer_review_tag, None)
+            related_item_tag = SubElement(relations_program_tag, 'rel:related_item')
+            related.set_related_item_work_relation(
+                related_item_tag, 'inter_work_relation', 'isReviewOf', 'doi', related_article_doi)
+
+        doi.set_doi_data(peer_review_tag, review_article, crossref_config)
+
+
+def set_review_date(parent, article_date):
+    # article_date is an ArticleDate object
+    if article_date:
+        date_tag = SubElement(parent, 'review_date')
+        dates.set_date_detail(date_tag, article_date.date)

--- a/elifecrossref/peer_review.py
+++ b/elifecrossref/peer_review.py
@@ -1,0 +1,7 @@
+from xml.etree.ElementTree import SubElement
+from elifearticle import utils as eautils
+
+
+def set_peer_review(parent, poa_article, crossref_config, default_pub_date):
+    # Add peer_review for each article
+    peer_review_tag = SubElement(parent, 'peer_review')

--- a/elifecrossref/title.py
+++ b/elifecrossref/title.py
@@ -1,0 +1,19 @@
+from xml.etree.ElementTree import Element
+from elifearticle import utils as eautils
+from elifecrossref import tags
+
+
+def set_titles(parent, poa_article, crossref_config):
+    """
+    Set the titles and title tags allowing sub tags within title
+    """
+    root_tag_name = 'titles'
+    tag_name = 'title'
+    root_xml_element = Element(root_tag_name)
+    # remove unwanted tags
+    tag_converted_title = eautils.remove_tag('ext-link', poa_article.title)
+    if crossref_config.get('face_markup') is True:
+        tags.add_inline_tag(root_xml_element, tag_name, tag_converted_title)
+    else:
+        tags.add_clean_tag(root_xml_element, tag_name, tag_converted_title)
+    parent.append(root_xml_element)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+import os
+
+
+TEST_BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + os.sep
+TEST_DATA_PATH = TEST_BASE_PATH + "test_data" + os.sep
+
+
+def read_file_content(file_name):
+    with open(file_name, 'rb') as open_file:
+        return open_file.read()

--- a/tests/test_data/elife-crossref-peer_review-00666-20170717071707.xml
+++ b/tests/test_data/elife-crossref-peer_review-00666-20170717071707.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+    <head>
+        <doi_batch_id>elife-crossref-peer_review-00666-20170717071707</doi_batch_id>
+        <timestamp>20170717071707</timestamp>
+        <depositor>
+            <depositor_name>eLife</depositor_name>
+            <email_address>production@elifesciences.org</email_address>
+        </depositor>
+        <registrant>eLife</registrant>
+    </head>
+    <body>
+        <peer_review stage="pre-publication" type="editor-report">
+            <contributors>
+                <person_name contributor_role="editor" sequence="first">
+                    <given_name>Rutz</given_name>
+                    <surname>Christian</surname>
+                </person_name>
+            </contributors>
+            <titles>
+                <title>Decision letter: Immune mediated hookworm clearance and survival of a marine mammal decreases with warmer ocean temperatures</title>
+            </titles>
+            <review_date>
+                <month>01</month>
+                <day>12</day>
+                <year>2018</year>
+            </review_date>
+            <rel:program>
+                <rel:related_item>
+                    <rel:inter_work_relation identifier-type="doi" relationship-type="isReviewOf">10.7554/eLife.00666</rel:inter_work_relation>
+                </rel:related_item>
+            </rel:program>
+            <doi_data>
+                <doi>10.7554/eLife.00666.029</doi>
+                <resource>https://elifesciences.org/articles/00666#SA1</resource>
+            </doi_data>
+        </peer_review>
+        <peer_review stage="pre-publication" type="author-comment">
+            <contributors>
+                <person_name contributor_role="author" sequence="first">
+                    <given_name>Melissa</given_name>
+                    <surname>Harrison</surname>
+                </person_name>
+            </contributors>
+            <titles>
+                <title>Author response: Immune mediated hookworm clearance and survival of a marine mammal decreases with warmer ocean temperatures</title>
+            </titles>
+            <review_date>
+                <month>01</month>
+                <day>12</day>
+                <year>2018</year>
+            </review_date>
+            <rel:program>
+                <rel:related_item>
+                    <rel:inter_work_relation identifier-type="doi" relationship-type="isReviewOf">10.7554/eLife.00666</rel:inter_work_relation>
+                </rel:related_item>
+            </rel:program>
+            <doi_data>
+                <doi>10.7554/eLife.00666.030</doi>
+                <resource>https://elifesciences.org/articles/00666#SA2</resource>
+            </doi_data>
+        </peer_review>
+    </body>
+</doi_batch>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,8 +3,8 @@ import time
 import os
 from xml.etree.ElementTree import Comment
 from elifecrossref import generate
-from tests import TEST_BASE_PATH, TEST_DATA_PATH, read_file_content
 from elifecrossref.conf import raw_config, parse_raw_config
+from tests import TEST_BASE_PATH, TEST_DATA_PATH, read_file_content
 
 
 generate.TMP_DIR = TEST_BASE_PATH + "tmp" + os.sep

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,17 +3,11 @@ import time
 import os
 from xml.etree.ElementTree import Comment
 from elifecrossref import generate
+from tests import TEST_BASE_PATH, TEST_DATA_PATH, read_file_content
 from elifecrossref.conf import raw_config, parse_raw_config
 
 
-TEST_BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + os.sep
-TEST_DATA_PATH = TEST_BASE_PATH + "test_data" + os.sep
 generate.TMP_DIR = TEST_BASE_PATH + "tmp" + os.sep
-
-
-def read_file_content(file_name):
-    with open(file_name, 'rb') as open_file:
-        return open_file.read()
 
 
 class TestGenerate(unittest.TestCase):

--- a/tests/test_generate_peer_review.py
+++ b/tests/test_generate_peer_review.py
@@ -1,0 +1,87 @@
+import unittest
+import time
+import os
+from elifearticle.article import Article, ArticleDate, Contributor
+from elifecrossref import generate
+from elifecrossref.conf import raw_config, parse_raw_config
+from tests import TEST_BASE_PATH, TEST_DATA_PATH, read_file_content
+
+
+generate.TMP_DIR = TEST_BASE_PATH + "tmp" + os.sep
+
+
+def sample_data():
+    """some sample data for development until real object definition is final and XML is parsed"""
+    reviews = []
+    # decision letter
+    decision_letter = Article()
+    decision_letter.article_type = 'editor-report'
+    dec_author = Contributor('editor', 'Christian', 'Rutz')
+    decision_letter.contributors.append(dec_author)
+    decision_letter.title = (
+        'Decision letter: Immune mediated hookworm clearance and survival of a marine mammal ' +
+        'decreases with warmer ocean temperatures')
+    # review date
+    review_date = ArticleDate(
+        'review_date', time.strptime("2018-01-12 00:00:00", "%Y-%m-%d %H:%M:%S"))
+    decision_letter.add_date(review_date)
+    # related article doi
+    related_article = Article()
+    related_article.doi = '10.7554/eLife.00666'
+    decision_letter.related_articles = [related_article]
+    # review article doi
+    decision_letter.doi = '10.7554/eLife.00666.029'
+    # a hack to get the resource url right for now
+    decision_letter.manuscript = '00666#SA1'
+    # append it
+    reviews.append(decision_letter)
+
+    # author response
+    author_response = Article()
+    author_response.article_type = 'author-comment'
+    article_author = Contributor('author', 'Harrison', 'Melissa')
+    author_response.contributors.append(article_author)
+    author_response.title = (
+        'Author response: Immune mediated hookworm clearance and survival of a marine mammal ' +
+        'decreases with warmer ocean temperatures')
+    # review date
+    review_date = ArticleDate(
+        'review_date', time.strptime("2018-01-12 00:00:00", "%Y-%m-%d %H:%M:%S"))
+    author_response.add_date(review_date)
+    # related article doi
+    related_article = Article()
+    related_article.doi = '10.7554/eLife.00666'
+    author_response.related_articles = [related_article]
+    # review article doi
+    author_response.doi = '10.7554/eLife.00666.030'
+    # a hack to get the resource url right for now
+    author_response.manuscript = '00666#SA2'
+    # append it
+    reviews.append(author_response)
+
+    return reviews
+
+
+class TestGeneratePeerReview(unittest.TestCase):
+
+    def setUp(self):
+        self.passes = []
+        self.default_pub_date = time.strptime("2017-07-17 07:17:07", "%Y-%m-%d %H:%M:%S")
+        self.passes.append(
+            ('elife-00666.xml', 'elife-crossref-peer_review-00666-20170717071707.xml',
+             'elife', self.default_pub_date))
+
+    def test_parse(self):
+        for (article_xml_file, crossref_xml_file, config_section, pub_date) in self.passes:
+            file_path = TEST_DATA_PATH + article_xml_file
+            articles = generate.build_articles_for_crossref([file_path])
+            # set some review sample data
+            articles[0].review_articles = sample_data()
+            crossref_config = None
+            if config_section:
+                crossref_config = parse_raw_config(raw_config(config_section))
+            crossref_xml = generate.crossref_xml(articles, crossref_config, pub_date, False,
+                                                 'peer_review', pretty=True, indent="    ")
+            model_crossref_xml = read_file_content(TEST_DATA_PATH + crossref_xml_file)
+            self.assertEqual(crossref_xml, model_crossref_xml.decode('utf-8'),
+                             'Failed parse test on file %s' % article_xml_file)


### PR DESCRIPTION
The end goal here is to generate XML output like the test data fixture `tests/test_data/elife-crossref-peer_review-00666-20170717071707.xml`.

Continuing some of the earlier refactoring of this library, in order to reuse some of the logic for generating journal article deposits, I moved around and adapted functions that generate contributor data, dates, doi, titles, and related items so they could be used for both article deposits and for peer review deposits.

The `CrossrefXML` class (defined in `generate.py`) was changed to produce different types of output by specifying the `submission_type` value. The batch id generation was refactored out and made to generate two types of batch id values.

I made it so when calling `crossref_xml()` (also in `generate.py`) you can ask for pretty XML output and specify the indent. This made it possible to make the test data in a multi-line, readable, pretty format for the peer_review deposit sample.

No other test scenarios were materially changed, and since the tests are passing, I will conclude that there are no regressions for generating journal article deposits.

The `sample_data()` (in `tests/test_generate_peer_review.py`) may or may not stay in the end. This was the quickest way to populate `Article` objects with data to produce the desired output. My next step in this feature is to parse the data out of the real article XML files and then that can be used to generate peer_review deposits.