### PR TITLE
Component doi deposit changes

### DIFF
--- a/crossref.cfg
+++ b/crossref.cfg
@@ -14,6 +14,7 @@ batch_file_prefix: crossref-
 doi_pattern: 
 component_doi_pattern: 
 component_license_ref:
+component_exclude_types: []
 elife_style_component_doi: false
 archive_locations: ["CLOCKSS"]
 elocation_id: true
@@ -32,6 +33,7 @@ batch_file_prefix: elife-crossref-
 doi_pattern: https://elifesciences.org/articles/{manuscript}
 component_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#{id}
 component_license_ref: https://submit.elifesciences.org/html/elife_author_instructions.html#policies
+component_exclude_types: ["sub-article"]
 elife_style_component_doi: true
 year_of_first_volume: 2012
 elocation_id: true

--- a/elifecrossref/component.py
+++ b/elifecrossref/component.py
@@ -10,7 +10,10 @@ def set_component_list(parent, poa_article, crossref_config):
         return
 
     component_list_tag = SubElement(parent, 'component_list')
-    for comp in poa_article.component_list:
+    # ignore excluded components based on the configuration settings
+    component_list = [comp for comp in poa_article.component_list
+                      if comp.type not in crossref_config.get('component_exclude_types', [])]
+    for comp in component_list:
         set_component(component_list_tag, poa_article, comp, crossref_config)
 
 

--- a/elifecrossref/conf.py
+++ b/elifecrossref/conf.py
@@ -40,6 +40,7 @@ def parse_raw_config(raw_config_object):
     list_values.append("archive_locations")
     list_values.append("access_indicators_applies_to")
     list_values.append("pub_date_types")
+    list_values.append("component_exclude_types")
 
     for value_name in raw_config_object:
         if value_name in boolean_values:

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -122,12 +122,14 @@ def crossref_xml(poa_articles, crossref_config=None, pub_date=None, add_comment=
     return c_xml.output_xml(pretty=pretty, indent=indent)
 
 
-def crossref_xml_to_disk(poa_articles, crossref_config=None, pub_date=None, add_comment=True):
+def crossref_xml_to_disk(poa_articles, crossref_config=None, pub_date=None, add_comment=True,
+                         submission_type='journal', pretty=False, indent=""):
     """build crossref xml and write the output to disk"""
     if not crossref_config:
         crossref_config = parse_raw_config(raw_config(None))
-    c_xml = build_crossref_xml(poa_articles, crossref_config, pub_date, add_comment)
-    xml_string = c_xml.output_xml()
+    c_xml = build_crossref_xml(
+        poa_articles, crossref_config, pub_date, add_comment, submission_type)
+    xml_string = c_xml.output_xml(pretty=pretty, indent=indent)
     # Write to file
     filename = TMP_DIR + os.sep + c_xml.batch_id + '.xml'
     with open(filename, "wb") as open_file:

--- a/generate_test_fixtures.py
+++ b/generate_test_fixtures.py
@@ -25,4 +25,5 @@ if __name__ == '__main__':
         generate.TMP_DIR = 'tests/test_data'
         articles = generate.build_articles_for_crossref([xml_file])
         crossref_config = parse_raw_config(raw_config(config_section))
-        generate.crossref_xml_to_disk(articles, crossref_config, pub_date, add_comment)
+        generate.crossref_xml_to_disk(
+            articles, crossref_config, pub_date, add_comment, "journal", pretty=True, indent="\t")

--- a/tests/test_data/crossref-606-20170717071707.xml
+++ b/tests/test_data/crossref-606-20170717071707.xml
@@ -1,1 +1,314 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>crossref-606-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name/><email_address/></depositor><registrant/></head><body><journal><journal_metadata language="en"><full_title>Stability: International Journal of Security and Development</full_title><issn media_type="electronic">2165-2627</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>02</month><day>06</day><year>2018</year></publication_date><journal_volume><volume>7</volume></journal_volume></journal_issue><journal_article publication_type="full_text"><titles><title>Strategic Communications for Peace Operations: The African Union’s Information War Against al-Shabaab</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Paul D.</given_name><surname>Williams</surname><affiliation>The George Washington University, USA</affiliation></person_name></contributors><jats:abstract><jats:p>Despite widespread agreement that effective strategic communications are a necessary part of complex peace operations, many missions struggle to generate relevant capabilities and implement effective campaigns. This article analyzes the experiences of the African Union Mission in Somalia (AMISOM) as a case study of this problem. Specifically, it examines how the United Nations (UN) tried to fill the gap by hiring a consortium of private firms known as the AU-UN Information Support Team (IST) to wage a strategic communications campaign against al-Shabaab. The IST’s goal was to drive, as well as communicate, AMISOM’s success, improve the mission’s media presence, and develop a communications strategy. The IST played an innovative and important function for AMISOM but suffered from several significant challenges that reduced its effectiveness. The conclusion therefore identifies four main lessons from AMISOM’s experiences that could improve strategic communications for peace operations.</jats:p></jats:abstract><publication_date media_type="online"><month>02</month><day>06</day><year>2018</year></publication_date><publisher_item><item_number item_number_type="article_number">3</item_number><identifier id_type="doi">10.5334/sta.606</identifier></publisher_item><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.5334/sta.606</doi><resource>http://www.stabilityjournal.org/articles/10.5334/sta.606/</resource></doi_data><citation_list><citation key="B1"><volume_title>The Star (Kenya)</volume_title><cYear>2014</cYear><article_title>AMISOM must leave Somalia before ‘Mission Creep’ sets in</article_title><unstructured_citation>2014. AMISOM must leave Somalia before ‘Mission Creep’ sets in. The Star (Kenya). http://www.the-star.co.ke/news/2014/03/11/amisom-must-leave-somalia-before-mission-creep-sets-in_c906058.</unstructured_citation></citation><citation key="B2"><volume_title>AMISOM Annual Report 2010</volume_title><author>AMISOM</author><cYear>2010</cYear></citation><citation key="B3"><volume_title>AMISOM Annual Report 2011</volume_title><author>AMISOM</author><cYear>2011</cYear></citation><citation key="B4"><volume_title>AMISOM Mission Implementation Plan 2012</volume_title><author>AMISOM</author><cYear>2012</cYear></citation><citation key="B5"><volume_title>AMISOM Strategic Directive 2013</volume_title><author>AMISOM</author><cYear>2013</cYear></citation><citation key="B6"><author>AMISOM</author><cYear>2016a</cYear><article_title>Al-Shabaab violating human rights by recruiting child soldiers</article_title><unstructured_citation>AMISOM. 2016a. Al-Shabaab violating human rights by recruiting child soldiers. https://www.youtube.com/watch?v=a1QZnU3N6VA.</unstructured_citation></citation><citation key="B7"><author>AMISOM</author><cYear>2016b</cYear><article_title>AMISOM introduces ‘Radio-In-A-box’ to enhance communication with local populations</article_title><unstructured_citation>AMISOM. 2016b. AMISOM introduces ‘Radio-In-A-box’ to enhance communication with local populations. http://amisom-au.org/2016/02/amisom-introduces-radio-in-a-box-to-enhance-communication-with-local-populations/.</unstructured_citation></citation><citation key="B8"><cYear>2016</cYear><article_title>Continuity and Change: The evolution and resilience of Al-Shabab’s media insurgency, 2006–2016</article_title><unstructured_citation>2016. Continuity and Change: The evolution and resilience of Al-Shabab’s media insurgency, 2006–2016. https://www.hate-speech.org/new-report-on-al-shabab-media/.</unstructured_citation></citation><citation key="B9"><journal_title>Procedia–Social and Behavioral Sciences</journal_title><volume>148</volume><first_page>579</first_page><cYear>2014</cYear><article_title>Cultural Awareness in Peace Operations: Effective Marketing or Strategic Communications</article_title><doi>10.1016/j.sbspro.2014.07.083</doi></citation><citation key="B10"><volume_title>Communication and Peace: Mapping an Emerging Field</volume_title><first_page>163</first_page><cYear>2015</cYear></citation><citation key="B11"><volume_title>Waging Peace: UN Peace Operations Confronting Terrorism and Violent Extremism</volume_title><cYear>2016</cYear><unstructured_citation>2016. New York: International Peace Institute. Waging Peace: UN Peace Operations Confronting Terrorism and Violent Extremism. https://www.ipinst.org/2016/10/un-peaceops-contronting-terrorism-extremism.</unstructured_citation></citation><citation key="B12"><volume_title>Strategic Communications for the New Era of Peace Operations</volume_title><author>Challenges Forum</author><first_page>1</first_page><cYear>2015</cYear><unstructured_citation>Challenges Forum. 2015. Strategic Communications for the New Era of Peace Operations. http://www.challengesforum.org/Global/Reports/Policy%20Briefs/Policy%20Brief%202015_1_Strategic%20Communications%20for%20the%20New%20Era%20of%20Peace%20Operations.pdf.</unstructured_citation></citation><citation key="B13"><author>CPJ</author><cYear>2017</cYear><article_title>Somalia. Committee to Protect Journalists</article_title><unstructured_citation>CPJ. 2017. Somalia. Committee to Protect Journalists. https://cpj.org/africa/somalia/.</unstructured_citation></citation><citation key="B14"><volume_title>The African Standby Force: Quo Vadis?</volume_title><first_page>63</first_page><cYear>2017</cYear></citation><citation key="B15"><journal_title>International Peacekeeping</journal_title><volume>7</volume><issue>1</issue><first_page>142</first_page><cYear>2000</cYear><article_title>Cultural Issues in Contemporary Peacekeeping</article_title><doi>10.1080/13533310008413823</doi></citation><citation key="B16"><volume_title>Final Report: Radio in a Box Program</volume_title><author>Farsight Africa Group</author><cYear>2017</cYear></citation><citation key="B17"><volume_title>The World’s Most Dangerous Place</volume_title><cYear>2013</cYear></citation><citation key="B18"><cYear>2013</cYear><article_title>Mastering the Narrative: Counterterrorism Strategic Communications and the United Nations. Center on Global Counterterrorism Cooperation</article_title><unstructured_citation>2013. Mastering the Narrative: Counterterrorism Strategic Communications and the United Nations. Center on Global Counterterrorism Cooperation. http://globalcenter.org/wp-content/uploads/2013/03/Feb2013_CT_StratComm.pdf.</unstructured_citation></citation><citation key="B19"><journal_title>Stability</journal_title><volume>2</volume><issue>2</issue><first_page>23</first_page><cYear>2013</cYear><article_title>Lessons from the African Union Mission for Somalia (AMISOM) for Peace Operations in Mali</article_title><doi>10.5334/sta.bj</doi></citation><citation key="B20"><journal_title>International Journal of Strategic Communication</journal_title><volume>1</volume><issue>1</issue><first_page>3</first_page><cYear>2007</cYear><article_title>Defining strategic communication</article_title><doi>10.1080/15531180701285244</doi></citation><citation key="B21"><volume_title>Al-Shabaab in Somalia</volume_title><cYear>2013</cYear><doi>10.1093/acprof:oso/9780199327874.001.0001</doi></citation><citation key="B22"><journal_title>Uniting our Strengths for Peace–Politics, Partnership and People</journal_title><author>HIPPO</author><cYear>2015</cYear></citation><citation key="B23"><volume_title>Somalia’s Divided Islamists</volume_title><author>ICG</author><cYear>2010</cYear><unstructured_citation>ICG. 2010. Somalia’s Divided Islamists. https://www.crisisgroup.org/africa/horn-africa/somalia/somalia-s-divided-islamists.</unstructured_citation></citation><citation key="B24"><journal_title>Citizens’ Perception of Peace and Stabilization Initiatives in Somalia</journal_title><author>Ipsos</author><cYear>2015</cYear></citation><citation key="B25"><journal_title>Citizens Perception of Peace and Stabilization Initiative in Somalia</journal_title><author>Ipsos</author><cYear>2016</cYear></citation><citation key="B26"><journal_title>Final Report: Information Support Services to UNSOA/AMISOM: November 2009–November 2012</journal_title><author>IST</author><cYear>2012</cYear></citation><citation key="B27"><journal_title>Mogadishu Polling Survey 2013 (Wave 2)</journal_title><author>IST</author><cYear>2013</cYear></citation><citation key="B28"><journal_title>Citizens Perception of Peace and Stabilization Initiatives in Somalia</journal_title><author>IST</author><cYear>2015</cYear></citation><citation key="B29"><volume_title>TV, Twitter and Telegram: How Do Jihadi Insurgents Attempt to Influence the Mass Media?</volume_title><cYear>2017</cYear><unstructured_citation>2017. King’s College London. TV, Twitter and Telegram: How Do Jihadi Insurgents Attempt to Influence the Mass Media?.</unstructured_citation></citation><citation key="B30"><volume_title>Peacekeeping and Public Information</volume_title><cYear>1999</cYear></citation><citation key="B31"><volume_title>Communication and Peace: Mapping an Emerging Field</volume_title><first_page>135</first_page><cYear>2015</cYear></citation><citation key="B32"><journal_title>International Peacekeeping</journal_title><volume>11</volume><issue>4</issue><first_page>608</first_page><cYear>2004</cYear><article_title>Untapped power? The status of UN information operations</article_title><doi>10.1080/1353331042000248696</doi></citation><citation key="B33"><volume_title>The Surge to Stabilize: Lessons for the UN from the AU’s Experience in Somalia</volume_title><cYear>2016</cYear><unstructured_citation>2016. New York: International Peace Institute. The Surge to Stabilize: Lessons for the UN from the AU’s Experience in Somalia. https://www.ipinst.org/2016/05/un-au-stabilize-somalia.</unstructured_citation></citation><citation key="B34"><author>NATO</author><cYear>2009</cYear><article_title>Strategic Communication Policy</article_title></citation><citation key="B35"><volume_title>Military Concept for Strategic Communications</volume_title><author>NATO</author><cYear>2010</cYear><unstructured_citation>NATO. 2010. Military Concept for Strategic Communications. http://info.publicintelligence.net/NATO-STRATCOM-Concept.pdf.</unstructured_citation></citation><citation key="B36"><journal_title>International Peacekeeping</journal_title><cYear>2017</cYear><article_title>Policy Entrepreneurship by International Bureaucracies: The Evolution of Public Information in UN Peacekeeping</article_title><doi>10.1080/13533312.2017.1395286</doi></citation><citation key="B37"><volume_title>Strategic Communication: Origins, Concepts and Current Debates</volume_title><cYear>2011</cYear></citation><citation key="B38"><volume_title>Military Review</volume_title><cYear>2008</cYear><article_title>Multi-National Force Iraq Commander’s Counterinsurgency Guidance</article_title><unstructured_citation>2008. Multi-National Force Iraq Commander’s Counterinsurgency Guidance. Military Review. http://usacac.army.mil/CAC2/MilitaryReview/Archives/English/MilitaryReview_20081031_art004.pdf.</unstructured_citation></citation><citation key="B39"><cYear>2013</cYear><unstructured_citation>2013. Remarks to the Institute for Horn of Africa Studies and Affairs conference, Minneapolis, October. http://www.youtube.com/watch?v=iq3PfPwlzBk&amp;feature=youtu.be.</unstructured_citation></citation><citation key="B40"><journal_title>Citizens’ Perceptions of the United Nations in Somalia: A Qualitative Analysis</journal_title><author>UNSOM</author><cYear>2016</cYear></citation><citation key="B41"><journal_title>Citizens Perception of Peace and Stabilization Initiative in Somalia</journal_title><author>UNSOM-AU</author><cYear>2016</cYear></citation><citation key="B42"><author>Wikileak Cable</author><cYear>2010</cYear></citation><citation key="B43"><volume_title>The Battle at El Adde: The Kenyan Defence Forces, a-Shabaab, and Unanswered Questions</volume_title><cYear>2016</cYear><unstructured_citation>2016. New York: International Peace Institute. The Battle at El Adde: The Kenyan Defence Forces, a-Shabaab, and Unanswered Questions. https://www.ipinst.org/2016/07/the-battle-at-el-adde-the-kenya-defence-forces-al-shabaab-and-unanswered-questions.</unstructured_citation></citation><citation key="B44"><volume_title>UN Support to Regional Peace Operations: Lessons from UNSOA</volume_title><cYear>2017</cYear><unstructured_citation>2017. New York: International Peace Institute. UN Support to Regional Peace Operations: Lessons from UNSOA. https://www.ipinst.org/2017/02/un-support-regional-peace-ops-unsoa.</unstructured_citation></citation><citation key="B45"><volume_title>Fighting for Peace in Somalia: A History and Analysis of the African Union Mission (AMISOM), 2007–2017</volume_title><cYear>2018</cYear></citation></citation_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>crossref-606-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name/>
+			<email_address/>
+		</depositor>
+		<registrant/>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>Stability: International Journal of Security and Development</full_title>
+				<issn media_type="electronic">2165-2627</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>02</month>
+					<day>06</day>
+					<year>2018</year>
+				</publication_date>
+				<journal_volume>
+					<volume>7</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text">
+				<titles>
+					<title>Strategic Communications for Peace Operations: The African Union’s Information War Against al-Shabaab</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Paul D.</given_name>
+						<surname>Williams</surname>
+						<affiliation>The George Washington University, USA</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Despite widespread agreement that effective strategic communications are a necessary part of complex peace operations, many missions struggle to generate relevant capabilities and implement effective campaigns. This article analyzes the experiences of the African Union Mission in Somalia (AMISOM) as a case study of this problem. Specifically, it examines how the United Nations (UN) tried to fill the gap by hiring a consortium of private firms known as the AU-UN Information Support Team (IST) to wage a strategic communications campaign against al-Shabaab. The IST’s goal was to drive, as well as communicate, AMISOM’s success, improve the mission’s media presence, and develop a communications strategy. The IST played an innovative and important function for AMISOM but suffered from several significant challenges that reduced its effectiveness. The conclusion therefore identifies four main lessons from AMISOM’s experiences that could improve strategic communications for peace operations.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>02</month>
+					<day>06</day>
+					<year>2018</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">3</item_number>
+					<identifier id_type="doi">10.5334/sta.606</identifier>
+				</publisher_item>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.5334/sta.606</doi>
+					<resource>http://www.stabilityjournal.org/articles/10.5334/sta.606/</resource>
+				</doi_data>
+				<citation_list>
+					<citation key="B1">
+						<volume_title>The Star (Kenya)</volume_title>
+						<cYear>2014</cYear>
+						<article_title>AMISOM must leave Somalia before ‘Mission Creep’ sets in</article_title>
+						<unstructured_citation>2014. AMISOM must leave Somalia before ‘Mission Creep’ sets in. The Star (Kenya). http://www.the-star.co.ke/news/2014/03/11/amisom-must-leave-somalia-before-mission-creep-sets-in_c906058.</unstructured_citation>
+					</citation>
+					<citation key="B2">
+						<volume_title>AMISOM Annual Report 2010</volume_title>
+						<author>AMISOM</author>
+						<cYear>2010</cYear>
+					</citation>
+					<citation key="B3">
+						<volume_title>AMISOM Annual Report 2011</volume_title>
+						<author>AMISOM</author>
+						<cYear>2011</cYear>
+					</citation>
+					<citation key="B4">
+						<volume_title>AMISOM Mission Implementation Plan 2012</volume_title>
+						<author>AMISOM</author>
+						<cYear>2012</cYear>
+					</citation>
+					<citation key="B5">
+						<volume_title>AMISOM Strategic Directive 2013</volume_title>
+						<author>AMISOM</author>
+						<cYear>2013</cYear>
+					</citation>
+					<citation key="B6">
+						<author>AMISOM</author>
+						<cYear>2016a</cYear>
+						<article_title>Al-Shabaab violating human rights by recruiting child soldiers</article_title>
+						<unstructured_citation>AMISOM. 2016a. Al-Shabaab violating human rights by recruiting child soldiers. https://www.youtube.com/watch?v=a1QZnU3N6VA.</unstructured_citation>
+					</citation>
+					<citation key="B7">
+						<author>AMISOM</author>
+						<cYear>2016b</cYear>
+						<article_title>AMISOM introduces ‘Radio-In-A-box’ to enhance communication with local populations</article_title>
+						<unstructured_citation>AMISOM. 2016b. AMISOM introduces ‘Radio-In-A-box’ to enhance communication with local populations. http://amisom-au.org/2016/02/amisom-introduces-radio-in-a-box-to-enhance-communication-with-local-populations/.</unstructured_citation>
+					</citation>
+					<citation key="B8">
+						<cYear>2016</cYear>
+						<article_title>Continuity and Change: The evolution and resilience of Al-Shabab’s media insurgency, 2006–2016</article_title>
+						<unstructured_citation>2016. Continuity and Change: The evolution and resilience of Al-Shabab’s media insurgency, 2006–2016. https://www.hate-speech.org/new-report-on-al-shabab-media/.</unstructured_citation>
+					</citation>
+					<citation key="B9">
+						<journal_title>Procedia–Social and Behavioral Sciences</journal_title>
+						<volume>148</volume>
+						<first_page>579</first_page>
+						<cYear>2014</cYear>
+						<article_title>Cultural Awareness in Peace Operations: Effective Marketing or Strategic Communications</article_title>
+						<doi>10.1016/j.sbspro.2014.07.083</doi>
+					</citation>
+					<citation key="B10">
+						<volume_title>Communication and Peace: Mapping an Emerging Field</volume_title>
+						<first_page>163</first_page>
+						<cYear>2015</cYear>
+					</citation>
+					<citation key="B11">
+						<volume_title>Waging Peace: UN Peace Operations Confronting Terrorism and Violent Extremism</volume_title>
+						<cYear>2016</cYear>
+						<unstructured_citation>2016. New York: International Peace Institute. Waging Peace: UN Peace Operations Confronting Terrorism and Violent Extremism. https://www.ipinst.org/2016/10/un-peaceops-contronting-terrorism-extremism.</unstructured_citation>
+					</citation>
+					<citation key="B12">
+						<volume_title>Strategic Communications for the New Era of Peace Operations</volume_title>
+						<author>Challenges Forum</author>
+						<first_page>1</first_page>
+						<cYear>2015</cYear>
+						<unstructured_citation>Challenges Forum. 2015. Strategic Communications for the New Era of Peace Operations. http://www.challengesforum.org/Global/Reports/Policy%20Briefs/Policy%20Brief%202015_1_Strategic%20Communications%20for%20the%20New%20Era%20of%20Peace%20Operations.pdf.</unstructured_citation>
+					</citation>
+					<citation key="B13">
+						<author>CPJ</author>
+						<cYear>2017</cYear>
+						<article_title>Somalia. Committee to Protect Journalists</article_title>
+						<unstructured_citation>CPJ. 2017. Somalia. Committee to Protect Journalists. https://cpj.org/africa/somalia/.</unstructured_citation>
+					</citation>
+					<citation key="B14">
+						<volume_title>The African Standby Force: Quo Vadis?</volume_title>
+						<first_page>63</first_page>
+						<cYear>2017</cYear>
+					</citation>
+					<citation key="B15">
+						<journal_title>International Peacekeeping</journal_title>
+						<volume>7</volume>
+						<issue>1</issue>
+						<first_page>142</first_page>
+						<cYear>2000</cYear>
+						<article_title>Cultural Issues in Contemporary Peacekeeping</article_title>
+						<doi>10.1080/13533310008413823</doi>
+					</citation>
+					<citation key="B16">
+						<volume_title>Final Report: Radio in a Box Program</volume_title>
+						<author>Farsight Africa Group</author>
+						<cYear>2017</cYear>
+					</citation>
+					<citation key="B17">
+						<volume_title>The World’s Most Dangerous Place</volume_title>
+						<cYear>2013</cYear>
+					</citation>
+					<citation key="B18">
+						<cYear>2013</cYear>
+						<article_title>Mastering the Narrative: Counterterrorism Strategic Communications and the United Nations. Center on Global Counterterrorism Cooperation</article_title>
+						<unstructured_citation>2013. Mastering the Narrative: Counterterrorism Strategic Communications and the United Nations. Center on Global Counterterrorism Cooperation. http://globalcenter.org/wp-content/uploads/2013/03/Feb2013_CT_StratComm.pdf.</unstructured_citation>
+					</citation>
+					<citation key="B19">
+						<journal_title>Stability</journal_title>
+						<volume>2</volume>
+						<issue>2</issue>
+						<first_page>23</first_page>
+						<cYear>2013</cYear>
+						<article_title>Lessons from the African Union Mission for Somalia (AMISOM) for Peace Operations in Mali</article_title>
+						<doi>10.5334/sta.bj</doi>
+					</citation>
+					<citation key="B20">
+						<journal_title>International Journal of Strategic Communication</journal_title>
+						<volume>1</volume>
+						<issue>1</issue>
+						<first_page>3</first_page>
+						<cYear>2007</cYear>
+						<article_title>Defining strategic communication</article_title>
+						<doi>10.1080/15531180701285244</doi>
+					</citation>
+					<citation key="B21">
+						<volume_title>Al-Shabaab in Somalia</volume_title>
+						<cYear>2013</cYear>
+						<doi>10.1093/acprof:oso/9780199327874.001.0001</doi>
+					</citation>
+					<citation key="B22">
+						<journal_title>Uniting our Strengths for Peace–Politics, Partnership and People</journal_title>
+						<author>HIPPO</author>
+						<cYear>2015</cYear>
+					</citation>
+					<citation key="B23">
+						<volume_title>Somalia’s Divided Islamists</volume_title>
+						<author>ICG</author>
+						<cYear>2010</cYear>
+						<unstructured_citation>ICG. 2010. Somalia’s Divided Islamists. https://www.crisisgroup.org/africa/horn-africa/somalia/somalia-s-divided-islamists.</unstructured_citation>
+					</citation>
+					<citation key="B24">
+						<journal_title>Citizens’ Perception of Peace and Stabilization Initiatives in Somalia</journal_title>
+						<author>Ipsos</author>
+						<cYear>2015</cYear>
+					</citation>
+					<citation key="B25">
+						<journal_title>Citizens Perception of Peace and Stabilization Initiative in Somalia</journal_title>
+						<author>Ipsos</author>
+						<cYear>2016</cYear>
+					</citation>
+					<citation key="B26">
+						<journal_title>Final Report: Information Support Services to UNSOA/AMISOM: November 2009–November 2012</journal_title>
+						<author>IST</author>
+						<cYear>2012</cYear>
+					</citation>
+					<citation key="B27">
+						<journal_title>Mogadishu Polling Survey 2013 (Wave 2)</journal_title>
+						<author>IST</author>
+						<cYear>2013</cYear>
+					</citation>
+					<citation key="B28">
+						<journal_title>Citizens Perception of Peace and Stabilization Initiatives in Somalia</journal_title>
+						<author>IST</author>
+						<cYear>2015</cYear>
+					</citation>
+					<citation key="B29">
+						<volume_title>TV, Twitter and Telegram: How Do Jihadi Insurgents Attempt to Influence the Mass Media?</volume_title>
+						<cYear>2017</cYear>
+						<unstructured_citation>2017. King’s College London. TV, Twitter and Telegram: How Do Jihadi Insurgents Attempt to Influence the Mass Media?.</unstructured_citation>
+					</citation>
+					<citation key="B30">
+						<volume_title>Peacekeeping and Public Information</volume_title>
+						<cYear>1999</cYear>
+					</citation>
+					<citation key="B31">
+						<volume_title>Communication and Peace: Mapping an Emerging Field</volume_title>
+						<first_page>135</first_page>
+						<cYear>2015</cYear>
+					</citation>
+					<citation key="B32">
+						<journal_title>International Peacekeeping</journal_title>
+						<volume>11</volume>
+						<issue>4</issue>
+						<first_page>608</first_page>
+						<cYear>2004</cYear>
+						<article_title>Untapped power? The status of UN information operations</article_title>
+						<doi>10.1080/1353331042000248696</doi>
+					</citation>
+					<citation key="B33">
+						<volume_title>The Surge to Stabilize: Lessons for the UN from the AU’s Experience in Somalia</volume_title>
+						<cYear>2016</cYear>
+						<unstructured_citation>2016. New York: International Peace Institute. The Surge to Stabilize: Lessons for the UN from the AU’s Experience in Somalia. https://www.ipinst.org/2016/05/un-au-stabilize-somalia.</unstructured_citation>
+					</citation>
+					<citation key="B34">
+						<author>NATO</author>
+						<cYear>2009</cYear>
+						<article_title>Strategic Communication Policy</article_title>
+					</citation>
+					<citation key="B35">
+						<volume_title>Military Concept for Strategic Communications</volume_title>
+						<author>NATO</author>
+						<cYear>2010</cYear>
+						<unstructured_citation>NATO. 2010. Military Concept for Strategic Communications. http://info.publicintelligence.net/NATO-STRATCOM-Concept.pdf.</unstructured_citation>
+					</citation>
+					<citation key="B36">
+						<journal_title>International Peacekeeping</journal_title>
+						<cYear>2017</cYear>
+						<article_title>Policy Entrepreneurship by International Bureaucracies: The Evolution of Public Information in UN Peacekeeping</article_title>
+						<doi>10.1080/13533312.2017.1395286</doi>
+					</citation>
+					<citation key="B37">
+						<volume_title>Strategic Communication: Origins, Concepts and Current Debates</volume_title>
+						<cYear>2011</cYear>
+					</citation>
+					<citation key="B38">
+						<volume_title>Military Review</volume_title>
+						<cYear>2008</cYear>
+						<article_title>Multi-National Force Iraq Commander’s Counterinsurgency Guidance</article_title>
+						<unstructured_citation>2008. Multi-National Force Iraq Commander’s Counterinsurgency Guidance. Military Review. http://usacac.army.mil/CAC2/MilitaryReview/Archives/English/MilitaryReview_20081031_art004.pdf.</unstructured_citation>
+					</citation>
+					<citation key="B39">
+						<cYear>2013</cYear>
+						<unstructured_citation>2013. Remarks to the Institute for Horn of Africa Studies and Affairs conference, Minneapolis, October. http://www.youtube.com/watch?v=iq3PfPwlzBk&amp;feature=youtu.be.</unstructured_citation>
+					</citation>
+					<citation key="B40">
+						<journal_title>Citizens’ Perceptions of the United Nations in Somalia: A Qualitative Analysis</journal_title>
+						<author>UNSOM</author>
+						<cYear>2016</cYear>
+					</citation>
+					<citation key="B41">
+						<journal_title>Citizens Perception of Peace and Stabilization Initiative in Somalia</journal_title>
+						<author>UNSOM-AU</author>
+						<cYear>2016</cYear>
+					</citation>
+					<citation key="B42">
+						<author>Wikileak Cable</author>
+						<cYear>2010</cYear>
+					</citation>
+					<citation key="B43">
+						<volume_title>The Battle at El Adde: The Kenyan Defence Forces, a-Shabaab, and Unanswered Questions</volume_title>
+						<cYear>2016</cYear>
+						<unstructured_citation>2016. New York: International Peace Institute. The Battle at El Adde: The Kenyan Defence Forces, a-Shabaab, and Unanswered Questions. https://www.ipinst.org/2016/07/the-battle-at-el-adde-the-kenya-defence-forces-al-shabaab-and-unanswered-questions.</unstructured_citation>
+					</citation>
+					<citation key="B44">
+						<volume_title>UN Support to Regional Peace Operations: Lessons from UNSOA</volume_title>
+						<cYear>2017</cYear>
+						<unstructured_citation>2017. New York: International Peace Institute. UN Support to Regional Peace Operations: Lessons from UNSOA. https://www.ipinst.org/2017/02/un-support-regional-peace-ops-unsoa.</unstructured_citation>
+					</citation>
+					<citation key="B45">
+						<volume_title>Fighting for Peace in Somalia: A History and Analysis of the African Union Mission (AMISOM), 2007–2017</volume_title>
+						<cYear>2018</cYear>
+					</citation>
+				</citation_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/crossref-bmjopen-2013-003269-20170717071707.xml
+++ b/tests/test_data/crossref-bmjopen-2013-003269-20170717071707.xml
@@ -1,1 +1,415 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>crossref-bmjopen-2013-003269-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>BMJ Open</depositor_name><email_address>bmj_open@example.org</email_address></depositor><registrant>BMJ_Open</registrant></head><body><journal><journal_metadata language="en"><full_title>BMJ Open</full_title><issn media_type="electronic">2044-6055</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>01</month><day>31</day><year>2014</year></publication_date><journal_volume><volume>4</volume></journal_volume></journal_issue><journal_article publication_type="full_text"><titles><title>Hospital-based surveillance of rotavirus gastroenteritis among children under 5 years of age in the Republic of Ivory Coast: a cross-sectional study</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Chantal</given_name><surname>Akoua-Koffi</surname><affiliation>1</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Vincent</given_name><surname>Asse Kouadio</surname><affiliation>2</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Jean Jacques</given_name><surname>Yao Atteby</surname><affiliation>3</affiliation></person_name></contributors><jats:abstract><jats:p>To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5 years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.</jats:p><jats:p>A cross-sectional hospital-based surveillance study.</jats:p><jats:p>5 reference paediatric hospitals across Abidjan.</jats:p><jats:p>Children aged less than 5 years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.</jats:p><jats:p>The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.</jats:p><jats:p>Of 357 enrolled children (mean age 13.6±11.14 months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11 months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.</jats:p><jats:p>RVGE causes substantial morbidity among children under 5 years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.</jats:p></jats:abstract><publication_date media_type="online"><month>01</month><day>31</day><year>2014</year></publication_date><publisher_item><item_number item_number_type="article_number">e003269</item_number><identifier id_type="doi">10.1136/bmjopen-2013-003269</identifier></publisher_item><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.1136/bmjopen-2013-003269</doi><resource>http://bmjopen.bmj.com/lookup/doi/10.1136/bmjopen-2013-003269</resource></doi_data><citation_list><citation key="R1"><volume_title>Emerg Infect Dis</volume_title><author>Parashar</author><volume>9</volume><first_page>565</first_page><cYear>2003</cYear><article_title>Global Illness and deaths caused by rotavirus disease in children</article_title></citation><citation key="R2"><volume_title>Lancet Infect Dis</volume_title><author>Tate</author><volume>12</volume><first_page>136</first_page><cYear>2012</cYear><article_title>WHO-coordinated Global Rotavirus Surveillance Network. 2008 estimate of worldwide rotavirus-associated mortality in children younger than 5 years before the introduction of universal rotavirus vaccination programmes: a systematic review and meta-analysis</article_title></citation><citation key="R3"><volume_title>J Infect Dis</volume_title><author>Parashar</author><volume>200</volume><first_page>S9</first_page><cYear>2009</cYear><article_title>Global mortality associated with rotavirus disease among children in 2004</article_title></citation><citation key="R4"><volume_title>Lancet Infect Dis</volume_title><author>Sanchez-Padilla</author><volume>9</volume><first_page>567</first_page><cYear>2009</cYear><article_title>Burden of disease and circulating serotypes of rotavirus infection in sub-Saharan Africa: systematic review and meta-analysis</article_title></citation><citation key="R5"><volume_title>Emerg Infect Dis</volume_title><author>Parashar</author><volume>4</volume><first_page>561</first_page><cYear>1998</cYear><article_title>Rotavirus</article_title></citation><citation key="R6"><volume_title>J Infect Dis</volume_title><author>Glass</author><volume>174</volume><first_page>S5</first_page><cYear>1996</cYear><article_title>The epidemiology of rotavirus diarrhea in the United States: surveillance and estimates of disease burden</article_title></citation><citation key="R7"><volume_title>J Infect Dis</volume_title><author>Gurwith</author><volume>147</volume><first_page>685</first_page><cYear>1983</cYear><article_title>Diarrhea among infants and young children in Canada: a longitudinal study in three northern communities</article_title></citation><citation key="R8"><volume_title>Pediatr Infect Dis J</volume_title><author>Rodriguez</author><volume>6</volume><first_page>170</first_page><cYear>1987</cYear><article_title>Longitudinal study of rotavirus infection and gastroenteritis in families served by a pediatric medical practice: clinical and epidemiologic observations</article_title></citation><citation key="R9"><volume_title>Bull World Health Organ</volume_title><author>Cunliffe</author><volume>76</volume><first_page>525</first_page><cYear>1998</cYear><article_title>Epidemiology of rotavirus diarrhea in Africa: a review to assess the need for rotavirus immunization</article_title></citation><citation key="R10"><volume_title>Am J Epidemiol</volume_title><author>Naficy</author><volume>150</volume><first_page>770</first_page><cYear>1999</cYear><article_title>Epidemiology of rotavirus diarrhea in Egyptian children and implications for disease control</article_title></citation><citation key="R11"><volume_title>Expert Rev Vaccines</volume_title><author>Cunliffe</author><volume>4</volume><first_page>521</first_page><cYear>2005</cYear><article_title>A critical time for rotavirus vaccines: a review</article_title></citation><citation key="R12"><volume_title>J Infect Dis</volume_title><author>Glass</author><volume>192</volume><first_page>S160</first_page><cYear>2005</cYear><article_title>Rotavirus vaccines: targeting the developing world</article_title></citation><citation key="R13"><volume_title>Vaccine</volume_title><author>Steele</author><volume>21</volume><first_page>361</first_page><cYear>2003</cYear><article_title>Rotavirus strains circulating in Africa during 1996–1999: emergence of G9 strains and P[6] strains</article_title></citation><citation key="R14"><volume_title>Emerg Infect Dis</volume_title><author>Yang</author><volume>13</volume><first_page>1587</first_page><cYear>2007</cYear><article_title>Emergence of human rotavirus group A genotype G9 strains, Wuhan, China</article_title></citation><citation key="R15"><volume_title>Epidemiology and prevention of vaccine-preventable diseases</volume_title><author>Atkinson</author><cYear>2008</cYear></citation><citation key="R16"><volume_title>Rev Med Côte d'Ivoire</volume_title><author>Cowpli-Bony</author><volume>79</volume><first_page>21</first_page><cYear>1987</cYear><article_title>Technique immunoenzymatique epidemiologie des diarrhees aigues a rotavirus chez 115 enfants diarrheiques atteints de malnutrition a Abidjan</article_title></citation><citation key="R17"><volume_title>Rev Med Côte d'Ivoire</volume_title><author>Lougou</author><volume>81</volume><first_page>4</first_page><cYear>1987</cYear><article_title>Sous-groupes de rotavirus humains en Côte d'Ivoire determines par immunoenzymologie</article_title></citation><citation key="R18"><volume_title>Med Afr Noire</volume_title><author>Akoua-Koffi</author><volume>40</volume><first_page>599</first_page><cYear>1993</cYear><article_title>Interet de l'utilisation d'un test au latex (Rotalex) pour le depistage de rotavirus dans les selles diarrheiques a Abidjan</article_title></citation><citation key="R19"><volume_title>Afr J Health Sci</volume_title><author>Akran</author><volume>8</volume><first_page>33</first_page><cYear>2001</cYear><article_title>Electrophoretypes of rotavirus in children 15 years of age in Abidjan, Côte d'Ivoire in 1997</article_title></citation><citation key="R20"><volume_title>Arch Pediatr</volume_title><author>Niangue-Beugre</author><volume>13</volume><first_page>395</first_page><cYear>2006</cYear><article_title>Aspect epidemiologiques, cliniques et etiologiques des diarrhees aigues des enfants ages de 1 mois a 5 ans recus dans le service de pediatrie du CHU de Treichville (Côte d'Ivoire)</article_title></citation><citation key="R21"><volume_title>Bull Soc Pathol Exot</volume_title><author>Akoua-Koffi</author><volume>100</volume><first_page>246</first_page><cYear>2007</cYear><article_title>Epidemiological and virological aspects rotavirus diarrhea in Abidjan, Côte d'Ivoire (1997–2000)</article_title></citation><citation key="R22"><volume_title>Scand J Infect Dis</volume_title><author>Ruuska</author><volume>22</volume><first_page>259</first_page><cYear>1990</cYear><article_title>Rotavirus disease in Finnish children: use of numerical scores for clinical severity of diarrheal episodes</article_title></citation><citation key="R23"><volume_title>J Clin Microbiol</volume_title><author>van Doorn</author><volume>47</volume><first_page>2704</first_page><cYear>2009</cYear><article_title>Detection and genotyping of human rotavirus VP4 and VP7 genes by reverse transcriptase PCR and reverse hybridization</article_title></citation><citation key="R24"><volume_title>Virol J</volume_title><author>Junaid</author><volume>8</volume><first_page>233</first_page><cYear>2011</cYear><article_title>Incidence of rotavirus infection in children with gastroenteritis attending Jos university teaching hospital, Nigeria</article_title></citation><citation key="R25"><volume_title>BMC Infect Dis</volume_title><author>Khoury</author><volume>11</volume><first_page>9</first_page><cYear>2011</cYear><article_title>Burden of rotavirus gastroenteritis in the Middle Eastern and North African pediatric population</article_title></citation><citation key="R26"><volume_title>J Med Virol</volume_title><author>Abugalia</author><volume>83</volume><first_page>1849</first_page><cYear>2011</cYear><article_title>Clinical features and molecular epidemiology of rotavirus and norovirus infections in Libyan children</article_title></citation><citation key="R27"><volume_title>Semin Pediatr Infect Dis</volume_title><author>Ochoa</author><volume>15</volume><first_page>229</first_page><cYear>2004</cYear><article_title>Management of children with infection-associated persistent diarrhea</article_title></citation><citation key="R28"><volume_title>Indian J Pediatr</volume_title><author>Uysal</author><volume>67</volume><first_page>329</first_page><cYear>2000</cYear><article_title>Clinical risk factors for fatal diarrhea in hospitalized children</article_title></citation><citation key="R29"><volume_title>J Infect Dis</volume_title><author>Armah</author><volume>202</volume><issue>(Suppl)</issue><first_page>S64</first_page><cYear>2010</cYear><article_title>Diversity of rotavirus strains circulating in West Africa from 1996 to 2000</article_title></citation><citation key="R30"><volume_title>J Infect Dis</volume_title><author>Todd</author><volume>202</volume><first_page>S34</first_page><cYear>2010</cYear><article_title>Rotavirus strain types circulating in Africa: review of studies published during 1997–2006</article_title></citation><citation key="R31"><author>World Health Organization</author><article_title>Rotavirus surveillance in the African Region. Updates of Rotavirus surveillance in the African Region</article_title></citation><citation key="R32"><volume_title>Pediatr Infect Dis J</volume_title><author>Dennehy</author><volume>19</volume><first_page>S103</first_page><cYear>2000</cYear><article_title>Transmission of rotavirus and other enteric pathogens in the home</article_title></citation><citation key="R33"><volume_title>Emerg Infect Dis</volume_title><author>Parashar</author><volume>12</volume><first_page>304</first_page><cYear>2006</cYear><article_title>Rotavirus and severe childhood diarrhea</article_title></citation><citation key="R34"><volume_title>Pediatr Infect Dis J</volume_title><author>Paulke-Korienk</author><volume>29</volume><first_page>319</first_page><cYear>2010</cYear><article_title>Universal mass vaccination against rotavirus gastroenteritis: impact on hospitalization rates in Austrian children</article_title></citation><citation key="R35"><volume_title>N Engl J Med</volume_title><author>Richardson</author><volume>362</volume><first_page>299</first_page><cYear>2010</cYear><article_title>Reduction in childhood diarrhea deaths after rotavirus vaccine introduction in Mexico</article_title></citation><citation key="R36"><volume_title>Hum Vaccin</volume_title><author>Yen</author><volume>7</volume><first_page>1282</first_page><cYear>2011</cYear><article_title>Rotavirus vaccines: update on global impact and future priorities</article_title></citation><citation key="R37"><volume_title>MMWR Morb Mortal Wkly Rep</volume_title><author>Centers for Disease Control</author><volume>57</volume><first_page>1255</first_page><cYear>2008</cYear><article_title>Rotavirus surveillance—worldwide, 2001–2008</article_title></citation><citation key="R38"><volume_title>N Engl J Med</volume_title><author>Ruiz-Palacios</author><volume>354</volume><first_page>11</first_page><cYear>2006</cYear><article_title>Safety and efficacy of an attenuated vaccine against severe rotavirus gastroenteritis</article_title></citation><citation key="R39"><volume_title>Lancet</volume_title><author>Linhares</author><volume>371</volume><first_page>1181</first_page><cYear>2008</cYear><article_title>Efficacy and safety of an oral live attenuated human rotavirus vaccine against rotavirus gastroenteritis during the first 2 years of life in Latin American infants: randomized, double-blind controlled study</article_title></citation><citation key="R40"><volume_title>N Engl J Med</volume_title><author>Madhi</author><volume>362</volume><first_page>289</first_page><cYear>2010</cYear><article_title>Effect of human rotavirus vaccine on severe diarrhea in African infants</article_title></citation><citation key="R41"><volume_title>Lancet</volume_title><author>Armah</author><volume>376</volume><first_page>606</first_page><cYear>2010</cYear><article_title>Efficacy of pentavalent rotavirus vaccine against severe rotavirus gastroenteritis in infants in developing countries in sub-Saharan Africa: a randomized, double-blind, placebo-controlled trial</article_title></citation><citation key="R42"><volume_title>Wkly Epidemiol Rec</volume_title><volume>84</volume><first_page>517</first_page><cYear>2009</cYear><article_title>Meeting of the Strategic Advisory Group of Experts on immunization, October 2009—conclusions and recommendations</article_title></citation><citation key="R43"><author>World Health Organization</author><article_title>Generic protocols for (i) hospital-based surveillance to estimate the burden of rotavirus gastroenteritis in children and (ii) a community-based survey on utilization of health care services for gastroenteritis in children</article_title></citation></citation_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>crossref-bmjopen-2013-003269-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>BMJ Open</depositor_name>
+			<email_address>bmj_open@example.org</email_address>
+		</depositor>
+		<registrant>BMJ_Open</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>BMJ Open</full_title>
+				<issn media_type="electronic">2044-6055</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>01</month>
+					<day>31</day>
+					<year>2014</year>
+				</publication_date>
+				<journal_volume>
+					<volume>4</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text">
+				<titles>
+					<title>Hospital-based surveillance of rotavirus gastroenteritis among children under 5 years of age in the Republic of Ivory Coast: a cross-sectional study</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Chantal</given_name>
+						<surname>Akoua-Koffi</surname>
+						<affiliation>1</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Vincent</given_name>
+						<surname>Asse Kouadio</surname>
+						<affiliation>2</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Jean Jacques</given_name>
+						<surname>Yao Atteby</surname>
+						<affiliation>3</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5 years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.</jats:p>
+					<jats:p>A cross-sectional hospital-based surveillance study.</jats:p>
+					<jats:p>5 reference paediatric hospitals across Abidjan.</jats:p>
+					<jats:p>Children aged less than 5 years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.</jats:p>
+					<jats:p>The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.</jats:p>
+					<jats:p>Of 357 enrolled children (mean age 13.6±11.14 months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11 months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.</jats:p>
+					<jats:p>RVGE causes substantial morbidity among children under 5 years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>01</month>
+					<day>31</day>
+					<year>2014</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e003269</item_number>
+					<identifier id_type="doi">10.1136/bmjopen-2013-003269</identifier>
+				</publisher_item>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.1136/bmjopen-2013-003269</doi>
+					<resource>http://bmjopen.bmj.com/lookup/doi/10.1136/bmjopen-2013-003269</resource>
+				</doi_data>
+				<citation_list>
+					<citation key="R1">
+						<volume_title>Emerg Infect Dis</volume_title>
+						<author>Parashar</author>
+						<volume>9</volume>
+						<first_page>565</first_page>
+						<cYear>2003</cYear>
+						<article_title>Global Illness and deaths caused by rotavirus disease in children</article_title>
+					</citation>
+					<citation key="R2">
+						<volume_title>Lancet Infect Dis</volume_title>
+						<author>Tate</author>
+						<volume>12</volume>
+						<first_page>136</first_page>
+						<cYear>2012</cYear>
+						<article_title>WHO-coordinated Global Rotavirus Surveillance Network. 2008 estimate of worldwide rotavirus-associated mortality in children younger than 5 years before the introduction of universal rotavirus vaccination programmes: a systematic review and meta-analysis</article_title>
+					</citation>
+					<citation key="R3">
+						<volume_title>J Infect Dis</volume_title>
+						<author>Parashar</author>
+						<volume>200</volume>
+						<first_page>S9</first_page>
+						<cYear>2009</cYear>
+						<article_title>Global mortality associated with rotavirus disease among children in 2004</article_title>
+					</citation>
+					<citation key="R4">
+						<volume_title>Lancet Infect Dis</volume_title>
+						<author>Sanchez-Padilla</author>
+						<volume>9</volume>
+						<first_page>567</first_page>
+						<cYear>2009</cYear>
+						<article_title>Burden of disease and circulating serotypes of rotavirus infection in sub-Saharan Africa: systematic review and meta-analysis</article_title>
+					</citation>
+					<citation key="R5">
+						<volume_title>Emerg Infect Dis</volume_title>
+						<author>Parashar</author>
+						<volume>4</volume>
+						<first_page>561</first_page>
+						<cYear>1998</cYear>
+						<article_title>Rotavirus</article_title>
+					</citation>
+					<citation key="R6">
+						<volume_title>J Infect Dis</volume_title>
+						<author>Glass</author>
+						<volume>174</volume>
+						<first_page>S5</first_page>
+						<cYear>1996</cYear>
+						<article_title>The epidemiology of rotavirus diarrhea in the United States: surveillance and estimates of disease burden</article_title>
+					</citation>
+					<citation key="R7">
+						<volume_title>J Infect Dis</volume_title>
+						<author>Gurwith</author>
+						<volume>147</volume>
+						<first_page>685</first_page>
+						<cYear>1983</cYear>
+						<article_title>Diarrhea among infants and young children in Canada: a longitudinal study in three northern communities</article_title>
+					</citation>
+					<citation key="R8">
+						<volume_title>Pediatr Infect Dis J</volume_title>
+						<author>Rodriguez</author>
+						<volume>6</volume>
+						<first_page>170</first_page>
+						<cYear>1987</cYear>
+						<article_title>Longitudinal study of rotavirus infection and gastroenteritis in families served by a pediatric medical practice: clinical and epidemiologic observations</article_title>
+					</citation>
+					<citation key="R9">
+						<volume_title>Bull World Health Organ</volume_title>
+						<author>Cunliffe</author>
+						<volume>76</volume>
+						<first_page>525</first_page>
+						<cYear>1998</cYear>
+						<article_title>Epidemiology of rotavirus diarrhea in Africa: a review to assess the need for rotavirus immunization</article_title>
+					</citation>
+					<citation key="R10">
+						<volume_title>Am J Epidemiol</volume_title>
+						<author>Naficy</author>
+						<volume>150</volume>
+						<first_page>770</first_page>
+						<cYear>1999</cYear>
+						<article_title>Epidemiology of rotavirus diarrhea in Egyptian children and implications for disease control</article_title>
+					</citation>
+					<citation key="R11">
+						<volume_title>Expert Rev Vaccines</volume_title>
+						<author>Cunliffe</author>
+						<volume>4</volume>
+						<first_page>521</first_page>
+						<cYear>2005</cYear>
+						<article_title>A critical time for rotavirus vaccines: a review</article_title>
+					</citation>
+					<citation key="R12">
+						<volume_title>J Infect Dis</volume_title>
+						<author>Glass</author>
+						<volume>192</volume>
+						<first_page>S160</first_page>
+						<cYear>2005</cYear>
+						<article_title>Rotavirus vaccines: targeting the developing world</article_title>
+					</citation>
+					<citation key="R13">
+						<volume_title>Vaccine</volume_title>
+						<author>Steele</author>
+						<volume>21</volume>
+						<first_page>361</first_page>
+						<cYear>2003</cYear>
+						<article_title>Rotavirus strains circulating in Africa during 1996–1999: emergence of G9 strains and P[6] strains</article_title>
+					</citation>
+					<citation key="R14">
+						<volume_title>Emerg Infect Dis</volume_title>
+						<author>Yang</author>
+						<volume>13</volume>
+						<first_page>1587</first_page>
+						<cYear>2007</cYear>
+						<article_title>Emergence of human rotavirus group A genotype G9 strains, Wuhan, China</article_title>
+					</citation>
+					<citation key="R15">
+						<volume_title>Epidemiology and prevention of vaccine-preventable diseases</volume_title>
+						<author>Atkinson</author>
+						<cYear>2008</cYear>
+					</citation>
+					<citation key="R16">
+						<volume_title>Rev Med Côte d'Ivoire</volume_title>
+						<author>Cowpli-Bony</author>
+						<volume>79</volume>
+						<first_page>21</first_page>
+						<cYear>1987</cYear>
+						<article_title>Technique immunoenzymatique epidemiologie des diarrhees aigues a rotavirus chez 115 enfants diarrheiques atteints de malnutrition a Abidjan</article_title>
+					</citation>
+					<citation key="R17">
+						<volume_title>Rev Med Côte d'Ivoire</volume_title>
+						<author>Lougou</author>
+						<volume>81</volume>
+						<first_page>4</first_page>
+						<cYear>1987</cYear>
+						<article_title>Sous-groupes de rotavirus humains en Côte d'Ivoire determines par immunoenzymologie</article_title>
+					</citation>
+					<citation key="R18">
+						<volume_title>Med Afr Noire</volume_title>
+						<author>Akoua-Koffi</author>
+						<volume>40</volume>
+						<first_page>599</first_page>
+						<cYear>1993</cYear>
+						<article_title>Interet de l'utilisation d'un test au latex (Rotalex) pour le depistage de rotavirus dans les selles diarrheiques a Abidjan</article_title>
+					</citation>
+					<citation key="R19">
+						<volume_title>Afr J Health Sci</volume_title>
+						<author>Akran</author>
+						<volume>8</volume>
+						<first_page>33</first_page>
+						<cYear>2001</cYear>
+						<article_title>Electrophoretypes of rotavirus in children 15 years of age in Abidjan, Côte d'Ivoire in 1997</article_title>
+					</citation>
+					<citation key="R20">
+						<volume_title>Arch Pediatr</volume_title>
+						<author>Niangue-Beugre</author>
+						<volume>13</volume>
+						<first_page>395</first_page>
+						<cYear>2006</cYear>
+						<article_title>Aspect epidemiologiques, cliniques et etiologiques des diarrhees aigues des enfants ages de 1 mois a 5 ans recus dans le service de pediatrie du CHU de Treichville (Côte d'Ivoire)</article_title>
+					</citation>
+					<citation key="R21">
+						<volume_title>Bull Soc Pathol Exot</volume_title>
+						<author>Akoua-Koffi</author>
+						<volume>100</volume>
+						<first_page>246</first_page>
+						<cYear>2007</cYear>
+						<article_title>Epidemiological and virological aspects rotavirus diarrhea in Abidjan, Côte d'Ivoire (1997–2000)</article_title>
+					</citation>
+					<citation key="R22">
+						<volume_title>Scand J Infect Dis</volume_title>
+						<author>Ruuska</author>
+						<volume>22</volume>
+						<first_page>259</first_page>
+						<cYear>1990</cYear>
+						<article_title>Rotavirus disease in Finnish children: use of numerical scores for clinical severity of diarrheal episodes</article_title>
+					</citation>
+					<citation key="R23">
+						<volume_title>J Clin Microbiol</volume_title>
+						<author>van Doorn</author>
+						<volume>47</volume>
+						<first_page>2704</first_page>
+						<cYear>2009</cYear>
+						<article_title>Detection and genotyping of human rotavirus VP4 and VP7 genes by reverse transcriptase PCR and reverse hybridization</article_title>
+					</citation>
+					<citation key="R24">
+						<volume_title>Virol J</volume_title>
+						<author>Junaid</author>
+						<volume>8</volume>
+						<first_page>233</first_page>
+						<cYear>2011</cYear>
+						<article_title>Incidence of rotavirus infection in children with gastroenteritis attending Jos university teaching hospital, Nigeria</article_title>
+					</citation>
+					<citation key="R25">
+						<volume_title>BMC Infect Dis</volume_title>
+						<author>Khoury</author>
+						<volume>11</volume>
+						<first_page>9</first_page>
+						<cYear>2011</cYear>
+						<article_title>Burden of rotavirus gastroenteritis in the Middle Eastern and North African pediatric population</article_title>
+					</citation>
+					<citation key="R26">
+						<volume_title>J Med Virol</volume_title>
+						<author>Abugalia</author>
+						<volume>83</volume>
+						<first_page>1849</first_page>
+						<cYear>2011</cYear>
+						<article_title>Clinical features and molecular epidemiology of rotavirus and norovirus infections in Libyan children</article_title>
+					</citation>
+					<citation key="R27">
+						<volume_title>Semin Pediatr Infect Dis</volume_title>
+						<author>Ochoa</author>
+						<volume>15</volume>
+						<first_page>229</first_page>
+						<cYear>2004</cYear>
+						<article_title>Management of children with infection-associated persistent diarrhea</article_title>
+					</citation>
+					<citation key="R28">
+						<volume_title>Indian J Pediatr</volume_title>
+						<author>Uysal</author>
+						<volume>67</volume>
+						<first_page>329</first_page>
+						<cYear>2000</cYear>
+						<article_title>Clinical risk factors for fatal diarrhea in hospitalized children</article_title>
+					</citation>
+					<citation key="R29">
+						<volume_title>J Infect Dis</volume_title>
+						<author>Armah</author>
+						<volume>202</volume>
+						<issue>(Suppl)</issue>
+						<first_page>S64</first_page>
+						<cYear>2010</cYear>
+						<article_title>Diversity of rotavirus strains circulating in West Africa from 1996 to 2000</article_title>
+					</citation>
+					<citation key="R30">
+						<volume_title>J Infect Dis</volume_title>
+						<author>Todd</author>
+						<volume>202</volume>
+						<first_page>S34</first_page>
+						<cYear>2010</cYear>
+						<article_title>Rotavirus strain types circulating in Africa: review of studies published during 1997–2006</article_title>
+					</citation>
+					<citation key="R31">
+						<author>World Health Organization</author>
+						<article_title>Rotavirus surveillance in the African Region. Updates of Rotavirus surveillance in the African Region</article_title>
+					</citation>
+					<citation key="R32">
+						<volume_title>Pediatr Infect Dis J</volume_title>
+						<author>Dennehy</author>
+						<volume>19</volume>
+						<first_page>S103</first_page>
+						<cYear>2000</cYear>
+						<article_title>Transmission of rotavirus and other enteric pathogens in the home</article_title>
+					</citation>
+					<citation key="R33">
+						<volume_title>Emerg Infect Dis</volume_title>
+						<author>Parashar</author>
+						<volume>12</volume>
+						<first_page>304</first_page>
+						<cYear>2006</cYear>
+						<article_title>Rotavirus and severe childhood diarrhea</article_title>
+					</citation>
+					<citation key="R34">
+						<volume_title>Pediatr Infect Dis J</volume_title>
+						<author>Paulke-Korienk</author>
+						<volume>29</volume>
+						<first_page>319</first_page>
+						<cYear>2010</cYear>
+						<article_title>Universal mass vaccination against rotavirus gastroenteritis: impact on hospitalization rates in Austrian children</article_title>
+					</citation>
+					<citation key="R35">
+						<volume_title>N Engl J Med</volume_title>
+						<author>Richardson</author>
+						<volume>362</volume>
+						<first_page>299</first_page>
+						<cYear>2010</cYear>
+						<article_title>Reduction in childhood diarrhea deaths after rotavirus vaccine introduction in Mexico</article_title>
+					</citation>
+					<citation key="R36">
+						<volume_title>Hum Vaccin</volume_title>
+						<author>Yen</author>
+						<volume>7</volume>
+						<first_page>1282</first_page>
+						<cYear>2011</cYear>
+						<article_title>Rotavirus vaccines: update on global impact and future priorities</article_title>
+					</citation>
+					<citation key="R37">
+						<volume_title>MMWR Morb Mortal Wkly Rep</volume_title>
+						<author>Centers for Disease Control</author>
+						<volume>57</volume>
+						<first_page>1255</first_page>
+						<cYear>2008</cYear>
+						<article_title>Rotavirus surveillance—worldwide, 2001–2008</article_title>
+					</citation>
+					<citation key="R38">
+						<volume_title>N Engl J Med</volume_title>
+						<author>Ruiz-Palacios</author>
+						<volume>354</volume>
+						<first_page>11</first_page>
+						<cYear>2006</cYear>
+						<article_title>Safety and efficacy of an attenuated vaccine against severe rotavirus gastroenteritis</article_title>
+					</citation>
+					<citation key="R39">
+						<volume_title>Lancet</volume_title>
+						<author>Linhares</author>
+						<volume>371</volume>
+						<first_page>1181</first_page>
+						<cYear>2008</cYear>
+						<article_title>Efficacy and safety of an oral live attenuated human rotavirus vaccine against rotavirus gastroenteritis during the first 2 years of life in Latin American infants: randomized, double-blind controlled study</article_title>
+					</citation>
+					<citation key="R40">
+						<volume_title>N Engl J Med</volume_title>
+						<author>Madhi</author>
+						<volume>362</volume>
+						<first_page>289</first_page>
+						<cYear>2010</cYear>
+						<article_title>Effect of human rotavirus vaccine on severe diarrhea in African infants</article_title>
+					</citation>
+					<citation key="R41">
+						<volume_title>Lancet</volume_title>
+						<author>Armah</author>
+						<volume>376</volume>
+						<first_page>606</first_page>
+						<cYear>2010</cYear>
+						<article_title>Efficacy of pentavalent rotavirus vaccine against severe rotavirus gastroenteritis in infants in developing countries in sub-Saharan Africa: a randomized, double-blind, placebo-controlled trial</article_title>
+					</citation>
+					<citation key="R42">
+						<volume_title>Wkly Epidemiol Rec</volume_title>
+						<volume>84</volume>
+						<first_page>517</first_page>
+						<cYear>2009</cYear>
+						<article_title>Meeting of the Strategic Advisory Group of Experts on immunization, October 2009—conclusions and recommendations</article_title>
+					</citation>
+					<citation key="R43">
+						<author>World Health Organization</author>
+						<article_title>Generic protocols for (i) hospital-based surveillance to estimate the burden of rotavirus gastroenteritis in children and (ii) a community-based survey on utilization of health care services for gastroenteritis in children</article_title>
+					</citation>
+				</citation_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/cstp-crossref-77-20170717071707.xml
+++ b/tests/test_data/cstp-crossref-77-20170717071707.xml
@@ -1,1 +1,387 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>cstp-crossref-77-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>Ubiquity Press</depositor_name><email_address>ubiq@example.org</email_address></depositor><registrant>ubiq</registrant></head><body><journal><journal_metadata language="en"><full_title>Citizen Science: Theory and Practice</full_title><issn media_type="electronic">2057-4991</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>07</month><day>04</day><year>2017</year></publication_date><journal_volume><volume>2</volume></journal_volume></journal_issue><journal_article publication_type="full_text"><titles><title>Public Perceptions of Citizen Science</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Eva</given_name><surname>Lewandowski</surname><affiliation>Wisconsin Department of Natural Resources, US</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Wendy</given_name><surname>Caldwell</surname><affiliation>University of Minnesota, US</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Dane</given_name><surname>Elmquist</surname><affiliation>University of Minnesota, US</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Karen</given_name><surname>Oberhauser</surname><affiliation>University of Minnesota, US</affiliation></person_name></contributors><jats:abstract><jats:p>Members of the public are the foundation and the backbone of citizen science, but much remains unknown about how the public views citizen science. We conducted a survey of public familiarity with, and perceptions of, citizen science. We found that less than half of respondents were familiar with the term “citizen science,” but over 70% were familiar with the concept by another name. Most respondents were more confident in hypothetical citizen science findings when professional scientists were involved to some degree, compared to situations in which only citizen scientists were involved. Confidence in citizen science findings tended to increase with age, despite the fact that self-confidence in respondents’ own abilities to perform citizen science tasks decreased with age. Fewer than half of respondents (31–47%), and more men than women, were confident in their own ability to perform science process tasks, with the exception of collecting data (53% confident), and only slightly more predicted they would enjoy such activities. Based on our findings, we suggest ways in which leaders of citizen science projects can better promote recruitment, retention, and engagement on the part of volunteers and the public as a whole.</jats:p></jats:abstract><publication_date media_type="online"><month>07</month><day>04</day><year>2017</year></publication_date><publisher_item><item_number item_number_type="article_number">3</item_number><identifier id_type="doi">10.5334/cstp.77</identifier></publisher_item><doi_data><doi>10.5334/cstp.77</doi><resource>http://theoryandpractice.citizenscienceassociation.org/articles/10.5334/cstp.77/</resource></doi_data><citation_list><citation key="B1"><journal_title>Patient Education and Counseling</journal_title><author>Blanch</author><volume>72</volume><first_page>374</first_page><cYear>2008</cYear><article_title>Medical student gender and issues of confidence</article_title><doi>10.1016/j.pec.2008.05.021</doi></citation><citation key="B2"><journal_title>Public Understanding of Science</journal_title><author>Bonney</author><volume>25</volume><issue>1</issue><first_page>2</first_page><cYear>2015</cYear><article_title>Can citizen science enhance public understanding of science?</article_title><doi>10.1177/0963662515607406</doi></citation><citation key="B3"><journal_title>International Journal of Science Education</journal_title><author>Brossard</author><volume>27</volume><issue>9</issue><first_page>1099</first_page><cYear>2005</cYear><article_title>Scientific knowledge and attitude change: The impact of a citizen science project</article_title><doi>10.1080/09500690500069483</doi></citation><citation key="B4"><volume_title>Volunteering in the United States-2014</volume_title><author>Bureau of Labor Statistics</author><cYear>2014</cYear></citation><citation key="B5"><volume_title>The incidental steward: Reflections on citizen science</volume_title><author>Busch</author><cYear>2013</cYear></citation><citation key="B6"><author>Comber</author><cYear>2014</cYear><article_title>Semantic analysis of citizen sensing, crowdsourcing and VGI</article_title><unstructured_citation>Comber A., Schade S., See L., Mooney P., Foody G. 2014. Semantic analysis of citizen sensing, crowdsourcing and VGI. Paper presented at Connecting a Digital Europe through Location and Place. Proceedings of the AGILE 2014 International Conference on Geographic Information Science.</unstructured_citation></citation><citation key="B7"><journal_title>Environmental Monitoring and Assessment</journal_title><author>Conrad</author><volume>176</volume><issue>1–4</issue><first_page>273</first_page><cYear>2011</cYear><article_title>A review of citizen science and community-based environmental monitoring: Issues and opportunities</article_title><doi>10.1007/s10661-010-1582-5</doi></citation><citation key="B8"><journal_title>Ecology and Society</journal_title><author>Cooper</author><volume>12</volume><issue>2</issue><first_page>11</first_page><cYear>2007</cYear><article_title>Citizen science as a tool for conservation in residential ecosystems</article_title><doi>10.5751/ES-02197-120211</doi></citation><citation key="B9"><journal_title>PloS One</journal_title><author>Cooper</author><volume>9</volume><issue>9</issue><first_page>e106508</first_page><cYear>2014</cYear><article_title>The invisible prevalence of citizen science in global research: Migratory birds and climate change</article_title><doi>10.1371/journal.pone.0106508</doi></citation><citation key="B10"><journal_title>Public Understanding of Science</journal_title><author>Crall</author><volume>22</volume><issue>6</issue><first_page>745</first_page><cYear>2013</cYear><article_title>The impacts of an invasive species citizen science training program on participant attitudes, behavior, and science literacy</article_title><doi>10.1177/0963662511434894</doi></citation><citation key="B11"><journal_title>Frontiers in Ecology and the Environment</journal_title><author>Dickinson</author><volume>10</volume><issue>6</issue><first_page>291</first_page><cYear>2012</cYear><article_title>The current state of citizen science as a tool for ecological research and public engagement</article_title><doi>10.1890/110236</doi></citation><citation key="B12"><journal_title>Annual Review of Ecology, Evolution, and Systematics</journal_title><author>Dickinson</author><volume>41</volume><first_page>149</first_page><cYear>2010</cYear><article_title>Citizen science as an ecological research tool: Challenges and benefits</article_title><doi>10.1146/annurev-ecolsys-102209-144636</doi></citation><citation key="B13"><volume_title>Internet, mail, and mixed-mode surveys</volume_title><author>Dillman</author><cYear>2008</cYear></citation><citation key="B14"><journal_title>Conservation Biology</journal_title><author>Evans</author><volume>19</volume><issue>3</issue><first_page>589</first_page><cYear>2005</cYear><article_title>The Neighborhood Nestwatch Program: Participant outcomes of a citizen-science ecological research project</article_title><doi>10.1111/j.1523-1739.2005.00s01.x</doi></citation><citation key="B15"><journal_title>Environmental Conservation</journal_title><author>Finn</author><volume>37</volume><issue>01</issue><first_page>83</first_page><cYear>2010</cYear><article_title>Assessing the quality of seagrass data collected by community volunteers in Moreton Bay Marine Park, Australia</article_title><doi>10.1017/S0376892910000251</doi></citation><citation key="B16"><journal_title>PloS ONE</journal_title><author>Follett</author><volume>10</volume><issue>11</issue><cYear>2015</cYear><article_title>An analysis of citizen science based research: Usage and publication patterns</article_title><doi>10.1371/journal.pone.0143687</doi></citation><citation key="B17"><journal_title>ACM SIGCSE Bulletin</journal_title><author>Irani</author><volume>36</volume><issue>1</issue><first_page>195</first_page><cYear>2004</cYear><article_title>Understanding gender and confidence in CS course culture</article_title><doi>10.1145/1028174.971371</doi></citation><citation key="B18"><journal_title>International Journal of Science Education</journal_title><author>Jenkins</author><volume>21</volume><issue>7</issue><first_page>703</first_page><cYear>1999</cYear><article_title>School science, citizenship and the public understanding of science</article_title><doi>10.1080/095006999290363</doi></citation><citation key="B19"><journal_title>Conservation Biology</journal_title><author>Jordan</author><volume>25</volume><issue>6</issue><first_page>1148</first_page><cYear>2011</cYear><article_title>Knowledge gain and behavioral change in citizen-science programs</article_title><doi>10.1111/j.1523-1739.2011.01745.x</doi></citation><citation key="B20"><journal_title>Pacific Conservation Biology</journal_title><author>Koss</author><volume>15</volume><first_page>116</first_page><cYear>2009</cYear><article_title>An evaluation of Sea Search as a citizen science programme in Marine Protected Areas</article_title><doi>10.1071/PC090116</doi></citation><citation key="B21"><journal_title>Conservation Biology</journal_title><author>Kremen</author><volume>25</volume><first_page>607</first_page><cYear>2011</cYear><article_title>Evaluating the quality of citizen-scientist data on pollinator communities</article_title><doi>10.1111/j.1523-1739.2011.01657.x</doi></citation><citation key="B22"><journal_title>Biological Conservation</journal_title><author>Lewandowski</author><volume>208</volume><first_page>106</first_page><cYear>2017</cYear><article_title>Butterfly citizen scientists in the United States increase their engagement in conservation</article_title><doi>10.1016/j.biocon.2015.07.029</doi></citation><citation key="B23"><journal_title>Conservation Biology</journal_title><author>Lewandowski</author><volume>29</volume><issue>3</issue><first_page>713</first_page><cYear>2015</cYear><article_title>Influence of volunteer and project characteristics on data quality of biological surveys</article_title><doi>10.1111/cobi.12481</doi></citation><citation key="B24"><journal_title>BioScience</journal_title><author>Martin</author><volume>66</volume><issue>8</issue><first_page>683</first_page><cYear>2016</cYear><article_title>Public interest in marine citizen science: Is there potential for growth?</article_title><doi>10.1093/biosci/biw070</doi></citation><citation key="B25"><journal_title>Issues in Ecology</journal_title><author>McKinley</author><volume>19</volume><cYear>2015</cYear><article_title>Investing in citizen science can improve natural resource management and environmental protection</article_title></citation><citation key="B26"><author>Minnesota State Fair</author><cYear>2015</cYear><article_title>Minnesota state fair website</article_title><unstructured_citation>Minnesota State Fair. 2015. Minnesota state fair website. http://www.mnstatefair.org/.</unstructured_citation></citation><citation key="B27"><volume_title>Science and engineering indicators 2012 (NSB 12-01)</volume_title><author>National Science Board</author><cYear>2012</cYear></citation><citation key="B28"><journal_title>Biological Conservation</journal_title><author>Newman</author><volume>208</volume><first_page>55</first_page><cYear>2017</cYear><article_title>Leveraging the power of place in citizen science for effective conservation decision making</article_title><doi>10.1016/j.biocon.2016.07.019</doi></citation><citation key="B29"><journal_title>Science and Public Policy</journal_title><author>Rayner</author><volume>30</volume><issue>3</issue><first_page>163</first_page><cYear>2003</cYear><article_title>Democracy in the age of assessment: Reflections on the roles of expertise and democracy in public-sector decision making</article_title><doi>10.3152/147154303781780533</doi></citation><citation key="B30"><journal_title>Public Understanding of Science</journal_title><author>Riesch</author><volume>23</volume><issue>1</issue><first_page>107</first_page><cYear>2014</cYear><article_title>Citizen science as seen by scientists: Methodological, epistemological and ethical dimensions</article_title><doi>10.1177/0963662513497324</doi></citation><citation key="B31"><volume_title>Diary of a citizen scientist: Chasing tiger beetles and other new ways of engaging the world</volume_title><author>Russell</author><cYear>2014</cYear></citation><citation key="B32"><journal_title>Environmental management</journal_title><author>Savan</author><volume>31</volume><issue>5</issue><first_page>0561</first_page><cYear>2003</cYear><article_title>Volunteer environmental monitoring and the role of the universities: The case of Citizens’ Environment Watch</article_title><doi>10.1007/s00267-002-2897-y</doi></citation><citation key="B33"><journal_title>Biotropica</journal_title><author>Shanley</author><volume>41</volume><issue>5</issue><first_page>535</first_page><cYear>2009</cYear><article_title>Out of the loop: Why research rarely reaches policy makers and the public and what can be done</article_title><doi>10.1111/j.1744-7429.2009.00561.x</doi></citation><citation key="B34"><journal_title>Ecology and Society</journal_title><author>Shirk</author><volume>17</volume><issue>2</issue><first_page>29</first_page><cYear>2012</cYear><article_title>Public participation in scientific research: A framework for deliberate design</article_title><doi>10.5751/ES-04705-170229</doi></citation><citation key="B35"><journal_title>Studies in Science Education</journal_title><author>Stocklmayer</author><volume>46</volume><issue>1</issue><first_page>1</first_page><cYear>2010</cYear><article_title>The roles of the formal and informal sectors in the provision of effective science education</article_title><doi>10.1080/03057260903562284</doi></citation><citation key="B36"><volume_title>Overview of race and hispanic origin: 2010</volume_title><author>U.S. Census Bureau</author><cYear>2011</cYear></citation></citation_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>cstp-crossref-77-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>Ubiquity Press</depositor_name>
+			<email_address>ubiq@example.org</email_address>
+		</depositor>
+		<registrant>ubiq</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>Citizen Science: Theory and Practice</full_title>
+				<issn media_type="electronic">2057-4991</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>07</month>
+					<day>04</day>
+					<year>2017</year>
+				</publication_date>
+				<journal_volume>
+					<volume>2</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text">
+				<titles>
+					<title>Public Perceptions of Citizen Science</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Eva</given_name>
+						<surname>Lewandowski</surname>
+						<affiliation>Wisconsin Department of Natural Resources, US</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Wendy</given_name>
+						<surname>Caldwell</surname>
+						<affiliation>University of Minnesota, US</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Dane</given_name>
+						<surname>Elmquist</surname>
+						<affiliation>University of Minnesota, US</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Karen</given_name>
+						<surname>Oberhauser</surname>
+						<affiliation>University of Minnesota, US</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Members of the public are the foundation and the backbone of citizen science, but much remains unknown about how the public views citizen science. We conducted a survey of public familiarity with, and perceptions of, citizen science. We found that less than half of respondents were familiar with the term “citizen science,” but over 70% were familiar with the concept by another name. Most respondents were more confident in hypothetical citizen science findings when professional scientists were involved to some degree, compared to situations in which only citizen scientists were involved. Confidence in citizen science findings tended to increase with age, despite the fact that self-confidence in respondents’ own abilities to perform citizen science tasks decreased with age. Fewer than half of respondents (31–47%), and more men than women, were confident in their own ability to perform science process tasks, with the exception of collecting data (53% confident), and only slightly more predicted they would enjoy such activities. Based on our findings, we suggest ways in which leaders of citizen science projects can better promote recruitment, retention, and engagement on the part of volunteers and the public as a whole.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>07</month>
+					<day>04</day>
+					<year>2017</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">3</item_number>
+					<identifier id_type="doi">10.5334/cstp.77</identifier>
+				</publisher_item>
+				<doi_data>
+					<doi>10.5334/cstp.77</doi>
+					<resource>http://theoryandpractice.citizenscienceassociation.org/articles/10.5334/cstp.77/</resource>
+				</doi_data>
+				<citation_list>
+					<citation key="B1">
+						<journal_title>Patient Education and Counseling</journal_title>
+						<author>Blanch</author>
+						<volume>72</volume>
+						<first_page>374</first_page>
+						<cYear>2008</cYear>
+						<article_title>Medical student gender and issues of confidence</article_title>
+						<doi>10.1016/j.pec.2008.05.021</doi>
+					</citation>
+					<citation key="B2">
+						<journal_title>Public Understanding of Science</journal_title>
+						<author>Bonney</author>
+						<volume>25</volume>
+						<issue>1</issue>
+						<first_page>2</first_page>
+						<cYear>2015</cYear>
+						<article_title>Can citizen science enhance public understanding of science?</article_title>
+						<doi>10.1177/0963662515607406</doi>
+					</citation>
+					<citation key="B3">
+						<journal_title>International Journal of Science Education</journal_title>
+						<author>Brossard</author>
+						<volume>27</volume>
+						<issue>9</issue>
+						<first_page>1099</first_page>
+						<cYear>2005</cYear>
+						<article_title>Scientific knowledge and attitude change: The impact of a citizen science project</article_title>
+						<doi>10.1080/09500690500069483</doi>
+					</citation>
+					<citation key="B4">
+						<volume_title>Volunteering in the United States-2014</volume_title>
+						<author>Bureau of Labor Statistics</author>
+						<cYear>2014</cYear>
+					</citation>
+					<citation key="B5">
+						<volume_title>The incidental steward: Reflections on citizen science</volume_title>
+						<author>Busch</author>
+						<cYear>2013</cYear>
+					</citation>
+					<citation key="B6">
+						<author>Comber</author>
+						<cYear>2014</cYear>
+						<article_title>Semantic analysis of citizen sensing, crowdsourcing and VGI</article_title>
+						<unstructured_citation>Comber A., Schade S., See L., Mooney P., Foody G. 2014. Semantic analysis of citizen sensing, crowdsourcing and VGI. Paper presented at Connecting a Digital Europe through Location and Place. Proceedings of the AGILE 2014 International Conference on Geographic Information Science.</unstructured_citation>
+					</citation>
+					<citation key="B7">
+						<journal_title>Environmental Monitoring and Assessment</journal_title>
+						<author>Conrad</author>
+						<volume>176</volume>
+						<issue>1–4</issue>
+						<first_page>273</first_page>
+						<cYear>2011</cYear>
+						<article_title>A review of citizen science and community-based environmental monitoring: Issues and opportunities</article_title>
+						<doi>10.1007/s10661-010-1582-5</doi>
+					</citation>
+					<citation key="B8">
+						<journal_title>Ecology and Society</journal_title>
+						<author>Cooper</author>
+						<volume>12</volume>
+						<issue>2</issue>
+						<first_page>11</first_page>
+						<cYear>2007</cYear>
+						<article_title>Citizen science as a tool for conservation in residential ecosystems</article_title>
+						<doi>10.5751/ES-02197-120211</doi>
+					</citation>
+					<citation key="B9">
+						<journal_title>PloS One</journal_title>
+						<author>Cooper</author>
+						<volume>9</volume>
+						<issue>9</issue>
+						<first_page>e106508</first_page>
+						<cYear>2014</cYear>
+						<article_title>The invisible prevalence of citizen science in global research: Migratory birds and climate change</article_title>
+						<doi>10.1371/journal.pone.0106508</doi>
+					</citation>
+					<citation key="B10">
+						<journal_title>Public Understanding of Science</journal_title>
+						<author>Crall</author>
+						<volume>22</volume>
+						<issue>6</issue>
+						<first_page>745</first_page>
+						<cYear>2013</cYear>
+						<article_title>The impacts of an invasive species citizen science training program on participant attitudes, behavior, and science literacy</article_title>
+						<doi>10.1177/0963662511434894</doi>
+					</citation>
+					<citation key="B11">
+						<journal_title>Frontiers in Ecology and the Environment</journal_title>
+						<author>Dickinson</author>
+						<volume>10</volume>
+						<issue>6</issue>
+						<first_page>291</first_page>
+						<cYear>2012</cYear>
+						<article_title>The current state of citizen science as a tool for ecological research and public engagement</article_title>
+						<doi>10.1890/110236</doi>
+					</citation>
+					<citation key="B12">
+						<journal_title>Annual Review of Ecology, Evolution, and Systematics</journal_title>
+						<author>Dickinson</author>
+						<volume>41</volume>
+						<first_page>149</first_page>
+						<cYear>2010</cYear>
+						<article_title>Citizen science as an ecological research tool: Challenges and benefits</article_title>
+						<doi>10.1146/annurev-ecolsys-102209-144636</doi>
+					</citation>
+					<citation key="B13">
+						<volume_title>Internet, mail, and mixed-mode surveys</volume_title>
+						<author>Dillman</author>
+						<cYear>2008</cYear>
+					</citation>
+					<citation key="B14">
+						<journal_title>Conservation Biology</journal_title>
+						<author>Evans</author>
+						<volume>19</volume>
+						<issue>3</issue>
+						<first_page>589</first_page>
+						<cYear>2005</cYear>
+						<article_title>The Neighborhood Nestwatch Program: Participant outcomes of a citizen-science ecological research project</article_title>
+						<doi>10.1111/j.1523-1739.2005.00s01.x</doi>
+					</citation>
+					<citation key="B15">
+						<journal_title>Environmental Conservation</journal_title>
+						<author>Finn</author>
+						<volume>37</volume>
+						<issue>01</issue>
+						<first_page>83</first_page>
+						<cYear>2010</cYear>
+						<article_title>Assessing the quality of seagrass data collected by community volunteers in Moreton Bay Marine Park, Australia</article_title>
+						<doi>10.1017/S0376892910000251</doi>
+					</citation>
+					<citation key="B16">
+						<journal_title>PloS ONE</journal_title>
+						<author>Follett</author>
+						<volume>10</volume>
+						<issue>11</issue>
+						<cYear>2015</cYear>
+						<article_title>An analysis of citizen science based research: Usage and publication patterns</article_title>
+						<doi>10.1371/journal.pone.0143687</doi>
+					</citation>
+					<citation key="B17">
+						<journal_title>ACM SIGCSE Bulletin</journal_title>
+						<author>Irani</author>
+						<volume>36</volume>
+						<issue>1</issue>
+						<first_page>195</first_page>
+						<cYear>2004</cYear>
+						<article_title>Understanding gender and confidence in CS course culture</article_title>
+						<doi>10.1145/1028174.971371</doi>
+					</citation>
+					<citation key="B18">
+						<journal_title>International Journal of Science Education</journal_title>
+						<author>Jenkins</author>
+						<volume>21</volume>
+						<issue>7</issue>
+						<first_page>703</first_page>
+						<cYear>1999</cYear>
+						<article_title>School science, citizenship and the public understanding of science</article_title>
+						<doi>10.1080/095006999290363</doi>
+					</citation>
+					<citation key="B19">
+						<journal_title>Conservation Biology</journal_title>
+						<author>Jordan</author>
+						<volume>25</volume>
+						<issue>6</issue>
+						<first_page>1148</first_page>
+						<cYear>2011</cYear>
+						<article_title>Knowledge gain and behavioral change in citizen-science programs</article_title>
+						<doi>10.1111/j.1523-1739.2011.01745.x</doi>
+					</citation>
+					<citation key="B20">
+						<journal_title>Pacific Conservation Biology</journal_title>
+						<author>Koss</author>
+						<volume>15</volume>
+						<first_page>116</first_page>
+						<cYear>2009</cYear>
+						<article_title>An evaluation of Sea Search as a citizen science programme in Marine Protected Areas</article_title>
+						<doi>10.1071/PC090116</doi>
+					</citation>
+					<citation key="B21">
+						<journal_title>Conservation Biology</journal_title>
+						<author>Kremen</author>
+						<volume>25</volume>
+						<first_page>607</first_page>
+						<cYear>2011</cYear>
+						<article_title>Evaluating the quality of citizen-scientist data on pollinator communities</article_title>
+						<doi>10.1111/j.1523-1739.2011.01657.x</doi>
+					</citation>
+					<citation key="B22">
+						<journal_title>Biological Conservation</journal_title>
+						<author>Lewandowski</author>
+						<volume>208</volume>
+						<first_page>106</first_page>
+						<cYear>2017</cYear>
+						<article_title>Butterfly citizen scientists in the United States increase their engagement in conservation</article_title>
+						<doi>10.1016/j.biocon.2015.07.029</doi>
+					</citation>
+					<citation key="B23">
+						<journal_title>Conservation Biology</journal_title>
+						<author>Lewandowski</author>
+						<volume>29</volume>
+						<issue>3</issue>
+						<first_page>713</first_page>
+						<cYear>2015</cYear>
+						<article_title>Influence of volunteer and project characteristics on data quality of biological surveys</article_title>
+						<doi>10.1111/cobi.12481</doi>
+					</citation>
+					<citation key="B24">
+						<journal_title>BioScience</journal_title>
+						<author>Martin</author>
+						<volume>66</volume>
+						<issue>8</issue>
+						<first_page>683</first_page>
+						<cYear>2016</cYear>
+						<article_title>Public interest in marine citizen science: Is there potential for growth?</article_title>
+						<doi>10.1093/biosci/biw070</doi>
+					</citation>
+					<citation key="B25">
+						<journal_title>Issues in Ecology</journal_title>
+						<author>McKinley</author>
+						<volume>19</volume>
+						<cYear>2015</cYear>
+						<article_title>Investing in citizen science can improve natural resource management and environmental protection</article_title>
+					</citation>
+					<citation key="B26">
+						<author>Minnesota State Fair</author>
+						<cYear>2015</cYear>
+						<article_title>Minnesota state fair website</article_title>
+						<unstructured_citation>Minnesota State Fair. 2015. Minnesota state fair website. http://www.mnstatefair.org/.</unstructured_citation>
+					</citation>
+					<citation key="B27">
+						<volume_title>Science and engineering indicators 2012 (NSB 12-01)</volume_title>
+						<author>National Science Board</author>
+						<cYear>2012</cYear>
+					</citation>
+					<citation key="B28">
+						<journal_title>Biological Conservation</journal_title>
+						<author>Newman</author>
+						<volume>208</volume>
+						<first_page>55</first_page>
+						<cYear>2017</cYear>
+						<article_title>Leveraging the power of place in citizen science for effective conservation decision making</article_title>
+						<doi>10.1016/j.biocon.2016.07.019</doi>
+					</citation>
+					<citation key="B29">
+						<journal_title>Science and Public Policy</journal_title>
+						<author>Rayner</author>
+						<volume>30</volume>
+						<issue>3</issue>
+						<first_page>163</first_page>
+						<cYear>2003</cYear>
+						<article_title>Democracy in the age of assessment: Reflections on the roles of expertise and democracy in public-sector decision making</article_title>
+						<doi>10.3152/147154303781780533</doi>
+					</citation>
+					<citation key="B30">
+						<journal_title>Public Understanding of Science</journal_title>
+						<author>Riesch</author>
+						<volume>23</volume>
+						<issue>1</issue>
+						<first_page>107</first_page>
+						<cYear>2014</cYear>
+						<article_title>Citizen science as seen by scientists: Methodological, epistemological and ethical dimensions</article_title>
+						<doi>10.1177/0963662513497324</doi>
+					</citation>
+					<citation key="B31">
+						<volume_title>Diary of a citizen scientist: Chasing tiger beetles and other new ways of engaging the world</volume_title>
+						<author>Russell</author>
+						<cYear>2014</cYear>
+					</citation>
+					<citation key="B32">
+						<journal_title>Environmental management</journal_title>
+						<author>Savan</author>
+						<volume>31</volume>
+						<issue>5</issue>
+						<first_page>0561</first_page>
+						<cYear>2003</cYear>
+						<article_title>Volunteer environmental monitoring and the role of the universities: The case of Citizens’ Environment Watch</article_title>
+						<doi>10.1007/s00267-002-2897-y</doi>
+					</citation>
+					<citation key="B33">
+						<journal_title>Biotropica</journal_title>
+						<author>Shanley</author>
+						<volume>41</volume>
+						<issue>5</issue>
+						<first_page>535</first_page>
+						<cYear>2009</cYear>
+						<article_title>Out of the loop: Why research rarely reaches policy makers and the public and what can be done</article_title>
+						<doi>10.1111/j.1744-7429.2009.00561.x</doi>
+					</citation>
+					<citation key="B34">
+						<journal_title>Ecology and Society</journal_title>
+						<author>Shirk</author>
+						<volume>17</volume>
+						<issue>2</issue>
+						<first_page>29</first_page>
+						<cYear>2012</cYear>
+						<article_title>Public participation in scientific research: A framework for deliberate design</article_title>
+						<doi>10.5751/ES-04705-170229</doi>
+					</citation>
+					<citation key="B35">
+						<journal_title>Studies in Science Education</journal_title>
+						<author>Stocklmayer</author>
+						<volume>46</volume>
+						<issue>1</issue>
+						<first_page>1</first_page>
+						<cYear>2010</cYear>
+						<article_title>The roles of the formal and informal sectors in the provision of effective science education</article_title>
+						<doi>10.1080/03057260903562284</doi>
+					</citation>
+					<citation key="B36">
+						<volume_title>Overview of race and hispanic origin: 2010</volume_title>
+						<author>U.S. Census Bureau</author>
+						<cYear>2011</cYear>
+					</citation>
+				</citation_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-00508-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00508-20170717071707.xml
@@ -870,26 +870,6 @@
 							<resource>https://elifesciences.org/articles/00508#fig11</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.00508.016</doi>
-							<resource>https://elifesciences.org/articles/00508#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.00508.017</doi>
-							<resource>https://elifesciences.org/articles/00508#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_data/elife-crossref-00508-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00508-20170717071707.xml
@@ -1,1 +1,897 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-00508-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>09</month><day>10</day><year>2013</year></publication_date><journal_volume><volume>2</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Imaging-based chemical screening reveals activity-dependent neural differentiation of pluripotent stem cells</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Yaping</given_name><surname>Sun</surname><affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Zhiqiang</given_name><surname>Dong</surname><affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Taihao</given_name><surname>Jin</surname><affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Biochemistry, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Howard Hughes Medical Institute, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Kean-Hooi</given_name><surname>Ang</surname><affiliation>Department of Pharmaceutical Chemistry, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Small Molecule Discovery Center, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Miller</given_name><surname>Huang</surname><affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Neurological Surgery, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Pediatrics, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Kelly M</given_name><surname>Haston</surname><affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Jisong</given_name><surname>Peng</surname><affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Tao P</given_name><surname>Zhong</surname><affiliation>State Key Laboratory of Genetic Engineering, Department of Genetics, Fudan University School of Life Sciences, Shanghai, China</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Steven</given_name><surname>Finkbeiner</surname><affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Biochemistry, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Pharmaceutical Chemistry, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Keck Foundation Program in Brain Cell Engineering, Roddenberry Center for Stem Cell Biology and Medicine, Gladstone Institutes of Neurological Disease, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>William A</given_name><surname>Weiss</surname><affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Neurological Surgery, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Pediatrics, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Michelle R</given_name><surname>Arkin</surname><affiliation>Department of Pharmaceutical Chemistry, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Small Molecule Discovery Center, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Lily Y</given_name><surname>Jan</surname><affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Department of Biochemistry, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Howard Hughes Medical Institute, University of California, San Francisco, San Francisco, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Su</given_name><surname>Guo</surname><affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation><affiliation>State Key Laboratory of Genetic Engineering, Department of Genetics, Fudan University School of Life Sciences, Shanghai, China</affiliation></person_name></contributors><jats:abstract><jats:p>Mammalian pluripotent stem cells (PSCs) represent an important venue for understanding basic principles regulating tissue-specific differentiation and discovering new tools that may facilitate clinical applications. Mechanisms that direct neural differentiation of PSCs involve growth factor signaling and transcription regulation. However, it is unknown whether and how electrical activity influences this process. Here we report a high throughput imaging-based screen, which uncovers that selamectin, an anti-helminthic therapeutic compound with reported activity on invertebrate glutamate-gated chloride channels, promotes neural differentiation of PSCs. We show that selamectin’s pro-neurogenic activity is mediated by γ2-containing GABAA receptors in subsets of neural rosette progenitors, accompanied by increased proneural and lineage-specific transcription factor expression and cell cycle exit. In vivo, selamectin promotes neurogenesis in developing zebrafish. Our results establish a chemical screening platform that reveals activity-dependent neural differentiation from PSCs. Compounds identified in this and future screening might prove therapeutically beneficial for treating neurodevelopmental or neurodegenerative disorders.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>Pluripotent stem cells have the potential to become most of the cell types that make up an organism. However, the signals that trigger these cells to turn into neurons rather than lung cells or muscle cells, for example, are not fully understood. Proteins called growth factors are known to have a role in this process, as are transcription factors, but it is not clear if other factors are also involved.</jats:p><jats:p>In an attempt to identify additional mechanisms that could contribute to the formation of neurons, Sun et al. screened more than 2,000 small molecules for their ability to transform mouse pluripotent stem cells into neurons in cell culture. Surprisingly, they found that a compound called selamectin, which is used to treat parasitic flatworm infections, also triggered stem cells to turn into neurons.</jats:p><jats:p>Selamectin works by blocking a particular type of ion channel in flatworms, but this ion channel is not found in vertebrates, which means that selamectin must be promoting the formation of neurons in mice via a different mechanism. Given that a drug related to selamectin is known to act on a subtype of receptors for the neurotransmitter GABA, Sun et al. wondered whether these receptors—known as GABAA receptors—might also underlie the effects of selamectin. Consistent with this idea, drugs that increased GABAA activity stimulated the formation of neurons, whereas drugs that reduced GABAA function blocked the effects of selamectin.</jats:p><jats:p>In addition, Sun et al. showed that selamectin triggers human embryonic stem cells to become neurons, and that it also promotes the formation of new neurons in developing zebrafish in vivo. As well as revealing an additional mechanism for the formation of neurons from stem cells, the screening technique introduced by Sun et al. could help to identify further pro-neuronal molecules, which could aid the treatment of neurodevelopmental and neurodegenerative disorders.</jats:p></jats:abstract><publication_date media_type="online"><month>09</month><day>10</day><year>2013</year></publication_date><publisher_item><item_number item_number_type="article_number">e00508</item_number><identifier id_type="doi">10.7554/eLife.00508</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institutes of Health</fr:assertion><fr:assertion name="award_number">DA023904</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">CIRM</fr:assertion><fr:assertion name="award_number">GUO-RS1-00215-1</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Howard Hughes Medical Institute</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institutes of Health</fr:assertion><fr:assertion name="award_number">MH065334</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">UCSF QB3-Malaysia Program</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institutes of Health</fr:assertion><fr:assertion name="award_number">R01CA102321, P01CA081403</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">American Cancer Society</fr:assertion><fr:assertion name="award_number">PF-13-295-01-TBG</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institutes of Health</fr:assertion><fr:assertion name="award_number">U24 NS078370</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">CIRM</fr:assertion><fr:assertion name="award_number">RB4-06079</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Chinese Ministry of Science and Technology</fr:assertion><fr:assertion name="award_number">2013CB945301</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/3.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/3.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/3.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.00508</doi><resource>https://elifesciences.org/articles/00508</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/00508/elife-00508-v1.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/00508/elife-00508-v1.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>Biochem J</journal_title><author>Agrawal</author><volume>122</volume><first_page>759</first_page><cYear>1971</cYear><article_title>Subcellular distribution of taurine and cysteinesulphinate decarboxylase in developing rat brain</article_title></citation><citation key="bib2"><journal_title>Nat Rev Neurosci</journal_title><author>Alvarez-Buylla</author><volume>2</volume><first_page>287</first_page><cYear>2001</cYear><article_title>A unified hypothesis on the lineage of neural stem cells</article_title><doi>10.1038/35067582</doi></citation><citation key="bib3"><journal_title>Cell</journal_title><author>Andersson</author><volume>124</volume><first_page>393</first_page><cYear>2006</cYear><article_title>Identification of intrinsic determinants of midbrain dopamine neurons</article_title><doi>10.1016/j.cell.2005.10.037</doi></citation><citation key="bib4"><journal_title>Proc Natl Acad Sci USA</journal_title><author>Arrasate</author><volume>102</volume><first_page>3840</first_page><cYear>2005</cYear><article_title>Automated microscope system for determining factors that predict neuronal fate</article_title><doi>10.1073/pnas.0409777102</doi></citation><citation key="bib5"><journal_title>Nature</journal_title><author>Arrasate</author><volume>431</volume><first_page>805</first_page><cYear>2004</cYear><article_title>Inclusion body formation reduces levels of mutant huntingtin and the risk of neuronal death</article_title><doi>10.1038/nature02998</doi></citation><citation key="bib6"><journal_title>Physiol Rev</journal_title><author>Ben-Ari</author><volume>87</volume><first_page>1215</first_page><cYear>2007</cYear><article_title>GABA: a pioneer transmitter that excites immature neurons and generates primitive oscillations</article_title><doi>10.1152/physrev.00017.2006</doi></citation><citation key="bib7"><journal_title>Nat Rev Neurosci</journal_title><author>Bertrand</author><volume>3</volume><first_page>517</first_page><cYear>2002</cYear><article_title>Proneural genes and the specification of neural cell types</article_title><doi>10.1038/nrn874</doi></citation><citation key="bib8"><journal_title>Vet Parasitol</journal_title><author>Bishop</author><volume>91</volume><first_page>163</first_page><cYear>2000</cYear><article_title>Selamectin: a novel broad-spectrum endectocide for dogs and cats</article_title><doi>10.1016/S0304-4017(00)00289-2</doi></citation><citation key="bib9"><journal_title>Arch Insect Biochem Physiol</journal_title><author>Bloomquist</author><volume>54</volume><first_page>145</first_page><cYear>2003</cYear><article_title>Chloride channels as tools for developing selective insecticides</article_title><doi>10.1002/arch.10112</doi></citation><citation key="bib10"><journal_title>Cell Stem Cell</journal_title><author>Borowiak</author><volume>4</volume><first_page>348</first_page><cYear>2009</cYear><article_title>Small molecules efficiently direct endodermal differentiation of mouse and human embryonic stem cells</article_title><doi>10.1016/j.stem.2009.01.014</doi></citation><citation key="bib11"><journal_title>Nat Biotechnol</journal_title><author>Chambers</author><volume>27</volume><first_page>275</first_page><cYear>2009</cYear><article_title>Highly efficient neural conversion of human ES and iPS cells by dual inhibition of SMAD signaling</article_title><doi>10.1038/nbt.1529</doi></citation><citation key="bib12"><journal_title>J Pharmacol Exp Ther</journal_title><author>Dawson</author><volume>295</volume><first_page>1051</first_page><cYear>2000</cYear><article_title>Anticonvulsant and adverse effects of avermectin analogs in mice are mediated through the gamma-aminobutyric acid(A) receptor</article_title></citation><citation key="bib13"><journal_title>Neuron</journal_title><author>Demarque</author><volume>67</volume><first_page>321</first_page><cYear>2010</cYear><article_title>Activity-dependent expression of Lmx1b regulates specification of serotonergic neurons modulating swimming behavior</article_title><doi>10.1016/j.neuron.2010.06.006</doi></citation><citation key="bib14"><journal_title>Cell Stem Cell</journal_title><author>Desbordes</author><volume>2</volume><first_page>602</first_page><cYear>2008</cYear><article_title>High-throughput screening assay for the identification of compounds regulating self-renewal and differentiation in human embryonic stem cells</article_title><doi>10.1016/j.stem.2008.05.010</doi></citation><citation key="bib15"><journal_title>Proc Natl Acad Sci USA</journal_title><author>Ding</author><volume>100</volume><first_page>7632</first_page><cYear>2003</cYear><article_title>Synthetic small molecules that control stem cell fate</article_title><doi>10.1073/pnas.0732087100</doi></citation><citation key="bib16"><journal_title>Genes Dev</journal_title><author>Elkabetz</author><volume>22</volume><first_page>152</first_page><cYear>2008</cYear><article_title>Human ES cell-derived neural rosettes reveal a functionally distinct early neural stem cell stage</article_title><doi>10.1101/gad.1616208</doi></citation><citation key="bib17"><journal_title>Nat Rev Neurosci</journal_title><author>Farrant</author><volume>6</volume><first_page>215</first_page><cYear>2005</cYear><article_title>Variations on an inhibitory theme: phasic and tonic activation of GABAA receptors</article_title><doi>10.1038/nrn1625</doi></citation><citation key="bib18"><journal_title>Neuron</journal_title><author>Flint</author><volume>20</volume><first_page>43</first_page><cYear>1998</cYear><article_title>Nonsynaptic glycine receptor activation during early neocortical development</article_title><doi>10.1016/S0896-6273(00)80433-X</doi></citation><citation key="bib19"><journal_title>Curr Opin Neurobiol</journal_title><author>Gaspard</author><volume>20</volume><first_page>37</first_page><cYear>2010</cYear><article_title>Mechanisms of neural specification from embryonic stem cells</article_title><doi>10.1016/j.conb.2009.12.001</doi></citation><citation key="bib20"><journal_title>Trends Neurosci</journal_title><author>Ge</author><volume>30</volume><first_page>1</first_page><cYear>2007</cYear><article_title>GABA sets the tempo for activity-dependent adult neurogenesis</article_title><doi>10.1016/j.tins.2006.11.001</doi></citation><citation key="bib21"><journal_title>Drugs</journal_title><author>Goa</author><volume>42</volume><first_page>640</first_page><cYear>1991</cYear><article_title>Ivermectin. A review of its antifilarial activity, pharmacokinetic properties and clinical efficacy in onchocerciasis</article_title><doi>10.2165/00003495-199142040-00007</doi></citation><citation key="bib22"><journal_title>J Pharmacol Exp Ther</journal_title><author>Huang</author><volume>281</volume><first_page>261</first_page><cYear>1997</cYear><article_title>Avermectin B1a binds to high- and low-affinity sites with dual effects on the gamma-aminobutyric acid-gated chloride channel of cultured cerebellar granule neurons</article_title></citation><citation key="bib23"><journal_title>PLOS ONE</journal_title><author>Jang</author><volume>5</volume><first_page>e11528</first_page><cYear>2010a</cYear><article_title>Deoxygedunin, a natural product with potent neurotrophic activity in mice</article_title><doi>10.1371/journal.pone.0011528</doi></citation><citation key="bib24"><journal_title>Proc Natl Acad Sci USA</journal_title><author>Jang</author><volume>107</volume><first_page>2687</first_page><cYear>2010b</cYear><article_title>A selective TrkB agonist with potent neurotrophic activities by 7,8-dihydroxyflavone</article_title><doi>10.1073/pnas.0913572107</doi></citation><citation key="bib25"><journal_title>Am J Stem Cells</journal_title><author>Kreitzer</author><volume>2</volume><first_page>119</first_page><cYear>2013</cYear><article_title>A robust method to derive functional neural crest cells from human pluripotent stem cells</article_title></citation><citation key="bib26"><journal_title>Nat Biotech</journal_title><author>Lee</author><volume>18</volume><first_page>675</first_page><cYear>2000</cYear><article_title>Efficient generation of midbrain and hindbrain neurons from mouse embryonic stem cells</article_title><doi>10.1038/76536</doi></citation><citation key="bib27"><journal_title>Nat Neurosci</journal_title><author>Liu</author><volume>8</volume><first_page>1179</first_page><cYear>2005</cYear><article_title>Nonsynaptic GABA signaling in postnatal subventricular zone controls proliferation of GFAP-expressing progenitors</article_title><doi>10.1038/nn1522</doi></citation><citation key="bib28"><journal_title>Neuron</journal_title><author>LoTurco</author><volume>15</volume><first_page>1287</first_page><cYear>1995</cYear><article_title>GABA and glutamate depolarize cortical progenitor cells and inhibit DNA synthesis</article_title><doi>10.1016/0896-6273(95)90008-X</doi></citation><citation key="bib29"><journal_title>Nat Neurosci</journal_title><author>Marek</author><volume>13</volume><first_page>944</first_page><cYear>2010</cYear><article_title>cJun integrates calcium activity and tlx3 expression to regulate neurotransmitter specification</article_title><doi>10.1038/nn.2582</doi></citation><citation key="bib30"><journal_title>Proc Natl Acad Sci USA</journal_title><author>Martinat</author><volume>103</volume><first_page>2874</first_page><cYear>2006</cYear><article_title>Cooperative transcription activation by Nurr1 and Pitx3 induces embryonic stem cell maturation to the midbrain dopamine neuron phenotype</article_title><doi>10.1073/pnas.0511153103</doi></citation><citation key="bib31"><journal_title>Results Probl Cell Differ</journal_title><author>Mehler</author><volume>39</volume><first_page>27</first_page><cYear>2002</cYear><article_title>Mechanisms regulating lineage diversity during mammalian cerebral cortical neurogenesis and gliogenesis</article_title><doi>10.1007/978-3-540-46006-0_2</doi></citation><citation key="bib32"><journal_title>Curr Opin Neurobiol</journal_title><author>Okano</author><volume>19</volume><first_page>112</first_page><cYear>2009</cYear><article_title>Cell types to order: temporal specification of CNS stem cells</article_title><doi>10.1016/j.conb.2009.04.003</doi></citation><citation key="bib33"><journal_title>Nat Rev Neurosci</journal_title><author>Owens</author><volume>3</volume><first_page>715</first_page><cYear>2002</cYear><article_title>Is there more to GABA than synaptic inhibition?</article_title><doi>10.1038/nrn919</doi></citation><citation key="bib34"><journal_title>J Neurosci Res</journal_title><author>Palackal</author><volume>15</volume><first_page>223</first_page><cYear>1986</cYear><article_title>Abnormal visual cortex development in the kitten associated with maternal dietary taurine deprivation</article_title><doi>10.1002/jnr.490150212</doi></citation><citation key="bib35"><journal_title>Dev Biol</journal_title><author>Park</author><volume>227</volume><first_page>279</first_page><cYear>2000</cYear><article_title>Analysis of upstream elements in the HuC promoter leads to the establishment of transgenic zebrafish with fluorescent neurons</article_title><doi>10.1006/dbio.2000.9898</doi></citation><citation key="bib36"><journal_title>J Neurosci</journal_title><author>Pong</author><volume>2</volume><first_page>966</first_page><cYear>1982</cYear><article_title>A comparative study of avermectin B1a and other modulators of the gamma-aminobutyric acid receptor. chloride ion channel complex</article_title></citation><citation key="bib37"><journal_title>Chem Biol</journal_title><author>Saxe</author><volume>14</volume><first_page>1019</first_page><cYear>2007</cYear><article_title>A phenotypic small-molecule screen identifies an orphan ligand-receptor pair that regulates neural stem cell differentiation</article_title><doi>10.1016/j.chembiol.2007.07.016</doi></citation><citation key="bib38"><journal_title>Nat Methods</journal_title><author>Schindelin</author><volume>9</volume><first_page>676</first_page><cYear>2012</cYear><article_title>Fiji: an open-source platform for biological-image analysis</article_title><doi>10.1038/nmeth.2019</doi></citation><citation key="bib39"><journal_title>FASEB J</journal_title><author>Schwirtlich</author><volume>24</volume><first_page>1218</first_page><cYear>2010</cYear><article_title>GABAA and GABAB receptors of distinct properties affect oppositely the proliferation of mouse embryonic stem cells through synergistic elevation of intracellular Ca2+</article_title><doi>10.1096/fj.09-143586</doi></citation><citation key="bib40"><journal_title>J Biol Chem</journal_title><author>Shan</author><volume>276</volume><first_page>12556</first_page><cYear>2001</cYear><article_title>Ivermectin, an unconventional agonist of the glycine receptor chloride channel</article_title><doi>10.1074/jbc.M011264200</doi></citation><citation key="bib41"><journal_title>Methods Enzymol</journal_title><author>Sharma</author><volume>506</volume><first_page>331</first_page><cYear>2012</cYear><article_title>High-throughput screening in primary neurons</article_title><doi>10.1016/B978-0-12-391856-7.00041-X</doi></citation><citation key="bib42"><journal_title>Annu Rev Cell Dev Biol</journal_title><author>Smith</author><volume>17</volume><first_page>435</first_page><cYear>2001</cYear><article_title>Embryo-derived stem cells: of mice and men</article_title><doi>10.1146/annurev.cellbio.17.1.435</doi></citation><citation key="bib43"><journal_title>Nature</journal_title><author>Song</author><volume>489</volume><first_page>150</first_page><cYear>2012</cYear><article_title>Neuronal circuitry mechanism regulating adult quiescent neural stem-cell fate decision</article_title><doi>10.1038/nature11306</doi></citation><citation key="bib44"><journal_title>Nature</journal_title><author>Spitzer</author><volume>444</volume><first_page>707</first_page><cYear>2006</cYear><article_title>Electrical activity in early neuronal development</article_title><doi>10.1038/nature05300</doi></citation><citation key="bib45"><journal_title>Nat Rev Neurosci</journal_title><author>Spitzer</author><volume>13</volume><first_page>94</first_page><cYear>2012</cYear><article_title>Activity-dependent neurotransmitter respecification</article_title><doi>10.1038/nrn3154</doi></citation><citation key="bib46"><journal_title>J Neurobiol</journal_title><author>Stewart</author><volume>50</volume><first_page>305</first_page><cYear>2002</cYear><article_title>Neural progenitor cells of the neonatal rat anterior subventricular zone express functional GABA(A) receptors</article_title><doi>10.1002/neu.10038</doi></citation><citation key="bib47"><journal_title>Nature</journal_title><author>Stockwell</author><volume>432</volume><first_page>846</first_page><cYear>2004</cYear><article_title>Exploring biology with small organic molecules</article_title><doi>10.1038/nature03196</doi></citation><citation key="bib48"><journal_title>Science</journal_title><author>Thomson</author><volume>282</volume><first_page>1145</first_page><cYear>1998</cYear><article_title>Embryonic stem cell lines derived from human blastocysts</article_title><doi>10.1126/science.282.5391.1145</doi></citation><citation key="bib49"><journal_title>Neuron</journal_title><author>Tozuka</author><volume>47</volume><first_page>803</first_page><cYear>2005</cYear><article_title>GABAergic excitation promotes neuronal differentiation in adult hippocampal progenitor cells</article_title><doi>10.1016/j.neuron.2005.08.023</doi></citation><citation key="bib50"><journal_title>J Mol Evol</journal_title><author>Vassilatis</author><volume>44</volume><first_page>501</first_page><cYear>1997</cYear><article_title>Evolutionary relationship of the ligand-gated ion channels and the avermectin-sensitive, glutamate-gated chloride channels</article_title><doi>10.1007/PL00006174</doi></citation><citation key="bib51"><journal_title>J Physiol</journal_title><author>Wang</author><volume>550</volume><first_page>785</first_page><cYear>2003</cYear><article_title>GABA depolarizes neuronal progenitors of the postnatal subventricular zone via GABAA receptor activation</article_title><doi>10.1113/jphysiol.2003.042572</doi></citation><citation key="bib52"><journal_title>Cell</journal_title><author>Wichterle</author><volume>10</volume><first_page>385</first_page><cYear>2002</cYear><article_title>Directed differentiation of embryonic stem cells into motor neurons</article_title><doi>10.1016/S0092-8674(02)00835-8</doi></citation><citation key="bib53"><journal_title>Stem Cells</journal_title><author>Yamada</author><volume>25</volume><first_page>562</first_page><cYear>2007</cYear><article_title>Electrical stimulation modulates fate determination of differentiating embryonic stem cells</article_title><doi>10.1634/stemcells.2006-0011</doi></citation><citation key="bib54"><journal_title>Methods Enzymol</journal_title><author>Ying</author><volume>365</volume><first_page>327</first_page><cYear>2003</cYear><article_title>Defined conditions for neural commitment and differentiation</article_title><doi>10.1016/S0076-6879(03)65023-8</doi></citation><citation key="bib55"><journal_title>Nat Biotechnol</journal_title><author>Ying</author><volume>21</volume><first_page>183</first_page><cYear>2003</cYear><article_title>Conversion of embryonic stem cells into neuroectodermal precursors in adherent monoculture</article_title><doi>10.1038/nbt780</doi></citation><citation key="bib56"><journal_title>Stem Cells</journal_title><author>Zhou</author><volume>28</volume><first_page>1741</first_page><cYear>2010</cYear><article_title>High-efficiency induction of neural conversion in human ESCs and human induced pluripotent stem cells with a single chemical inhibitor of transforming growth factor beta superfamily receptors</article_title><doi>10.1002/stem.504</doi></citation><citation key="bib57"><journal_title>Nat Rev Drug Discovery</journal_title><author>Zon</author><volume>4</volume><first_page>35</first_page><cYear>2005</cYear><article_title>In vivo drug discovery in zebrafish</article_title><doi>10.1038/nrd1606</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00508.001</doi><resource>https://elifesciences.org/articles/00508#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00508.002</doi><resource>https://elifesciences.org/articles/00508#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. High-throughput screening.</title><subtitle>(A) Scheme of the three-stage mESC neuronal differentiation-based chemical screening. (B) E14 mESC cultures express neural progenitor makers (Sox2, Lmx1A, and Nestin) after 7-day stage one culture. 46C mESC cultures, in which GFP is driven by the sox1 promoter, are GFP positive after 7-day stage one culture. (C) The quantification analysis of TH+ neurons among total cells using the INCell Developer software. (D) Summary of coefficient of variation (C.V.) of the DMSO control. (E) Representative images of immunostaining in control (left, treated with DMSO) and a hit compound (right). (F) A schematic summary of the chemical screen. Scale bar, 10 μm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.003</doi><resource>https://elifesciences.org/articles/00508#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. The neurotrophin receptor TrkB agonists [Dihydrodeoxygedunin (DOG) and 7,8-dihydroxyflavone (DHF)] increases TH+ cells in mESC cultures.</title><subtitle>(A) Structure of DHF and DOG. (B) DHF and DOG increase TH% in mESCs (t test, p&lt;0.05, n = 4).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.004</doi><resource>https://elifesciences.org/articles/00508#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Selamectin increases mESC differentiation into multiple neural lineages.</title><subtitle>(A) Representative images of TH and NeuN staining in control (DMSO) and selamectin-treated cultures. (B) Quantification shows increased production of both TH+ and total neurons by selamectin (t-test, n = 4, p&lt;0.001). (C–F) Selamectin treatment also increases the production of 5-HT neurons (C), GABAergic neurons (D), islet+ motor neurons (E), and Olig2+ oligodendocyte precursors (F) (t-test, n = 4, *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.005</doi><resource>https://elifesciences.org/articles/00508#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Dose response and time course of selamectin’s action in mESC cultures.</title><subtitle>(A) Dose response curve of selamectin (based on TH immunostaining). Cells were treated from Day 8 to Day 11. Selamectin is toxic above 500 nM. The EC50 value and curve fitting were performed with GraphPad Prism using a Sigmoidal dose-response (variable slope). Data are presented as mean ± S.D., n = 4. (B) Time course of selamectin’s action. Only cells treated with selamectin from Day 7 to Day 10 show significant increase of TH+ neurons (t-test, n = 4).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.006</doi><resource>https://elifesciences.org/articles/00508#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Pharmacological evidence indicates that selamectin’s proneurogenic activity is mediated by GABAA receptors.</title><subtitle>(A) Selamectin and avermectin belong to a chemical family of macrocyclic lactones and have the same structural backbone. (B) Avermectin has less potent proneurogenic activity than selamectin. Only 250 nM avermectin shows a significant effect, which was much less potent compared to that of 250 nM selamectin (t-test, n = 4, p=0.034 for Avermetin vs p=0.002 for selamectin). (C) Taurine, the most abundant endogenous ligand for glycine receptors during neocortical development has no proneurogenic activity in mESC cultures. (D) Muscimol, a GABAA receptor agonist, has a significant proneurogenic activity (t-test, n = 4, p&lt;0.001). (E) Chlordiazepoxide (CDZ), a positive allosteric modulator of GABAA receptor, also has a significant proneurogenic activity (t-test, p&lt;0.05), but there was no obvious additive effect when cells were treated with both selamectin and CDZ (t-test, p=0.480). (F) The GABAA receptor antagonist bicucullin and non-competitive blockers picrotoxin and pentylenetetrazol alone had no effect on neuronal production (white columns, control group were normalized to fold change = 1, displayed as the red dot line). However, when tested together with selamectin, the effect of selamectin was blocked (gray columns). In contrast, the glycine receptor inhibitor strychnine does not block the effect of selamectin. Final concentration: Bicuculline (Bicu) = 100 μM; Picrotoxin (PTX) = 500 μM; Pentylenetetrazol (PTZ) = 5 mM; Strychnine (STY) = 100 μM; Selamectin (Sela) = 0.3 μM; Muscimol (Musci) = 10 μM (t-test, n = 4).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.007</doi><resource>https://elifesciences.org/articles/00508#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6. Genetic evidence indicates that selamectin’s proneurogenic activity is mediated by the γ2 subunit-containing GABAA receptor.</title><subtitle>(A) Scheme of the EsiRNA transfection and cell harvest for qRT-PCR. (B) qRT-PCR shows fold change of the expression of different GABAA receptor subunits after EsiRNA transfection. ***p&lt;0.001 vs non-transfection control, $$$p&lt;0.001 vs GFP RNA transfection control. (C) Scheme of the EsiRNA knockdown experiment to identify the GABAA receptor subunit that mediates selamectin’s activity. (D–F) Representative images of NeuN and TH staining in DMSO and selamectin-treated cultures of non-transfected (D), α1 EsiRNA transfected (E), and γ2 EsiRNA transfected (F). (G) Quantification shows knockdown of γ2 subunit but not α1β1 and π subunits abolishes the effect of selamectin in increasing neurons (n = 4, **p&lt;0.01, ***p&lt;0.001 vs DMSO). (H) Quantification shows knockdown of γ2 subunit but not α1β1 and π subunits abolishes the effect of selamectin in increasing TH+ neurons neurons (n = 4, **p&lt;0.01, ***p&lt;0.001 vs DMSO). Scale bar, 100 μm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.008</doi><resource>https://elifesciences.org/articles/00508#fig6</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 7. GABA and selamectin (Sela)-induced currents in neural rosettes and non-rosette cells.</title><subtitle>(A) Bright field (BF) image (left) and green fluorescent protein (GFP) signal (right) of neural rosette cells. Majority of the cells in the view are neural rosette cells, and one of them with typical morphology is indicated by a red arrow. (B) An example of reduction of GABA (500 μM) induced currents by bicuculline (BICC, 200 μM). (C) Upper trace, an example of neural rosette cell displaying GABA (100 μM) induced currents that also displayed selamectin induced current. Lower trace, an example of neural rosette cell displaying GABA (100 μM) induced currents that did not display selamectin induced current. 16 μM Selamectin solution contains 0.4% DMSO, therefore 0.4% DMSO containing bath solution was used as the control solution as indicated in the figure. (D) A pie chart of the numbers of the four groups of neural rosette cell based on whether they displayed GABA and selamectin induced currents. The four groups are: 1) GABA+; Sela+, 2) GABA+; Sela−, 3) GABA−; Sela+, 4) GABA−; Sela−. The number of the cells in each group is indicated in the figure, except the group GABA−; Sela+, which is zero. (E) Bright field (BF) image (left) and green fluorescent protein (GFP) signal (right) of non-rosette cells. One cell with typical young neuron morphology is indicated by a red arrow. (F) Example of the inhibition of GABA (100 μM) induced currents by bicuculline (BICC, 100 μM). (G) Upper trace, an example of non-rosette cell displaying GABA (4 mM) induced current that also displayed salemectin (8 μM) induced current. Lower trace, an example of non-rosette cell displaying GABA (400 μM) responsive induced current that did not display salemectin (16 μM) induced current. (H) A pie chart of the numbers of four groups of non-rosette cells based on whether they displayed GABA and selamectin induced currents. The four groups are: 1) GABA+; Sela+, 2) GABA+; Sela−, 3) GABA−; Sela+, 4) GABA−; Sela−. The number of the cells in each group is indicated in the figure, except the group GABA−; Sela+, which is zero. The application time courses of the control solution (BATH), GABA, bicuculline (BICC) and selamectin (Sela) are indicated by horizontal bars in the figure. The membrane potential was holding at −70 mV in all recordings. The scales for time (horizontal) and currents (vertical) are indicated for each recording in the figure.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.009</doi><resource>https://elifesciences.org/articles/00508#fig7</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 8. Selamectin decreases proliferation and increases the expression of proneural and lineage-associated transcription factors.</title><subtitle>(A) Representative fields show the BrdU incorporation on Day 11 after cells were treated with selamectin (right panel) or DMSO (left panel) for 4 days. Significantly fewer BrdU+ cells were detected in the selamectin-treated group. (B) Quantification as the percentage of BrdU+ cells among total cells (t-test, n = 4, p=0.008). (C) qRT-PCR detects increased expression of proneural (Ascl1, NeurD) and lineage-associated transcription factors (Lmx1a, Lmx1b and Nurr1) in selamectin-treated group. β-actin was used as an input control and data was normalized to expression level on Day 8. (D) Representative fields show the TUNEL staining on Day 14 in cell cultures treated with DMSO or selamectin, with NeuN staining as a control to confirm selamectin efficacy in this experiment. (E) Quantification shows significant difference in NeuN% (p&lt;0.001) and no significant difference in TUNEL% (p=0.058) (t-test, n = 4). Scale bar, 10 μm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.010</doi><resource>https://elifesciences.org/articles/00508#fig8</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 9. Clonal analysis reveals that selamectin promotes progenitor cell cycle exit toward terminal differentiation.</title><subtitle>(A) Scheme of clonal culture analyses. (B) Quantification of cell cycle length and number of cells within single clones. (C–E) Representative images of double immunostaining of GFP with NeuN (C), TH (D), or the proliferation marker Ki67 (E) within single clones. (F) Quantification of the percentage of NeuN+ (left, DMSO n = 49, selamectin n = 51), TH+ (middle, DMSO n = 6, selamectin n = 7), and Ki67+ cells (right, DMSO n = 46, selamectin n = 41) within single clones. ***p&lt;0.001 vs DMSO). Scale bar, 100 μm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.011</doi><resource>https://elifesciences.org/articles/00508#fig9</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 1.</title></titles><format mime_type="video/avi"/><doi_data><doi>10.7554/eLife.00508.012</doi><resource>https://elifesciences.org/articles/00508#media1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 2.</title></titles><format mime_type="video/avi"/><doi_data><doi>10.7554/eLife.00508.013</doi><resource>https://elifesciences.org/articles/00508#media2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 10. Selamectin increases the differentiation of multiple neuronal lineages from human pluripotent stem cells.</title><subtitle>(A) Scheme of the three-stage neuronal differentiation protocol for H9 hESCs and hiPSCs. (B) Representative images of NeuN and TH staining in control (DMSO) and selamectin-treated cultures of H9 hESCs. (C) Quantification shows increased production of both TH+ and total neurons by selamectin in H9 hESCs. (n = 4, *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001 vs DMSO). (D) Representative images of NeuN and TH staining in control (DMSO) and selamectin-treated cultures of hiPSCs. (E) Quantification shows increased production of both TH+ and total neurons by selamectin in hiPSCs. (n = 4, *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001 vs DMSO). Scale bar, 100 μm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.014</doi><resource>https://elifesciences.org/articles/00508#fig10</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 11. Selamectin promotes neurogenesis in vivo in the developing zebrafish brain.</title><subtitle>(A) Scheme of the selamectin treatment on HuC:GFP transgenic zebrafish embryos. (B) Representative images show that selamectin (2 μM, 14 hr from 8 hpf to 22 hpf) increases Huc-GFP signal. (C) Quantification of the midbrain cluster (boxed) shows a significant difference between two groups (t-test, n = 20, p&lt;0.001). (D) Representative images show increased DA neurons in selamectin-treated embryos (2 μM for 40 hr from 8 hpf to 48 hpf). (E) Quantification of the ventral forebrain DA neurons shows a significant difference between two groups (t-test, n = 10, p&lt;0.001). (F) A schematic model shows the effect of selamectin on neuronal differentiation from mESCs.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00508.015</doi><resource>https://elifesciences.org/articles/00508#fig11</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00508.016</doi><resource>https://elifesciences.org/articles/00508#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00508.017</doi><resource>https://elifesciences.org/articles/00508#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-00508-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>09</month>
+					<day>10</day>
+					<year>2013</year>
+				</publication_date>
+				<journal_volume>
+					<volume>2</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Imaging-based chemical screening reveals activity-dependent neural differentiation of pluripotent stem cells</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Yaping</given_name>
+						<surname>Sun</surname>
+						<affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Zhiqiang</given_name>
+						<surname>Dong</surname>
+						<affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Taihao</given_name>
+						<surname>Jin</surname>
+						<affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Biochemistry, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Howard Hughes Medical Institute, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Kean-Hooi</given_name>
+						<surname>Ang</surname>
+						<affiliation>Department of Pharmaceutical Chemistry, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Small Molecule Discovery Center, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Miller</given_name>
+						<surname>Huang</surname>
+						<affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Neurological Surgery, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Pediatrics, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Kelly M</given_name>
+						<surname>Haston</surname>
+						<affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Jisong</given_name>
+						<surname>Peng</surname>
+						<affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Tao P</given_name>
+						<surname>Zhong</surname>
+						<affiliation>State Key Laboratory of Genetic Engineering, Department of Genetics, Fudan University School of Life Sciences, Shanghai, China</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Steven</given_name>
+						<surname>Finkbeiner</surname>
+						<affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Biochemistry, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Pharmaceutical Chemistry, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Keck Foundation Program in Brain Cell Engineering, Roddenberry Center for Stem Cell Biology and Medicine, Gladstone Institutes of Neurological Disease, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>William A</given_name>
+						<surname>Weiss</surname>
+						<affiliation>Department of Neurology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Neurological Surgery, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Pediatrics, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Michelle R</given_name>
+						<surname>Arkin</surname>
+						<affiliation>Department of Pharmaceutical Chemistry, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Small Molecule Discovery Center, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Lily Y</given_name>
+						<surname>Jan</surname>
+						<affiliation>Department of Physiology, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Department of Biochemistry, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Howard Hughes Medical Institute, University of California, San Francisco, San Francisco, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Su</given_name>
+						<surname>Guo</surname>
+						<affiliation>Department of Bioengineering and Therapeutic Science, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Eli and Edythe Broad Center of Regeneration Medicine and Stem Cell Research, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>Programs in Human Genetics and Biological Sciences, University of California, San Francisco, San Francisco, United States</affiliation>
+						<affiliation>State Key Laboratory of Genetic Engineering, Department of Genetics, Fudan University School of Life Sciences, Shanghai, China</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Mammalian pluripotent stem cells (PSCs) represent an important venue for understanding basic principles regulating tissue-specific differentiation and discovering new tools that may facilitate clinical applications. Mechanisms that direct neural differentiation of PSCs involve growth factor signaling and transcription regulation. However, it is unknown whether and how electrical activity influences this process. Here we report a high throughput imaging-based screen, which uncovers that selamectin, an anti-helminthic therapeutic compound with reported activity on invertebrate glutamate-gated chloride channels, promotes neural differentiation of PSCs. We show that selamectin’s pro-neurogenic activity is mediated by γ2-containing GABAA receptors in subsets of neural rosette progenitors, accompanied by increased proneural and lineage-specific transcription factor expression and cell cycle exit. In vivo, selamectin promotes neurogenesis in developing zebrafish. Our results establish a chemical screening platform that reveals activity-dependent neural differentiation from PSCs. Compounds identified in this and future screening might prove therapeutically beneficial for treating neurodevelopmental or neurodegenerative disorders.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>Pluripotent stem cells have the potential to become most of the cell types that make up an organism. However, the signals that trigger these cells to turn into neurons rather than lung cells or muscle cells, for example, are not fully understood. Proteins called growth factors are known to have a role in this process, as are transcription factors, but it is not clear if other factors are also involved.</jats:p>
+					<jats:p>In an attempt to identify additional mechanisms that could contribute to the formation of neurons, Sun et al. screened more than 2,000 small molecules for their ability to transform mouse pluripotent stem cells into neurons in cell culture. Surprisingly, they found that a compound called selamectin, which is used to treat parasitic flatworm infections, also triggered stem cells to turn into neurons.</jats:p>
+					<jats:p>Selamectin works by blocking a particular type of ion channel in flatworms, but this ion channel is not found in vertebrates, which means that selamectin must be promoting the formation of neurons in mice via a different mechanism. Given that a drug related to selamectin is known to act on a subtype of receptors for the neurotransmitter GABA, Sun et al. wondered whether these receptors—known as GABAA receptors—might also underlie the effects of selamectin. Consistent with this idea, drugs that increased GABAA activity stimulated the formation of neurons, whereas drugs that reduced GABAA function blocked the effects of selamectin.</jats:p>
+					<jats:p>In addition, Sun et al. showed that selamectin triggers human embryonic stem cells to become neurons, and that it also promotes the formation of new neurons in developing zebrafish in vivo. As well as revealing an additional mechanism for the formation of neurons from stem cells, the screening technique introduced by Sun et al. could help to identify further pro-neuronal molecules, which could aid the treatment of neurodevelopmental and neurodegenerative disorders.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>09</month>
+					<day>10</day>
+					<year>2013</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e00508</item_number>
+					<identifier id_type="doi">10.7554/eLife.00508</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">National Institutes of Health</fr:assertion>
+						<fr:assertion name="award_number">DA023904</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">CIRM</fr:assertion>
+						<fr:assertion name="award_number">GUO-RS1-00215-1</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Howard Hughes Medical Institute</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">National Institutes of Health</fr:assertion>
+						<fr:assertion name="award_number">MH065334</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">UCSF QB3-Malaysia Program</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">National Institutes of Health</fr:assertion>
+						<fr:assertion name="award_number">R01CA102321, P01CA081403</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">American Cancer Society</fr:assertion>
+						<fr:assertion name="award_number">PF-13-295-01-TBG</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">National Institutes of Health</fr:assertion>
+						<fr:assertion name="award_number">U24 NS078370</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">CIRM</fr:assertion>
+						<fr:assertion name="award_number">RB4-06079</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Chinese Ministry of Science and Technology</fr:assertion>
+						<fr:assertion name="award_number">2013CB945301</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.00508</doi>
+					<resource>https://elifesciences.org/articles/00508</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/00508/elife-00508-v1.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/00508/elife-00508-v1.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>Biochem J</journal_title>
+						<author>Agrawal</author>
+						<volume>122</volume>
+						<first_page>759</first_page>
+						<cYear>1971</cYear>
+						<article_title>Subcellular distribution of taurine and cysteinesulphinate decarboxylase in developing rat brain</article_title>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Nat Rev Neurosci</journal_title>
+						<author>Alvarez-Buylla</author>
+						<volume>2</volume>
+						<first_page>287</first_page>
+						<cYear>2001</cYear>
+						<article_title>A unified hypothesis on the lineage of neural stem cells</article_title>
+						<doi>10.1038/35067582</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Cell</journal_title>
+						<author>Andersson</author>
+						<volume>124</volume>
+						<first_page>393</first_page>
+						<cYear>2006</cYear>
+						<article_title>Identification of intrinsic determinants of midbrain dopamine neurons</article_title>
+						<doi>10.1016/j.cell.2005.10.037</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>Proc Natl Acad Sci USA</journal_title>
+						<author>Arrasate</author>
+						<volume>102</volume>
+						<first_page>3840</first_page>
+						<cYear>2005</cYear>
+						<article_title>Automated microscope system for determining factors that predict neuronal fate</article_title>
+						<doi>10.1073/pnas.0409777102</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>Nature</journal_title>
+						<author>Arrasate</author>
+						<volume>431</volume>
+						<first_page>805</first_page>
+						<cYear>2004</cYear>
+						<article_title>Inclusion body formation reduces levels of mutant huntingtin and the risk of neuronal death</article_title>
+						<doi>10.1038/nature02998</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Physiol Rev</journal_title>
+						<author>Ben-Ari</author>
+						<volume>87</volume>
+						<first_page>1215</first_page>
+						<cYear>2007</cYear>
+						<article_title>GABA: a pioneer transmitter that excites immature neurons and generates primitive oscillations</article_title>
+						<doi>10.1152/physrev.00017.2006</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>Nat Rev Neurosci</journal_title>
+						<author>Bertrand</author>
+						<volume>3</volume>
+						<first_page>517</first_page>
+						<cYear>2002</cYear>
+						<article_title>Proneural genes and the specification of neural cell types</article_title>
+						<doi>10.1038/nrn874</doi>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Vet Parasitol</journal_title>
+						<author>Bishop</author>
+						<volume>91</volume>
+						<first_page>163</first_page>
+						<cYear>2000</cYear>
+						<article_title>Selamectin: a novel broad-spectrum endectocide for dogs and cats</article_title>
+						<doi>10.1016/S0304-4017(00)00289-2</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Arch Insect Biochem Physiol</journal_title>
+						<author>Bloomquist</author>
+						<volume>54</volume>
+						<first_page>145</first_page>
+						<cYear>2003</cYear>
+						<article_title>Chloride channels as tools for developing selective insecticides</article_title>
+						<doi>10.1002/arch.10112</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Cell Stem Cell</journal_title>
+						<author>Borowiak</author>
+						<volume>4</volume>
+						<first_page>348</first_page>
+						<cYear>2009</cYear>
+						<article_title>Small molecules efficiently direct endodermal differentiation of mouse and human embryonic stem cells</article_title>
+						<doi>10.1016/j.stem.2009.01.014</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>Nat Biotechnol</journal_title>
+						<author>Chambers</author>
+						<volume>27</volume>
+						<first_page>275</first_page>
+						<cYear>2009</cYear>
+						<article_title>Highly efficient neural conversion of human ES and iPS cells by dual inhibition of SMAD signaling</article_title>
+						<doi>10.1038/nbt.1529</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>J Pharmacol Exp Ther</journal_title>
+						<author>Dawson</author>
+						<volume>295</volume>
+						<first_page>1051</first_page>
+						<cYear>2000</cYear>
+						<article_title>Anticonvulsant and adverse effects of avermectin analogs in mice are mediated through the gamma-aminobutyric acid(A) receptor</article_title>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Neuron</journal_title>
+						<author>Demarque</author>
+						<volume>67</volume>
+						<first_page>321</first_page>
+						<cYear>2010</cYear>
+						<article_title>Activity-dependent expression of Lmx1b regulates specification of serotonergic neurons modulating swimming behavior</article_title>
+						<doi>10.1016/j.neuron.2010.06.006</doi>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Cell Stem Cell</journal_title>
+						<author>Desbordes</author>
+						<volume>2</volume>
+						<first_page>602</first_page>
+						<cYear>2008</cYear>
+						<article_title>High-throughput screening assay for the identification of compounds regulating self-renewal and differentiation in human embryonic stem cells</article_title>
+						<doi>10.1016/j.stem.2008.05.010</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>Proc Natl Acad Sci USA</journal_title>
+						<author>Ding</author>
+						<volume>100</volume>
+						<first_page>7632</first_page>
+						<cYear>2003</cYear>
+						<article_title>Synthetic small molecules that control stem cell fate</article_title>
+						<doi>10.1073/pnas.0732087100</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>Genes Dev</journal_title>
+						<author>Elkabetz</author>
+						<volume>22</volume>
+						<first_page>152</first_page>
+						<cYear>2008</cYear>
+						<article_title>Human ES cell-derived neural rosettes reveal a functionally distinct early neural stem cell stage</article_title>
+						<doi>10.1101/gad.1616208</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Nat Rev Neurosci</journal_title>
+						<author>Farrant</author>
+						<volume>6</volume>
+						<first_page>215</first_page>
+						<cYear>2005</cYear>
+						<article_title>Variations on an inhibitory theme: phasic and tonic activation of GABAA receptors</article_title>
+						<doi>10.1038/nrn1625</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Neuron</journal_title>
+						<author>Flint</author>
+						<volume>20</volume>
+						<first_page>43</first_page>
+						<cYear>1998</cYear>
+						<article_title>Nonsynaptic glycine receptor activation during early neocortical development</article_title>
+						<doi>10.1016/S0896-6273(00)80433-X</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>Curr Opin Neurobiol</journal_title>
+						<author>Gaspard</author>
+						<volume>20</volume>
+						<first_page>37</first_page>
+						<cYear>2010</cYear>
+						<article_title>Mechanisms of neural specification from embryonic stem cells</article_title>
+						<doi>10.1016/j.conb.2009.12.001</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Trends Neurosci</journal_title>
+						<author>Ge</author>
+						<volume>30</volume>
+						<first_page>1</first_page>
+						<cYear>2007</cYear>
+						<article_title>GABA sets the tempo for activity-dependent adult neurogenesis</article_title>
+						<doi>10.1016/j.tins.2006.11.001</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Drugs</journal_title>
+						<author>Goa</author>
+						<volume>42</volume>
+						<first_page>640</first_page>
+						<cYear>1991</cYear>
+						<article_title>Ivermectin. A review of its antifilarial activity, pharmacokinetic properties and clinical efficacy in onchocerciasis</article_title>
+						<doi>10.2165/00003495-199142040-00007</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>J Pharmacol Exp Ther</journal_title>
+						<author>Huang</author>
+						<volume>281</volume>
+						<first_page>261</first_page>
+						<cYear>1997</cYear>
+						<article_title>Avermectin B1a binds to high- and low-affinity sites with dual effects on the gamma-aminobutyric acid-gated chloride channel of cultured cerebellar granule neurons</article_title>
+					</citation>
+					<citation key="bib23">
+						<journal_title>PLOS ONE</journal_title>
+						<author>Jang</author>
+						<volume>5</volume>
+						<first_page>e11528</first_page>
+						<cYear>2010a</cYear>
+						<article_title>Deoxygedunin, a natural product with potent neurotrophic activity in mice</article_title>
+						<doi>10.1371/journal.pone.0011528</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Proc Natl Acad Sci USA</journal_title>
+						<author>Jang</author>
+						<volume>107</volume>
+						<first_page>2687</first_page>
+						<cYear>2010b</cYear>
+						<article_title>A selective TrkB agonist with potent neurotrophic activities by 7,8-dihydroxyflavone</article_title>
+						<doi>10.1073/pnas.0913572107</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>Am J Stem Cells</journal_title>
+						<author>Kreitzer</author>
+						<volume>2</volume>
+						<first_page>119</first_page>
+						<cYear>2013</cYear>
+						<article_title>A robust method to derive functional neural crest cells from human pluripotent stem cells</article_title>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Nat Biotech</journal_title>
+						<author>Lee</author>
+						<volume>18</volume>
+						<first_page>675</first_page>
+						<cYear>2000</cYear>
+						<article_title>Efficient generation of midbrain and hindbrain neurons from mouse embryonic stem cells</article_title>
+						<doi>10.1038/76536</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Nat Neurosci</journal_title>
+						<author>Liu</author>
+						<volume>8</volume>
+						<first_page>1179</first_page>
+						<cYear>2005</cYear>
+						<article_title>Nonsynaptic GABA signaling in postnatal subventricular zone controls proliferation of GFAP-expressing progenitors</article_title>
+						<doi>10.1038/nn1522</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>Neuron</journal_title>
+						<author>LoTurco</author>
+						<volume>15</volume>
+						<first_page>1287</first_page>
+						<cYear>1995</cYear>
+						<article_title>GABA and glutamate depolarize cortical progenitor cells and inhibit DNA synthesis</article_title>
+						<doi>10.1016/0896-6273(95)90008-X</doi>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Nat Neurosci</journal_title>
+						<author>Marek</author>
+						<volume>13</volume>
+						<first_page>944</first_page>
+						<cYear>2010</cYear>
+						<article_title>cJun integrates calcium activity and tlx3 expression to regulate neurotransmitter specification</article_title>
+						<doi>10.1038/nn.2582</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Proc Natl Acad Sci USA</journal_title>
+						<author>Martinat</author>
+						<volume>103</volume>
+						<first_page>2874</first_page>
+						<cYear>2006</cYear>
+						<article_title>Cooperative transcription activation by Nurr1 and Pitx3 induces embryonic stem cell maturation to the midbrain dopamine neuron phenotype</article_title>
+						<doi>10.1073/pnas.0511153103</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Results Probl Cell Differ</journal_title>
+						<author>Mehler</author>
+						<volume>39</volume>
+						<first_page>27</first_page>
+						<cYear>2002</cYear>
+						<article_title>Mechanisms regulating lineage diversity during mammalian cerebral cortical neurogenesis and gliogenesis</article_title>
+						<doi>10.1007/978-3-540-46006-0_2</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Curr Opin Neurobiol</journal_title>
+						<author>Okano</author>
+						<volume>19</volume>
+						<first_page>112</first_page>
+						<cYear>2009</cYear>
+						<article_title>Cell types to order: temporal specification of CNS stem cells</article_title>
+						<doi>10.1016/j.conb.2009.04.003</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Nat Rev Neurosci</journal_title>
+						<author>Owens</author>
+						<volume>3</volume>
+						<first_page>715</first_page>
+						<cYear>2002</cYear>
+						<article_title>Is there more to GABA than synaptic inhibition?</article_title>
+						<doi>10.1038/nrn919</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>J Neurosci Res</journal_title>
+						<author>Palackal</author>
+						<volume>15</volume>
+						<first_page>223</first_page>
+						<cYear>1986</cYear>
+						<article_title>Abnormal visual cortex development in the kitten associated with maternal dietary taurine deprivation</article_title>
+						<doi>10.1002/jnr.490150212</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>Dev Biol</journal_title>
+						<author>Park</author>
+						<volume>227</volume>
+						<first_page>279</first_page>
+						<cYear>2000</cYear>
+						<article_title>Analysis of upstream elements in the HuC promoter leads to the establishment of transgenic zebrafish with fluorescent neurons</article_title>
+						<doi>10.1006/dbio.2000.9898</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>J Neurosci</journal_title>
+						<author>Pong</author>
+						<volume>2</volume>
+						<first_page>966</first_page>
+						<cYear>1982</cYear>
+						<article_title>A comparative study of avermectin B1a and other modulators of the gamma-aminobutyric acid receptor. chloride ion channel complex</article_title>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Chem Biol</journal_title>
+						<author>Saxe</author>
+						<volume>14</volume>
+						<first_page>1019</first_page>
+						<cYear>2007</cYear>
+						<article_title>A phenotypic small-molecule screen identifies an orphan ligand-receptor pair that regulates neural stem cell differentiation</article_title>
+						<doi>10.1016/j.chembiol.2007.07.016</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Nat Methods</journal_title>
+						<author>Schindelin</author>
+						<volume>9</volume>
+						<first_page>676</first_page>
+						<cYear>2012</cYear>
+						<article_title>Fiji: an open-source platform for biological-image analysis</article_title>
+						<doi>10.1038/nmeth.2019</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>FASEB J</journal_title>
+						<author>Schwirtlich</author>
+						<volume>24</volume>
+						<first_page>1218</first_page>
+						<cYear>2010</cYear>
+						<article_title>GABAA and GABAB receptors of distinct properties affect oppositely the proliferation of mouse embryonic stem cells through synergistic elevation of intracellular Ca2+</article_title>
+						<doi>10.1096/fj.09-143586</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>J Biol Chem</journal_title>
+						<author>Shan</author>
+						<volume>276</volume>
+						<first_page>12556</first_page>
+						<cYear>2001</cYear>
+						<article_title>Ivermectin, an unconventional agonist of the glycine receptor chloride channel</article_title>
+						<doi>10.1074/jbc.M011264200</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Methods Enzymol</journal_title>
+						<author>Sharma</author>
+						<volume>506</volume>
+						<first_page>331</first_page>
+						<cYear>2012</cYear>
+						<article_title>High-throughput screening in primary neurons</article_title>
+						<doi>10.1016/B978-0-12-391856-7.00041-X</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Annu Rev Cell Dev Biol</journal_title>
+						<author>Smith</author>
+						<volume>17</volume>
+						<first_page>435</first_page>
+						<cYear>2001</cYear>
+						<article_title>Embryo-derived stem cells: of mice and men</article_title>
+						<doi>10.1146/annurev.cellbio.17.1.435</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Nature</journal_title>
+						<author>Song</author>
+						<volume>489</volume>
+						<first_page>150</first_page>
+						<cYear>2012</cYear>
+						<article_title>Neuronal circuitry mechanism regulating adult quiescent neural stem-cell fate decision</article_title>
+						<doi>10.1038/nature11306</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>Nature</journal_title>
+						<author>Spitzer</author>
+						<volume>444</volume>
+						<first_page>707</first_page>
+						<cYear>2006</cYear>
+						<article_title>Electrical activity in early neuronal development</article_title>
+						<doi>10.1038/nature05300</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>Nat Rev Neurosci</journal_title>
+						<author>Spitzer</author>
+						<volume>13</volume>
+						<first_page>94</first_page>
+						<cYear>2012</cYear>
+						<article_title>Activity-dependent neurotransmitter respecification</article_title>
+						<doi>10.1038/nrn3154</doi>
+					</citation>
+					<citation key="bib46">
+						<journal_title>J Neurobiol</journal_title>
+						<author>Stewart</author>
+						<volume>50</volume>
+						<first_page>305</first_page>
+						<cYear>2002</cYear>
+						<article_title>Neural progenitor cells of the neonatal rat anterior subventricular zone express functional GABA(A) receptors</article_title>
+						<doi>10.1002/neu.10038</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Nature</journal_title>
+						<author>Stockwell</author>
+						<volume>432</volume>
+						<first_page>846</first_page>
+						<cYear>2004</cYear>
+						<article_title>Exploring biology with small organic molecules</article_title>
+						<doi>10.1038/nature03196</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Science</journal_title>
+						<author>Thomson</author>
+						<volume>282</volume>
+						<first_page>1145</first_page>
+						<cYear>1998</cYear>
+						<article_title>Embryonic stem cell lines derived from human blastocysts</article_title>
+						<doi>10.1126/science.282.5391.1145</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Neuron</journal_title>
+						<author>Tozuka</author>
+						<volume>47</volume>
+						<first_page>803</first_page>
+						<cYear>2005</cYear>
+						<article_title>GABAergic excitation promotes neuronal differentiation in adult hippocampal progenitor cells</article_title>
+						<doi>10.1016/j.neuron.2005.08.023</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>J Mol Evol</journal_title>
+						<author>Vassilatis</author>
+						<volume>44</volume>
+						<first_page>501</first_page>
+						<cYear>1997</cYear>
+						<article_title>Evolutionary relationship of the ligand-gated ion channels and the avermectin-sensitive, glutamate-gated chloride channels</article_title>
+						<doi>10.1007/PL00006174</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>J Physiol</journal_title>
+						<author>Wang</author>
+						<volume>550</volume>
+						<first_page>785</first_page>
+						<cYear>2003</cYear>
+						<article_title>GABA depolarizes neuronal progenitors of the postnatal subventricular zone via GABAA receptor activation</article_title>
+						<doi>10.1113/jphysiol.2003.042572</doi>
+					</citation>
+					<citation key="bib52">
+						<journal_title>Cell</journal_title>
+						<author>Wichterle</author>
+						<volume>10</volume>
+						<first_page>385</first_page>
+						<cYear>2002</cYear>
+						<article_title>Directed differentiation of embryonic stem cells into motor neurons</article_title>
+						<doi>10.1016/S0092-8674(02)00835-8</doi>
+					</citation>
+					<citation key="bib53">
+						<journal_title>Stem Cells</journal_title>
+						<author>Yamada</author>
+						<volume>25</volume>
+						<first_page>562</first_page>
+						<cYear>2007</cYear>
+						<article_title>Electrical stimulation modulates fate determination of differentiating embryonic stem cells</article_title>
+						<doi>10.1634/stemcells.2006-0011</doi>
+					</citation>
+					<citation key="bib54">
+						<journal_title>Methods Enzymol</journal_title>
+						<author>Ying</author>
+						<volume>365</volume>
+						<first_page>327</first_page>
+						<cYear>2003</cYear>
+						<article_title>Defined conditions for neural commitment and differentiation</article_title>
+						<doi>10.1016/S0076-6879(03)65023-8</doi>
+					</citation>
+					<citation key="bib55">
+						<journal_title>Nat Biotechnol</journal_title>
+						<author>Ying</author>
+						<volume>21</volume>
+						<first_page>183</first_page>
+						<cYear>2003</cYear>
+						<article_title>Conversion of embryonic stem cells into neuroectodermal precursors in adherent monoculture</article_title>
+						<doi>10.1038/nbt780</doi>
+					</citation>
+					<citation key="bib56">
+						<journal_title>Stem Cells</journal_title>
+						<author>Zhou</author>
+						<volume>28</volume>
+						<first_page>1741</first_page>
+						<cYear>2010</cYear>
+						<article_title>High-efficiency induction of neural conversion in human ESCs and human induced pluripotent stem cells with a single chemical inhibitor of transforming growth factor beta superfamily receptors</article_title>
+						<doi>10.1002/stem.504</doi>
+					</citation>
+					<citation key="bib57">
+						<journal_title>Nat Rev Drug Discovery</journal_title>
+						<author>Zon</author>
+						<volume>4</volume>
+						<first_page>35</first_page>
+						<cYear>2005</cYear>
+						<article_title>In vivo drug discovery in zebrafish</article_title>
+						<doi>10.1038/nrd1606</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.001</doi>
+							<resource>https://elifesciences.org/articles/00508#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.002</doi>
+							<resource>https://elifesciences.org/articles/00508#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. High-throughput screening.</title>
+							<subtitle>(A) Scheme of the three-stage mESC neuronal differentiation-based chemical screening. (B) E14 mESC cultures express neural progenitor makers (Sox2, Lmx1A, and Nestin) after 7-day stage one culture. 46C mESC cultures, in which GFP is driven by the sox1 promoter, are GFP positive after 7-day stage one culture. (C) The quantification analysis of TH+ neurons among total cells using the INCell Developer software. (D) Summary of coefficient of variation (C.V.) of the DMSO control. (E) Representative images of immunostaining in control (left, treated with DMSO) and a hit compound (right). (F) A schematic summary of the chemical screen. Scale bar, 10 μm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.003</doi>
+							<resource>https://elifesciences.org/articles/00508#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. The neurotrophin receptor TrkB agonists [Dihydrodeoxygedunin (DOG) and 7,8-dihydroxyflavone (DHF)] increases TH+ cells in mESC cultures.</title>
+							<subtitle>(A) Structure of DHF and DOG. (B) DHF and DOG increase TH% in mESCs (t test, p&lt;0.05, n = 4).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.004</doi>
+							<resource>https://elifesciences.org/articles/00508#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Selamectin increases mESC differentiation into multiple neural lineages.</title>
+							<subtitle>(A) Representative images of TH and NeuN staining in control (DMSO) and selamectin-treated cultures. (B) Quantification shows increased production of both TH+ and total neurons by selamectin (t-test, n = 4, p&lt;0.001). (C–F) Selamectin treatment also increases the production of 5-HT neurons (C), GABAergic neurons (D), islet+ motor neurons (E), and Olig2+ oligodendocyte precursors (F) (t-test, n = 4, *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.005</doi>
+							<resource>https://elifesciences.org/articles/00508#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Dose response and time course of selamectin’s action in mESC cultures.</title>
+							<subtitle>(A) Dose response curve of selamectin (based on TH immunostaining). Cells were treated from Day 8 to Day 11. Selamectin is toxic above 500 nM. The EC50 value and curve fitting were performed with GraphPad Prism using a Sigmoidal dose-response (variable slope). Data are presented as mean ± S.D., n = 4. (B) Time course of selamectin’s action. Only cells treated with selamectin from Day 7 to Day 10 show significant increase of TH+ neurons (t-test, n = 4).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.006</doi>
+							<resource>https://elifesciences.org/articles/00508#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Pharmacological evidence indicates that selamectin’s proneurogenic activity is mediated by GABAA receptors.</title>
+							<subtitle>(A) Selamectin and avermectin belong to a chemical family of macrocyclic lactones and have the same structural backbone. (B) Avermectin has less potent proneurogenic activity than selamectin. Only 250 nM avermectin shows a significant effect, which was much less potent compared to that of 250 nM selamectin (t-test, n = 4, p=0.034 for Avermetin vs p=0.002 for selamectin). (C) Taurine, the most abundant endogenous ligand for glycine receptors during neocortical development has no proneurogenic activity in mESC cultures. (D) Muscimol, a GABAA receptor agonist, has a significant proneurogenic activity (t-test, n = 4, p&lt;0.001). (E) Chlordiazepoxide (CDZ), a positive allosteric modulator of GABAA receptor, also has a significant proneurogenic activity (t-test, p&lt;0.05), but there was no obvious additive effect when cells were treated with both selamectin and CDZ (t-test, p=0.480). (F) The GABAA receptor antagonist bicucullin and non-competitive blockers picrotoxin and pentylenetetrazol alone had no effect on neuronal production (white columns, control group were normalized to fold change = 1, displayed as the red dot line). However, when tested together with selamectin, the effect of selamectin was blocked (gray columns). In contrast, the glycine receptor inhibitor strychnine does not block the effect of selamectin. Final concentration: Bicuculline (Bicu) = 100 μM; Picrotoxin (PTX) = 500 μM; Pentylenetetrazol (PTZ) = 5 mM; Strychnine (STY) = 100 μM; Selamectin (Sela) = 0.3 μM; Muscimol (Musci) = 10 μM (t-test, n = 4).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.007</doi>
+							<resource>https://elifesciences.org/articles/00508#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6. Genetic evidence indicates that selamectin’s proneurogenic activity is mediated by the γ2 subunit-containing GABAA receptor.</title>
+							<subtitle>(A) Scheme of the EsiRNA transfection and cell harvest for qRT-PCR. (B) qRT-PCR shows fold change of the expression of different GABAA receptor subunits after EsiRNA transfection. ***p&lt;0.001 vs non-transfection control, $$$p&lt;0.001 vs GFP RNA transfection control. (C) Scheme of the EsiRNA knockdown experiment to identify the GABAA receptor subunit that mediates selamectin’s activity. (D–F) Representative images of NeuN and TH staining in DMSO and selamectin-treated cultures of non-transfected (D), α1 EsiRNA transfected (E), and γ2 EsiRNA transfected (F). (G) Quantification shows knockdown of γ2 subunit but not α1β1 and π subunits abolishes the effect of selamectin in increasing neurons (n = 4, **p&lt;0.01, ***p&lt;0.001 vs DMSO). (H) Quantification shows knockdown of γ2 subunit but not α1β1 and π subunits abolishes the effect of selamectin in increasing TH+ neurons neurons (n = 4, **p&lt;0.01, ***p&lt;0.001 vs DMSO). Scale bar, 100 μm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.008</doi>
+							<resource>https://elifesciences.org/articles/00508#fig6</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 7. GABA and selamectin (Sela)-induced currents in neural rosettes and non-rosette cells.</title>
+							<subtitle>(A) Bright field (BF) image (left) and green fluorescent protein (GFP) signal (right) of neural rosette cells. Majority of the cells in the view are neural rosette cells, and one of them with typical morphology is indicated by a red arrow. (B) An example of reduction of GABA (500 μM) induced currents by bicuculline (BICC, 200 μM). (C) Upper trace, an example of neural rosette cell displaying GABA (100 μM) induced currents that also displayed selamectin induced current. Lower trace, an example of neural rosette cell displaying GABA (100 μM) induced currents that did not display selamectin induced current. 16 μM Selamectin solution contains 0.4% DMSO, therefore 0.4% DMSO containing bath solution was used as the control solution as indicated in the figure. (D) A pie chart of the numbers of the four groups of neural rosette cell based on whether they displayed GABA and selamectin induced currents. The four groups are: 1) GABA+; Sela+, 2) GABA+; Sela−, 3) GABA−; Sela+, 4) GABA−; Sela−. The number of the cells in each group is indicated in the figure, except the group GABA−; Sela+, which is zero. (E) Bright field (BF) image (left) and green fluorescent protein (GFP) signal (right) of non-rosette cells. One cell with typical young neuron morphology is indicated by a red arrow. (F) Example of the inhibition of GABA (100 μM) induced currents by bicuculline (BICC, 100 μM). (G) Upper trace, an example of non-rosette cell displaying GABA (4 mM) induced current that also displayed salemectin (8 μM) induced current. Lower trace, an example of non-rosette cell displaying GABA (400 μM) responsive induced current that did not display salemectin (16 μM) induced current. (H) A pie chart of the numbers of four groups of non-rosette cells based on whether they displayed GABA and selamectin induced currents. The four groups are: 1) GABA+; Sela+, 2) GABA+; Sela−, 3) GABA−; Sela+, 4) GABA−; Sela−. The number of the cells in each group is indicated in the figure, except the group GABA−; Sela+, which is zero. The application time courses of the control solution (BATH), GABA, bicuculline (BICC) and selamectin (Sela) are indicated by horizontal bars in the figure. The membrane potential was holding at −70 mV in all recordings. The scales for time (horizontal) and currents (vertical) are indicated for each recording in the figure.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.009</doi>
+							<resource>https://elifesciences.org/articles/00508#fig7</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 8. Selamectin decreases proliferation and increases the expression of proneural and lineage-associated transcription factors.</title>
+							<subtitle>(A) Representative fields show the BrdU incorporation on Day 11 after cells were treated with selamectin (right panel) or DMSO (left panel) for 4 days. Significantly fewer BrdU+ cells were detected in the selamectin-treated group. (B) Quantification as the percentage of BrdU+ cells among total cells (t-test, n = 4, p=0.008). (C) qRT-PCR detects increased expression of proneural (Ascl1, NeurD) and lineage-associated transcription factors (Lmx1a, Lmx1b and Nurr1) in selamectin-treated group. β-actin was used as an input control and data was normalized to expression level on Day 8. (D) Representative fields show the TUNEL staining on Day 14 in cell cultures treated with DMSO or selamectin, with NeuN staining as a control to confirm selamectin efficacy in this experiment. (E) Quantification shows significant difference in NeuN% (p&lt;0.001) and no significant difference in TUNEL% (p=0.058) (t-test, n = 4). Scale bar, 10 μm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.010</doi>
+							<resource>https://elifesciences.org/articles/00508#fig8</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 9. Clonal analysis reveals that selamectin promotes progenitor cell cycle exit toward terminal differentiation.</title>
+							<subtitle>(A) Scheme of clonal culture analyses. (B) Quantification of cell cycle length and number of cells within single clones. (C–E) Representative images of double immunostaining of GFP with NeuN (C), TH (D), or the proliferation marker Ki67 (E) within single clones. (F) Quantification of the percentage of NeuN+ (left, DMSO n = 49, selamectin n = 51), TH+ (middle, DMSO n = 6, selamectin n = 7), and Ki67+ cells (right, DMSO n = 46, selamectin n = 41) within single clones. ***p&lt;0.001 vs DMSO). Scale bar, 100 μm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.011</doi>
+							<resource>https://elifesciences.org/articles/00508#fig9</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 1.</title>
+						</titles>
+						<format mime_type="video/avi"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.012</doi>
+							<resource>https://elifesciences.org/articles/00508#media1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 2.</title>
+						</titles>
+						<format mime_type="video/avi"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.013</doi>
+							<resource>https://elifesciences.org/articles/00508#media2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 10. Selamectin increases the differentiation of multiple neuronal lineages from human pluripotent stem cells.</title>
+							<subtitle>(A) Scheme of the three-stage neuronal differentiation protocol for H9 hESCs and hiPSCs. (B) Representative images of NeuN and TH staining in control (DMSO) and selamectin-treated cultures of H9 hESCs. (C) Quantification shows increased production of both TH+ and total neurons by selamectin in H9 hESCs. (n = 4, *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001 vs DMSO). (D) Representative images of NeuN and TH staining in control (DMSO) and selamectin-treated cultures of hiPSCs. (E) Quantification shows increased production of both TH+ and total neurons by selamectin in hiPSCs. (n = 4, *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001 vs DMSO). Scale bar, 100 μm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.014</doi>
+							<resource>https://elifesciences.org/articles/00508#fig10</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 11. Selamectin promotes neurogenesis in vivo in the developing zebrafish brain.</title>
+							<subtitle>(A) Scheme of the selamectin treatment on HuC:GFP transgenic zebrafish embryos. (B) Representative images show that selamectin (2 μM, 14 hr from 8 hpf to 22 hpf) increases Huc-GFP signal. (C) Quantification of the midbrain cluster (boxed) shows a significant difference between two groups (t-test, n = 20, p&lt;0.001). (D) Representative images show increased DA neurons in selamectin-treated embryos (2 μM for 40 hr from 8 hpf to 48 hpf). (E) Quantification of the ventral forebrain DA neurons shows a significant difference between two groups (t-test, n = 10, p&lt;0.001). (F) A schematic model shows the effect of selamectin on neuronal differentiation from mESCs.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.015</doi>
+							<resource>https://elifesciences.org/articles/00508#fig11</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.016</doi>
+							<resource>https://elifesciences.org/articles/00508#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00508.017</doi>
+							<resource>https://elifesciences.org/articles/00508#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-00666-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00666-20170717071707.xml
@@ -1,69 +1,1038 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-00666-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>04</month><day>25</day><year>2016</year></publication_date><journal_volume><volume>5</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>The eLife research article</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Melissa</given_name><surname>Harrison</surname><suffix>Jnr</suffix><affiliation>Department of Production, eLife, Cambridge, United Kingdom</affiliation><ORCID authenticated="true">http://orcid.org/0000-0003-3523-4408</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>James F</given_name><surname>Gilbert</surname><affiliation>Department of Production, eLife, Cambridge, United Kingdom</affiliation></person_name><organization contributor_role="author" sequence="additional">eLife Editorial Production Group</organization><organization contributor_role="author" sequence="additional">eLife Technology Group</organization><organization contributor_role="author" sequence="additional">for the eLife Staff Team</organization></contributors><jats:abstract><jats:p>This is the abstract. This article will describe the eLife article and the process.
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-00666-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>04</month>
+					<day>25</day>
+					<year>2016</year>
+				</publication_date>
+				<journal_volume>
+					<volume>5</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>The eLife research article</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Melissa</given_name>
+						<surname>Harrison</surname>
+						<suffix>Jnr</suffix>
+						<affiliation>Department of Production, eLife, Cambridge, United Kingdom</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0003-3523-4408</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>James F</given_name>
+						<surname>Gilbert</surname>
+						<affiliation>Department of Production, eLife, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<organization contributor_role="author" sequence="additional">eLife Editorial Production Group</organization>
+					<organization contributor_role="author" sequence="additional">eLife Technology Group</organization>
+					<organization contributor_role="author" sequence="additional">for the eLife Staff Team</organization>
+				</contributors>
+				<jats:abstract>
+					<jats:p>
+						This is the abstract. This article will describe the eLife article and the process.
                     An abstract can contain any formatting, such as italics,
                         bold, superscript, subscript or small caps. MathML is
                     also allowed: 
-                    <mml:math>
-<mml:mrow>
-<mml:munder>
-<mml:mo/>
-<mml:mi>m</mml:mi>
-</mml:munder>
-<mml:mrow>
-<mml:msub>
-<mml:mover>
-<mml:mi>p</mml:mi>
-<mml:mo/>
-</mml:mover>
-<mml:mi>m</mml:mi>
-</mml:msub>
-<mml:mo>=</mml:mo>
-<mml:mn>0</mml:mn>
-</mml:mrow>
-</mml:mrow>
-</mml:math>
+                    
+						<mml:math>
+							
 
-                .</jats:p><jats:p>eLife does not structure abstracts into sub headings expect in a clinical trial article, but the abstract can have
+							<mml:mrow>
+								
+
+								<mml:munder>
+									
+
+									<mml:mo/>
+									
+
+									<mml:mi>m</mml:mi>
+									
+
+								</mml:munder>
+								
+
+								<mml:mrow>
+									
+
+									<mml:msub>
+										
+
+										<mml:mover>
+											
+
+											<mml:mi>p</mml:mi>
+											
+
+											<mml:mo/>
+											
+
+										</mml:mover>
+										
+
+										<mml:mi>m</mml:mi>
+										
+
+									</mml:msub>
+									
+
+									<mml:mo>=</mml:mo>
+									
+
+									<mml:mn>0</mml:mn>
+									
+
+								</mml:mrow>
+								
+
+							</mml:mrow>
+							
+
+						</mml:math>
+						
+
+                .
+					</jats:p>
+					<jats:p>eLife does not structure abstracts into sub headings expect in a clinical trial article, but the abstract can have
                     multiple paragarahs. The sub DOI is always .001 as it is the first asset in any
-                    article. I have added an unmatched &gt; bracket as this has been an issue for PubMed deposits in the past.</jats:p><jats:p>If this was a clinical trial the clinical trial details would be listed at the end of the abstract:</jats:p><jats:p>Clinical trial Registration: EudraCT2004-000446-20.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>eLife digest are now optional and not every research article will contain one.
+                    article. I have added an unmatched &gt; bracket as this has been an issue for PubMed deposits in the past.</jats:p>
+					<jats:p>If this was a clinical trial the clinical trial details would be listed at the end of the abstract:</jats:p>
+					<jats:p>Clinical trial Registration: EudraCT2004-000446-20.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>eLife digest are now optional and not every research article will contain one.
                     These are layman abstracts, designed for non-specialists in this field to be
-                    able to understand this article, as well as the general public.</jats:p><jats:p>Here is paragraph 2 of the digest.</jats:p></jats:abstract><publication_date media_type="online"><month>04</month><day>25</day><year>2016</year></publication_date><publisher_item><item_number item_number_type="article_number">e00666</item_number><identifier id_type="doi">10.7554/eLife.00666</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Howard Hughes Medical Institute<fr:assertion name="funder_identifier">https://dx.doi.org/10.13039/100000011</fr:assertion></fr:assertion><fr:assertion name="award_number">F32 GM089018</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Laura and John Arnold Foundation</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><rel:program><rel:related_item><rel:description>xml-mapping</rel:description><rel:inter_work_relation identifier-type="uri" relationship-type="isSupplementedBy">https://github.com/elifesciences/XML-mapping/blob/master/elife-00666.xml</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>elife-vendor-workflow-config</rel:description><rel:inter_work_relation identifier-type="uri" relationship-type="references">https://github.com/elifesciences/elife-vendor-workflow-config</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Dryad Digital Repository</rel:description><rel:inter_work_relation identifier-type="doi" relationship-type="references">10.5061/dryad.cv323</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>NKX2-5 mutations causative for congenital heart disease retain
-                functionality and are directed to hundreds of targets</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">GSE44902</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Crystal structure of KRYPTONITE in complex with mCHH DNA and
-                SAH</rel:description><rel:inter_work_relation identifier-type="doi" relationship-type="references">10.2210/pdb4qen/pdb</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Diagnostically relevant facial gestalt information from ordinary photos database</rel:description><rel:inter_work_relation identifier-type="uri" relationship-type="references">https://github.com/ChristofferNellaker/Clinical_Face_Phenotype_Space_Pipeline</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Mus musculus T-box 2 (Tbx2), mRNA</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">NM_009324</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Effects on the transcriptome of adult mouse pancreas (principally
-                acinar cells) by the inactivation of the Ptf1a gene in vivo</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">GSE70542</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Data from: Genome-wide errant targeting by Hairy</rel:description><rel:inter_work_relation identifier-type="doi" relationship-type="references">10.5061/dryad.cv323</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>ISG15 counteracts &lt;italic&gt;Listeria monocytogenes&lt;/italic&gt;
-                infection</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">PXD001805</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Transcription profiling by high throughput sequencing of LoVo
+                    able to understand this article, as well as the general public.</jats:p>
+					<jats:p>Here is paragraph 2 of the digest.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>04</month>
+					<day>25</day>
+					<year>2016</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e00666</item_number>
+					<identifier id_type="doi">10.7554/eLife.00666</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Howard Hughes Medical Institute
+							<fr:assertion name="funder_identifier">https://dx.doi.org/10.13039/100000011</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">F32 GM089018</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Laura and John Arnold Foundation</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<rel:program>
+					<rel:related_item>
+						<rel:description>xml-mapping</rel:description>
+						<rel:inter_work_relation identifier-type="uri" relationship-type="isSupplementedBy">https://github.com/elifesciences/XML-mapping/blob/master/elife-00666.xml</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>elife-vendor-workflow-config</rel:description>
+						<rel:inter_work_relation identifier-type="uri" relationship-type="references">https://github.com/elifesciences/elife-vendor-workflow-config</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Dryad Digital Repository</rel:description>
+						<rel:inter_work_relation identifier-type="doi" relationship-type="references">10.5061/dryad.cv323</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>NKX2-5 mutations causative for congenital heart disease retain
+                functionality and are directed to hundreds of targets</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">GSE44902</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Crystal structure of KRYPTONITE in complex with mCHH DNA and
+                SAH</rel:description>
+						<rel:inter_work_relation identifier-type="doi" relationship-type="references">10.2210/pdb4qen/pdb</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Diagnostically relevant facial gestalt information from ordinary photos database</rel:description>
+						<rel:inter_work_relation identifier-type="uri" relationship-type="references">https://github.com/ChristofferNellaker/Clinical_Face_Phenotype_Space_Pipeline</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Mus musculus T-box 2 (Tbx2), mRNA</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">NM_009324</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Effects on the transcriptome of adult mouse pancreas (principally
+                acinar cells) by the inactivation of the Ptf1a gene in vivo</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">GSE70542</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Data from: Genome-wide errant targeting by Hairy</rel:description>
+						<rel:inter_work_relation identifier-type="doi" relationship-type="references">10.5061/dryad.cv323</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>ISG15 counteracts &lt;italic&gt;Listeria monocytogenes&lt;/italic&gt;
+                infection</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">PXD001805</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Transcription profiling by high throughput sequencing of LoVo
                 cells infected with Listeria for 24 hr compared to uninfected
-                cells</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">E-MTAB-3649</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>SKN-1 from the JASPAR CORE database</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">MA0547.1</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Global Diversity of Shigella Species</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">PRJEB2846</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Shigella sonnei and flexneri from around the world</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">PRJEB2460</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Shigella flexneri from around the world</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">PRJEB2542</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Polymeric immunoglobulin receptor [Oncorhynchus mykiss]</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">GenBank: ADB81776.1</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>ChIP-Seq Identification of C. elegans TF Binding Sites</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="references">modENCODE_3369</rel:inter_work_relation></rel:related_item></rel:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.00666</doi><resource>https://elifesciences.org/articles/00666</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/00666/elife-00666.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/00666/elife-00666.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>The Journal of Cell Biology</journal_title><author>Aivazian</author><volume>173</volume><first_page>917</first_page><cYear>2006</cYear><article_title>TIP47 is a key effector for Rab9 localization</article_title><doi>10.1083/jcb.200510010</doi></citation><citation key="bib2"><volume_title>CRAN</volume_title><author>Bates</author><cYear>2016</cYear><article_title>Lme4: Linear Mixed-Effects Models Using Eigen and S4</article_title><unstructured_citation>Bates D, Maechler M, Bolker B, Walker S, Haubo Bojesen Christensen R, Singmann H, Dai B, Grothendieck G, Green P, Bolker B. 2016. Lme4: Linear Mixed-Effects Models Using Eigen and S4. CRAN. 1.1-12. https://cran.r-project.org/web/packages/lme4/index.html.</unstructured_citation></citation><citation key="bib3"><volume_title>bioRxiv</volume_title><author>Bloss</author><cYear>2016</cYear><article_title>A prospective randomized trial examining health care utilization in individuals using multiple 
-                smartphone-enabled biosensors</article_title><doi>10.1101/029983</doi></citation><citation key="bib4"><volume_title>NCBI Gene Expression Omnibus</volume_title><author>Bouveret</author><cYear>2015</cYear><article_title>NKX2-5 mutations causative for congenital heart disease retain
-                functionality and are directed to hundreds of targets</article_title></citation><citation key="bib5"><journal_title>International journal of systematic and evolutionary
-                microbiology</journal_title><author>Brettar</author><volume>54</volume><first_page>2335</first_page><cYear>2004</cYear><article_title>Aquiflexum balticum gen. nov., sp nov., a novel marine bacterium
+                cells</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">E-MTAB-3649</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>SKN-1 from the JASPAR CORE database</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">MA0547.1</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Global Diversity of Shigella Species</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">PRJEB2846</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Shigella sonnei and flexneri from around the world</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">PRJEB2460</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Shigella flexneri from around the world</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">PRJEB2542</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Polymeric immunoglobulin receptor [Oncorhynchus mykiss]</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">GenBank: ADB81776.1</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>ChIP-Seq Identification of C. elegans TF Binding Sites</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="references">modENCODE_3369</rel:inter_work_relation>
+					</rel:related_item>
+				</rel:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.00666</doi>
+					<resource>https://elifesciences.org/articles/00666</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/00666/elife-00666.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/00666/elife-00666.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>The Journal of Cell Biology</journal_title>
+						<author>Aivazian</author>
+						<volume>173</volume>
+						<first_page>917</first_page>
+						<cYear>2006</cYear>
+						<article_title>TIP47 is a key effector for Rab9 localization</article_title>
+						<doi>10.1083/jcb.200510010</doi>
+					</citation>
+					<citation key="bib2">
+						<volume_title>CRAN</volume_title>
+						<author>Bates</author>
+						<cYear>2016</cYear>
+						<article_title>Lme4: Linear Mixed-Effects Models Using Eigen and S4</article_title>
+						<unstructured_citation>Bates D, Maechler M, Bolker B, Walker S, Haubo Bojesen Christensen R, Singmann H, Dai B, Grothendieck G, Green P, Bolker B. 2016. Lme4: Linear Mixed-Effects Models Using Eigen and S4. CRAN. 1.1-12. https://cran.r-project.org/web/packages/lme4/index.html.</unstructured_citation>
+					</citation>
+					<citation key="bib3">
+						<volume_title>bioRxiv</volume_title>
+						<author>Bloss</author>
+						<cYear>2016</cYear>
+						<article_title>A prospective randomized trial examining health care utilization in individuals using multiple 
+                smartphone-enabled biosensors</article_title>
+						<doi>10.1101/029983</doi>
+					</citation>
+					<citation key="bib4">
+						<volume_title>NCBI Gene Expression Omnibus</volume_title>
+						<author>Bouveret</author>
+						<cYear>2015</cYear>
+						<article_title>NKX2-5 mutations causative for congenital heart disease retain
+                functionality and are directed to hundreds of targets</article_title>
+					</citation>
+					<citation key="bib5">
+						<journal_title>International journal of systematic and evolutionary
+                microbiology</journal_title>
+						<author>Brettar</author>
+						<volume>54</volume>
+						<first_page>2335</first_page>
+						<cYear>2004</cYear>
+						<article_title>Aquiflexum balticum gen. nov., sp nov., a novel marine bacterium
                 of the Cytophaga-Flavobacterium-Bacteroides group isolated from surface
-                water of the central Baltic Sea</article_title><doi>10.1099/ijs.0.63255-0</doi></citation><citation key="bib6"><journal_title>International journal of systematic and evolutionary
-                microbiology</journal_title><author>Brettar</author><volume>54</volume><first_page>65</first_page><cYear>2004</cYear><article_title>Belliella baltica gen. nov., sp. nov., a novel marine bacterium
+                water of the central Baltic Sea</article_title>
+						<doi>10.1099/ijs.0.63255-0</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>International journal of systematic and evolutionary
+                microbiology</journal_title>
+						<author>Brettar</author>
+						<volume>54</volume>
+						<first_page>65</first_page>
+						<cYear>2004</cYear>
+						<article_title>Belliella baltica gen. nov., sp. nov., a novel marine bacterium
                 of the Cytophaga-Flavobacterium-Bacteroides group isolated from surface
-                water of the central Baltic Sea</article_title><doi>10.1099/ijs.0.02752-0</doi></citation><citation key="bib7"><author>Bricogne</author><cYear>2011</cYear><article_title>BUSTER</article_title><unstructured_citation>Bricogne G, Blanc E, Brandl M, Flensburg C, Keller P, Paciorek W, Roversi P, Sharff A, Smart OS, Vonrhein C, Womack TO. 2011. BUSTER. Cambridge, UK: Global Phasing Ltd. 2.10.0. https://www.globalphasing.com/buster/.</unstructured_citation></citation><citation key="bib8"><volume_title>Advances in insect chemical ecology</volume_title><author>Cardé</author><cYear>2004</cYear></citation><citation key="bib9"><volume_title>arXiv.org</volume_title><author>Cartwright</author><cYear>2016</cYear><article_title>The Venus Hypothesis</article_title><unstructured_citation>Cartwright A. 2016. The Venus Hypothesis. arXiv.org. https://arxiv.org/abs/1608.03074.</unstructured_citation></citation><citation key="bib10"><volume_title>An Introduction to Work and Organizational Psychology: A European
-                Perspective</volume_title><author>Chmeil</author><cYear>2008</cYear></citation><citation key="bib11"><volume_title>Speciation and its consequences</volume_title><author>Coyne</author><first_page>1</first_page><cYear>1989</cYear></citation><citation key="bib12"><volume_title>PyMol</volume_title><author>DeLano</author><cYear>2002</cYear><article_title>The PyMol Molecular Graphics System</article_title><unstructured_citation>DeLano W. 2002. The PyMol Molecular Graphics System. Schrödinger LLC. PyMol. Version 1.7.4. https://www.pymol.org/.</unstructured_citation></citation><citation key="bib13"><volume_title>Educational excellence everywhere</volume_title><author>Department of Education</author><cYear>2016</cYear><isbn>9781474130158</isbn></citation><citation key="bib14"><volume_title>RCSB Protein Data Bank</volume_title><author>Du</author><cYear>2014</cYear><article_title>Crystal structure of KRYPTONITE in complex with mCHH DNA and
-                SAH</article_title><doi>10.2210/pdb4qen/pdb</doi></citation><citation key="bib15"><volume_title>it is NOT junk</volume_title><author>Eisen</author><cYear>2016</cYear><article_title>The Imprinter of All Maladies</article_title><unstructured_citation>Eisen M. 2016. The Imprinter of All Maladies. it is NOT junk. http://www.michaeleisen.org/blog/?p=1894 [Accessed August 19, 2016].</unstructured_citation></citation><citation key="bib16"><volume_title>Division of Clinical Neurology, University of Oxford</volume_title><author>Ferry</author><cYear>2014</cYear><article_title>Diagnostically relevant facial gestalt information from ordinary photos database</article_title></citation><citation key="bib17"><journal_title>Immunity</journal_title><author>Gall</author><volume>36</volume><first_page>120</first_page><cYear>2012</cYear><article_title>Autoimmunity initiates in nonhematopoietic cells and progresses
+                water of the central Baltic Sea</article_title>
+						<doi>10.1099/ijs.0.02752-0</doi>
+					</citation>
+					<citation key="bib7">
+						<author>Bricogne</author>
+						<cYear>2011</cYear>
+						<article_title>BUSTER</article_title>
+						<unstructured_citation>Bricogne G, Blanc E, Brandl M, Flensburg C, Keller P, Paciorek W, Roversi P, Sharff A, Smart OS, Vonrhein C, Womack TO. 2011. BUSTER. Cambridge, UK: Global Phasing Ltd. 2.10.0. https://www.globalphasing.com/buster/.</unstructured_citation>
+					</citation>
+					<citation key="bib8">
+						<volume_title>Advances in insect chemical ecology</volume_title>
+						<author>Cardé</author>
+						<cYear>2004</cYear>
+					</citation>
+					<citation key="bib9">
+						<volume_title>arXiv.org</volume_title>
+						<author>Cartwright</author>
+						<cYear>2016</cYear>
+						<article_title>The Venus Hypothesis</article_title>
+						<unstructured_citation>Cartwright A. 2016. The Venus Hypothesis. arXiv.org. https://arxiv.org/abs/1608.03074.</unstructured_citation>
+					</citation>
+					<citation key="bib10">
+						<volume_title>An Introduction to Work and Organizational Psychology: A European
+                Perspective</volume_title>
+						<author>Chmeil</author>
+						<cYear>2008</cYear>
+					</citation>
+					<citation key="bib11">
+						<volume_title>Speciation and its consequences</volume_title>
+						<author>Coyne</author>
+						<first_page>1</first_page>
+						<cYear>1989</cYear>
+					</citation>
+					<citation key="bib12">
+						<volume_title>PyMol</volume_title>
+						<author>DeLano</author>
+						<cYear>2002</cYear>
+						<article_title>The PyMol Molecular Graphics System</article_title>
+						<unstructured_citation>DeLano W. 2002. The PyMol Molecular Graphics System. Schrödinger LLC. PyMol. Version 1.7.4. https://www.pymol.org/.</unstructured_citation>
+					</citation>
+					<citation key="bib13">
+						<volume_title>Educational excellence everywhere</volume_title>
+						<author>Department of Education</author>
+						<cYear>2016</cYear>
+						<isbn>9781474130158</isbn>
+					</citation>
+					<citation key="bib14">
+						<volume_title>RCSB Protein Data Bank</volume_title>
+						<author>Du</author>
+						<cYear>2014</cYear>
+						<article_title>Crystal structure of KRYPTONITE in complex with mCHH DNA and
+                SAH</article_title>
+						<doi>10.2210/pdb4qen/pdb</doi>
+					</citation>
+					<citation key="bib15">
+						<volume_title>it is NOT junk</volume_title>
+						<author>Eisen</author>
+						<cYear>2016</cYear>
+						<article_title>The Imprinter of All Maladies</article_title>
+						<unstructured_citation>Eisen M. 2016. The Imprinter of All Maladies. it is NOT junk. http://www.michaeleisen.org/blog/?p=1894 [Accessed August 19, 2016].</unstructured_citation>
+					</citation>
+					<citation key="bib16">
+						<volume_title>Division of Clinical Neurology, University of Oxford</volume_title>
+						<author>Ferry</author>
+						<cYear>2014</cYear>
+						<article_title>Diagnostically relevant facial gestalt information from ordinary photos database</article_title>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Immunity</journal_title>
+						<author>Gall</author>
+						<volume>36</volume>
+						<first_page>120</first_page>
+						<cYear>2012</cYear>
+						<article_title>Autoimmunity initiates in nonhematopoietic cells and progresses
                 via lymphocytes in an interferon-dependent autoimmune
-                disease</article_title><doi>10.1016/j.immuni.2011.11.018</doi></citation><citation key="bib18"><volume_title>NCBI Nucleotide</volume_title><author>Gavrilov</author><cYear>2014</cYear><article_title>Mus musculus T-box 2 (Tbx2), mRNA</article_title></citation><citation key="bib19"><volume_title>Augmentin 250/62 SF Suspension</volume_title><author>GlaxoSmithKline UK</author><cYear>2016</cYear><unstructured_citation>GlaxoSmithKline UK. 2016. United Kingdom: GlaxoSmithKline UK. Augmentin 250/62 SF Suspension. https://www.medicines.org.uk/emc/medicine/19188.</unstructured_citation></citation><citation key="bib20"><journal_title>Bioinformatics</journal_title><author>Goodstadt</author><volume>26</volume><first_page>2778</first_page><cYear>2010</cYear><article_title>
+                disease</article_title>
+						<doi>10.1016/j.immuni.2011.11.018</doi>
+					</citation>
+					<citation key="bib18">
+						<volume_title>NCBI Nucleotide</volume_title>
+						<author>Gavrilov</author>
+						<cYear>2014</cYear>
+						<article_title>Mus musculus T-box 2 (Tbx2), mRNA</article_title>
+					</citation>
+					<citation key="bib19">
+						<volume_title>Augmentin 250/62 SF Suspension</volume_title>
+						<author>GlaxoSmithKline UK</author>
+						<cYear>2016</cYear>
+						<unstructured_citation>GlaxoSmithKline UK. 2016. United Kingdom: GlaxoSmithKline UK. Augmentin 250/62 SF Suspension. https://www.medicines.org.uk/emc/medicine/19188.</unstructured_citation>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Bioinformatics</journal_title>
+						<author>Goodstadt</author>
+						<volume>26</volume>
+						<first_page>2778</first_page>
+						<cYear>2010</cYear>
+						<article_title>
                 Ruffus: a lightweight Python library for computational pipelines
-            </article_title><doi>10.1093/bioinformatics/btq524</doi></citation><citation key="bib21"><volume_title>NCBI Gene Expression Omnibus</volume_title><author>Hoang</author><cYear>2015</cYear><article_title>Effects on the transcriptome of adult mouse pancreas (principally
-                acinar cells) by the inactivation of the Ptf1a gene in vivo</article_title></citation><citation key="bib22"><volume_title>Integrated pest management for crops and pastures</volume_title><author>Horne</author><cYear>2008</cYear><isbn>9780643092570</isbn></citation><citation key="bib23"><volume_title>Naccess</volume_title><author>Hubbard</author><cYear>1993</cYear><unstructured_citation>Hubbard S, Thornton J. 1993. Department of Biochemistry Molecular Biology, University College London. Naccess. V2.1.1. http://www.bioinf.manchester.ac.uk/naccess.</unstructured_citation></citation><citation key="bib24"><author>Jain</author><cYear>2010</cYear><article_title>Boundary learning by optimization with topological
-                constraints</article_title><unstructured_citation>Jain BV, Bollman B, Richardson M, Berger DR, Helmstaedter MN, Briggman KL, Denk W, Bowden JB, Mendenhall JM, Abraham WC, Harris KM, Kasthuri N, Hayworth KJ, Schalek R, Tapia JC, Lichtman JW, Seung HS. 2010. Boundary learning by optimization with topological
-                constraints. IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2010.</unstructured_citation></citation><citation key="bib25"><volume_title>Psychology A Study Of A Science</volume_title><author>Koch</author><volume>3: Formulations of the Person a</volume><cYear>1959</cYear></citation><citation key="bib26"><volume_title>Dryad Digital Repository</volume_title><author>Kok</author><cYear>2015</cYear><article_title>Data from: Genome-wide errant targeting by Hairy</article_title><doi>10.5061/dryad.cv323</doi></citation><citation key="bib27"><journal_title>Nucleic Acids Res</journal_title><author>McQuilton</author><volume>40</volume><first_page>D706</first_page><cYear>2012</cYear><article_title>FlyBase 101—the basics of navigating FlyBase</article_title><doi>10.1093/nar/gkr1030</doi></citation><citation key="bib28"><volume_title>Clinical training in serious mental illness (DHHS Publication No. ADM 90-1679)</volume_title><author>National Institute of Mental Health</author><cYear>1990</cYear><unstructured_citation>National Institute of Mental Health. 1990. Washington, DC, United States: Government Printing Office. Clinical training in serious mental illness (DHHS Publication No. ADM 90-1679).</unstructured_citation></citation><citation key="bib29"><volume_title>Github</volume_title><author>Nellåker</author><cYear>2014</cYear><article_title>Clinical_Face_Phenotype_Space_Pipeline</article_title><unstructured_citation>Nellåker C. 2014. Clinical_Face_Phenotype_Space_Pipeline. Github. v1.2. https://github.com/ChristofferNellaker/Clinical_Face_Phenotype_Space_Pipeline.</unstructured_citation></citation><citation key="bib30"><volume_title>Bioconductor</volume_title><author>Pages</author><cYear>2014</cYear><article_title>String objects representing biological sequences, and matching algorithms</article_title><unstructured_citation>Pages H, Gentleman R, Aboyoun P, Biostrings DS. 2014. String objects representing biological sequences, and matching algorithms. Bioconductor. R Package Version 2.30.1. https://bioconductor.org/packages/release/bioc/html/Biostrings.html.</unstructured_citation></citation><citation key="bib31"><volume_title>Independent component analysis and signal separation</volume_title><author>Palmer</author><first_page>90</first_page><cYear>2007</cYear><article_title>Probabilistic Formulation of Independent Vector Analysis Using Complex Gaussian Scale Mixtures</article_title><unstructured_citation>Palmer JA, Kreutz-Delgado K, Rao BD, Makeig S. 2007. Probabilistic Formulation of Independent Vector Analysis Using Complex Gaussian Scale Mixtures. Independent component analysis and signal separation.  8th International Conference, ICA 2009, Paraty, Brazil, March 15-18, 2009.</unstructured_citation></citation><citation key="bib32"><volume_title>United States patent</volume_title><cYear>2011</cYear><article_title>IRE-1alpha inhibitors</article_title><unstructured_citation>Patterson JB, Lonergan DG, Flynn GA, Qingpeng Z, Pallai PV, Mankind Corp. 2011. IRE-1alpha inhibitors. United States patent. US20100941530. http://europepmc.org/patents/PAT/US2011065162.</unstructured_citation></citation><citation key="bib33"><author>R Development Core Team</author><cYear>2015</cYear><article_title>R: a language and environment for statistical computing</article_title><unstructured_citation>R Development Core Team. 2015. R: a language and environment for statistical computing. Vienna, Austria: R Foundation for Statistical Computing. 3.2.2. http://www.r-project.org/.</unstructured_citation></citation><citation key="bib34"><volume_title>ProteomeXchange</volume_title><author>Radoshevich</author><cYear>2015</cYear><article_title>ISG15 counteracts Listeria monocytogenes
-                infection</article_title></citation><citation key="bib35"><volume_title>ArrayExpress</volume_title><author>Radoshevich</author><cYear>2015</cYear><article_title>Transcription profiling by high throughput sequencing of LoVo
+            </article_title>
+						<doi>10.1093/bioinformatics/btq524</doi>
+					</citation>
+					<citation key="bib21">
+						<volume_title>NCBI Gene Expression Omnibus</volume_title>
+						<author>Hoang</author>
+						<cYear>2015</cYear>
+						<article_title>Effects on the transcriptome of adult mouse pancreas (principally
+                acinar cells) by the inactivation of the Ptf1a gene in vivo</article_title>
+					</citation>
+					<citation key="bib22">
+						<volume_title>Integrated pest management for crops and pastures</volume_title>
+						<author>Horne</author>
+						<cYear>2008</cYear>
+						<isbn>9780643092570</isbn>
+					</citation>
+					<citation key="bib23">
+						<volume_title>Naccess</volume_title>
+						<author>Hubbard</author>
+						<cYear>1993</cYear>
+						<unstructured_citation>Hubbard S, Thornton J. 1993. Department of Biochemistry Molecular Biology, University College London. Naccess. V2.1.1. http://www.bioinf.manchester.ac.uk/naccess.</unstructured_citation>
+					</citation>
+					<citation key="bib24">
+						<author>Jain</author>
+						<cYear>2010</cYear>
+						<article_title>Boundary learning by optimization with topological
+                constraints</article_title>
+						<unstructured_citation>Jain BV, Bollman B, Richardson M, Berger DR, Helmstaedter MN, Briggman KL, Denk W, Bowden JB, Mendenhall JM, Abraham WC, Harris KM, Kasthuri N, Hayworth KJ, Schalek R, Tapia JC, Lichtman JW, Seung HS. 2010. Boundary learning by optimization with topological
+                constraints. IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2010.</unstructured_citation>
+					</citation>
+					<citation key="bib25">
+						<volume_title>Psychology A Study Of A Science</volume_title>
+						<author>Koch</author>
+						<volume>3: Formulations of the Person a</volume>
+						<cYear>1959</cYear>
+					</citation>
+					<citation key="bib26">
+						<volume_title>Dryad Digital Repository</volume_title>
+						<author>Kok</author>
+						<cYear>2015</cYear>
+						<article_title>Data from: Genome-wide errant targeting by Hairy</article_title>
+						<doi>10.5061/dryad.cv323</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Nucleic Acids Res</journal_title>
+						<author>McQuilton</author>
+						<volume>40</volume>
+						<first_page>D706</first_page>
+						<cYear>2012</cYear>
+						<article_title>FlyBase 101—the basics of navigating FlyBase</article_title>
+						<doi>10.1093/nar/gkr1030</doi>
+					</citation>
+					<citation key="bib28">
+						<volume_title>Clinical training in serious mental illness (DHHS Publication No. ADM 90-1679)</volume_title>
+						<author>National Institute of Mental Health</author>
+						<cYear>1990</cYear>
+						<unstructured_citation>National Institute of Mental Health. 1990. Washington, DC, United States: Government Printing Office. Clinical training in serious mental illness (DHHS Publication No. ADM 90-1679).</unstructured_citation>
+					</citation>
+					<citation key="bib29">
+						<volume_title>Github</volume_title>
+						<author>Nellåker</author>
+						<cYear>2014</cYear>
+						<article_title>Clinical_Face_Phenotype_Space_Pipeline</article_title>
+						<unstructured_citation>Nellåker C. 2014. Clinical_Face_Phenotype_Space_Pipeline. Github. v1.2. https://github.com/ChristofferNellaker/Clinical_Face_Phenotype_Space_Pipeline.</unstructured_citation>
+					</citation>
+					<citation key="bib30">
+						<volume_title>Bioconductor</volume_title>
+						<author>Pages</author>
+						<cYear>2014</cYear>
+						<article_title>String objects representing biological sequences, and matching algorithms</article_title>
+						<unstructured_citation>Pages H, Gentleman R, Aboyoun P, Biostrings DS. 2014. String objects representing biological sequences, and matching algorithms. Bioconductor. R Package Version 2.30.1. https://bioconductor.org/packages/release/bioc/html/Biostrings.html.</unstructured_citation>
+					</citation>
+					<citation key="bib31">
+						<volume_title>Independent component analysis and signal separation</volume_title>
+						<author>Palmer</author>
+						<first_page>90</first_page>
+						<cYear>2007</cYear>
+						<article_title>Probabilistic Formulation of Independent Vector Analysis Using Complex Gaussian Scale Mixtures</article_title>
+						<unstructured_citation>Palmer JA, Kreutz-Delgado K, Rao BD, Makeig S. 2007. Probabilistic Formulation of Independent Vector Analysis Using Complex Gaussian Scale Mixtures. Independent component analysis and signal separation.  8th International Conference, ICA 2009, Paraty, Brazil, March 15-18, 2009.</unstructured_citation>
+					</citation>
+					<citation key="bib32">
+						<volume_title>United States patent</volume_title>
+						<cYear>2011</cYear>
+						<article_title>IRE-1alpha inhibitors</article_title>
+						<unstructured_citation>Patterson JB, Lonergan DG, Flynn GA, Qingpeng Z, Pallai PV, Mankind Corp. 2011. IRE-1alpha inhibitors. United States patent. US20100941530. http://europepmc.org/patents/PAT/US2011065162.</unstructured_citation>
+					</citation>
+					<citation key="bib33">
+						<author>R Development Core Team</author>
+						<cYear>2015</cYear>
+						<article_title>R: a language and environment for statistical computing</article_title>
+						<unstructured_citation>R Development Core Team. 2015. R: a language and environment for statistical computing. Vienna, Austria: R Foundation for Statistical Computing. 3.2.2. http://www.r-project.org/.</unstructured_citation>
+					</citation>
+					<citation key="bib34">
+						<volume_title>ProteomeXchange</volume_title>
+						<author>Radoshevich</author>
+						<cYear>2015</cYear>
+						<article_title>ISG15 counteracts Listeria monocytogenes
+                infection</article_title>
+					</citation>
+					<citation key="bib35">
+						<volume_title>ArrayExpress</volume_title>
+						<author>Radoshevich</author>
+						<cYear>2015</cYear>
+						<article_title>Transcription profiling by high throughput sequencing of LoVo
                 cells infected with Listeria for 24 hr compared to uninfected
-                cells</article_title></citation><citation key="bib36"><author>Rasband</author><cYear>1997</cYear><article_title>Image J</article_title><unstructured_citation>Rasband WS. 1997. Image J. Bethesda, MA: US National Institutes of Health. http://imagej.nih.gov/ij/.</unstructured_citation></citation><citation key="bib37"><journal_title>Genome Res</journal_title><author>Roy</author><cYear>2013</cYear><article_title>Arboretum: reconstruction and analysis of the evolutionary
-                history of condition-specific transcriptional programs</article_title></citation><citation key="bib38"><author>Schneider</author><cYear>2006</cYear><article_title>PhD thesis: Submicroscopic Plasmodium falciparum gametocytaemia and the contribution to malaria transmission</article_title><unstructured_citation>Schneider P. 2006. PhD thesis: Submicroscopic Plasmodium falciparum gametocytaemia and the contribution to malaria transmission. Nijmegen, The Netherlands: Radboud University Nijmegen Medical Centre.</unstructured_citation></citation><citation key="bib39"><volume_title>The PyMOL Molecular Graphics System</volume_title><author>Schrödinger</author><cYear>2011</cYear><unstructured_citation>Schrödinger LLC. 2011. Schrödinger LLC. The PyMOL Molecular Graphics System. 1.2r3pre. https://www.pymol.org/.</unstructured_citation></citation><citation key="bib40"><volume_title>The Washington Post</volume_title><author>Schwartz</author><first_page>A1</first_page><cYear>1993</cYear><article_title>Obesity affects economic, social status</article_title></citation><citation key="bib41"><cYear>2015</cYear><article_title>Scripps Wired for Health Study</article_title></citation><citation key="bib42"><author>Smit</author><cYear>2010</cYear><article_title>RepeatModeler</article_title><unstructured_citation>Smit A, Hubley R. 2010. RepeatModeler. Seattle, USA: Institute for Systems Biology. open-1.0. http://www.repeatmasker.org/RepeatModeler.html.</unstructured_citation></citation><citation key="bib43"><volume_title>JASPAR</volume_title><author>Staab</author><cYear>2013</cYear><article_title>SKN-1 from the JASPAR CORE database</article_title></citation><citation key="bib44"><volume_title>preprints</volume_title><author>Tanaka</author><cYear>2016</cYear><article_title>Hypoxic Preconditioning of Human Cardiosphere-derived Cell Sheets Enhances Cellular Functions via 
-                Activation of the PI3K/Akt/mTOR/HIF-1a Pathway</article_title><doi>10.20944/preprints201608.0124.v1</doi></citation><citation key="bib45"><volume_title>NCBI BioProject</volume_title><author>The Shigella Genome Sequencing Consortium</author><cYear>2015</cYear><article_title>Global Diversity of Shigella Species</article_title></citation><citation key="bib46"><volume_title>NCBI BioProject</volume_title><author>The Shigella Genome Sequencing Consortium</author><cYear>2015</cYear><article_title>Shigella sonnei and flexneri from around the world</article_title></citation><citation key="bib47"><volume_title>NCBI BioProject </volume_title><author>The Shigella Genome Sequencing Consortium</author><cYear>2015</cYear><article_title>Shigella flexneri from around the world</article_title></citation><citation key="bib48"><volume_title>Advances in insect chemical ecology</volume_title><author>Turlings</author><first_page>21</first_page><cYear>2004</cYear></citation><citation key="bib49"><volume_title>Advances in insect chemical ecology</volume_title><author>Turlings</author><cYear>2004</cYear></citation><citation key="bib50"><author>Walker</author><article_title>Solar System Live</article_title><unstructured_citation>Walker J. Solar System Live. https://www.fourmilab.ch/solar/ [Accessed September 10, 1995].</unstructured_citation></citation><citation key="bib51"><journal_title>PLoS Biol</journal_title><author>Wolski</author><volume>6</volume><cYear>2008</cYear><article_title>Crystal structure of the FeS cluster-containing nucleotide
-                        excision repair helicase XPD</article_title><doi>10.1371/journal.pbio.0060149</doi><elocation_id>e149</elocation_id></citation><citation key="bib52"><volume_title> Growing up unequal: gender and socioeconomic differences in young
+                cells</article_title>
+					</citation>
+					<citation key="bib36">
+						<author>Rasband</author>
+						<cYear>1997</cYear>
+						<article_title>Image J</article_title>
+						<unstructured_citation>Rasband WS. 1997. Image J. Bethesda, MA: US National Institutes of Health. http://imagej.nih.gov/ij/.</unstructured_citation>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Genome Res</journal_title>
+						<author>Roy</author>
+						<cYear>2013</cYear>
+						<article_title>Arboretum: reconstruction and analysis of the evolutionary
+                history of condition-specific transcriptional programs</article_title>
+					</citation>
+					<citation key="bib38">
+						<author>Schneider</author>
+						<cYear>2006</cYear>
+						<article_title>PhD thesis: Submicroscopic Plasmodium falciparum gametocytaemia and the contribution to malaria transmission</article_title>
+						<unstructured_citation>Schneider P. 2006. PhD thesis: Submicroscopic Plasmodium falciparum gametocytaemia and the contribution to malaria transmission. Nijmegen, The Netherlands: Radboud University Nijmegen Medical Centre.</unstructured_citation>
+					</citation>
+					<citation key="bib39">
+						<volume_title>The PyMOL Molecular Graphics System</volume_title>
+						<author>Schrödinger</author>
+						<cYear>2011</cYear>
+						<unstructured_citation>Schrödinger LLC. 2011. Schrödinger LLC. The PyMOL Molecular Graphics System. 1.2r3pre. https://www.pymol.org/.</unstructured_citation>
+					</citation>
+					<citation key="bib40">
+						<volume_title>The Washington Post</volume_title>
+						<author>Schwartz</author>
+						<first_page>A1</first_page>
+						<cYear>1993</cYear>
+						<article_title>Obesity affects economic, social status</article_title>
+					</citation>
+					<citation key="bib41">
+						<cYear>2015</cYear>
+						<article_title>Scripps Wired for Health Study</article_title>
+					</citation>
+					<citation key="bib42">
+						<author>Smit</author>
+						<cYear>2010</cYear>
+						<article_title>RepeatModeler</article_title>
+						<unstructured_citation>Smit A, Hubley R. 2010. RepeatModeler. Seattle, USA: Institute for Systems Biology. open-1.0. http://www.repeatmasker.org/RepeatModeler.html.</unstructured_citation>
+					</citation>
+					<citation key="bib43">
+						<volume_title>JASPAR</volume_title>
+						<author>Staab</author>
+						<cYear>2013</cYear>
+						<article_title>SKN-1 from the JASPAR CORE database</article_title>
+					</citation>
+					<citation key="bib44">
+						<volume_title>preprints</volume_title>
+						<author>Tanaka</author>
+						<cYear>2016</cYear>
+						<article_title>Hypoxic Preconditioning of Human Cardiosphere-derived Cell Sheets Enhances Cellular Functions via 
+                Activation of the PI3K/Akt/mTOR/HIF-1a Pathway</article_title>
+						<doi>10.20944/preprints201608.0124.v1</doi>
+					</citation>
+					<citation key="bib45">
+						<volume_title>NCBI BioProject</volume_title>
+						<author>The Shigella Genome Sequencing Consortium</author>
+						<cYear>2015</cYear>
+						<article_title>Global Diversity of Shigella Species</article_title>
+					</citation>
+					<citation key="bib46">
+						<volume_title>NCBI BioProject</volume_title>
+						<author>The Shigella Genome Sequencing Consortium</author>
+						<cYear>2015</cYear>
+						<article_title>Shigella sonnei and flexneri from around the world</article_title>
+					</citation>
+					<citation key="bib47">
+						<volume_title>NCBI BioProject </volume_title>
+						<author>The Shigella Genome Sequencing Consortium</author>
+						<cYear>2015</cYear>
+						<article_title>Shigella flexneri from around the world</article_title>
+					</citation>
+					<citation key="bib48">
+						<volume_title>Advances in insect chemical ecology</volume_title>
+						<author>Turlings</author>
+						<first_page>21</first_page>
+						<cYear>2004</cYear>
+					</citation>
+					<citation key="bib49">
+						<volume_title>Advances in insect chemical ecology</volume_title>
+						<author>Turlings</author>
+						<cYear>2004</cYear>
+					</citation>
+					<citation key="bib50">
+						<author>Walker</author>
+						<article_title>Solar System Live</article_title>
+						<unstructured_citation>Walker J. Solar System Live. https://www.fourmilab.ch/solar/ [Accessed September 10, 1995].</unstructured_citation>
+					</citation>
+					<citation key="bib51">
+						<journal_title>PLoS Biol</journal_title>
+						<author>Wolski</author>
+						<volume>6</volume>
+						<cYear>2008</cYear>
+						<article_title>Crystal structure of the FeS cluster-containing nucleotide
+                        excision repair helicase XPD</article_title>
+						<doi>10.1371/journal.pbio.0060149</doi>
+						<elocation_id>e149</elocation_id>
+					</citation>
+					<citation key="bib52">
+						<volume_title> Growing up unequal: gender and socioeconomic differences in young
                 people's health and well-being. Health Behaviour in School-aged Children
-                (HBSC) study</volume_title><author>World Health Organization</author><cYear>2016</cYear></citation><citation key="bib53"><volume_title>NCBI</volume_title><author>Zhang</author><cYear>2010</cYear><article_title>Polymeric immunoglobulin receptor [Oncorhynchus mykiss]</article_title></citation><citation key="bib54"><volume_title>modMine</volume_title><author>Zhong</author><cYear>2013</cYear><article_title>ChIP-Seq Identification of C. elegans TF Binding Sites</article_title></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.001</doi><resource>https://elifesciences.org/articles/00666#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.002</doi><resource>https://elifesciences.org/articles/00666#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 1. This is the title.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.003</doi><resource>https://elifesciences.org/articles/00666#table1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 2.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.004</doi><resource>https://elifesciences.org/articles/00666#table2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 3. Representative curves of steady-state kinetic analyses for each IGF1R protein characterized.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.005</doi><resource>https://elifesciences.org/articles/00666#table3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 3—source data 1. Representative curves of steady-state kinetic analyses for each IGF1R protein characterized.</title><subtitle>Each data point was performed in duplicate and is shown separately.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.00666.006</doi><resource>https://elifesciences.org/articles/00666/figures#table3sdata1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Single figure: The header of an eLife article example on the HTML page. In the PDf this is represented as a single column.</title></titles><format mime_type="image/tiff"/><ai:program name="AccessIndicators"><ai:license_ref>https://submit.elifesciences.org/html/elife_author_instructions.html#policies</ai:license_ref></ai:program><doi_data><doi>10.7554/eLife.00666.007</doi><resource>https://elifesciences.org/articles/00666#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Figure with figure supplements. In the PDF this asset box will take full column width.</title><subtitle>This is the basic information provided about an article. Figure 1
+                (HBSC) study</volume_title>
+						<author>World Health Organization</author>
+						<cYear>2016</cYear>
+					</citation>
+					<citation key="bib53">
+						<volume_title>NCBI</volume_title>
+						<author>Zhang</author>
+						<cYear>2010</cYear>
+						<article_title>Polymeric immunoglobulin receptor [Oncorhynchus mykiss]</article_title>
+					</citation>
+					<citation key="bib54">
+						<volume_title>modMine</volume_title>
+						<author>Zhong</author>
+						<cYear>2013</cYear>
+						<article_title>ChIP-Seq Identification of C. elegans TF Binding Sites</article_title>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.001</doi>
+							<resource>https://elifesciences.org/articles/00666#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.002</doi>
+							<resource>https://elifesciences.org/articles/00666#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 1. This is the title.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.003</doi>
+							<resource>https://elifesciences.org/articles/00666#table1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 2.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.004</doi>
+							<resource>https://elifesciences.org/articles/00666#table2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 3. Representative curves of steady-state kinetic analyses for each IGF1R protein characterized.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.005</doi>
+							<resource>https://elifesciences.org/articles/00666#table3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 3—source data 1. Representative curves of steady-state kinetic analyses for each IGF1R protein characterized.</title>
+							<subtitle>Each data point was performed in duplicate and is shown separately.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.006</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#table3sdata1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Single figure: The header of an eLife article example on the HTML page. In the PDf this is represented as a single column.</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<ai:program name="AccessIndicators">
+							<ai:license_ref>https://submit.elifesciences.org/html/elife_author_instructions.html#policies</ai:license_ref>
+						</ai:program>
+						<doi_data>
+							<doi>10.7554/eLife.00666.007</doi>
+							<resource>https://elifesciences.org/articles/00666#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Figure with figure supplements. In the PDF this asset box will take full column width.</title>
+							<subtitle>This is the basic information provided about an article. Figure 1
                              shows an expanded view (Kok et al., 2015; National Institute of Mental 
-                                Health, 1990).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.008</doi><resource>https://elifesciences.org/articles/00666#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. The representation of the Major Subject Areas, Research Organisms and author keywords on the eLife HTML page</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.009</doi><resource>https://elifesciences.org/articles/00666/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 2. Representation of figure with figure supplements on the HTML view.</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.010</doi><resource>https://elifesciences.org/articles/00666/figures#fig2s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Figure with figure supplements and figure supplement with source data and a video (see Koch, 1959) .</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.011</doi><resource>https://elifesciences.org/articles/00666#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. Title of the figure supplement</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.012</doi><resource>https://elifesciences.org/articles/00666/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1—Source data 1. Title of the figure supplement source data.</title><subtitle>Legend of the figure supplement source data.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.00666.013</doi><resource>https://elifesciences.org/articles/00666/figures#fig3sdata1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—Video 1. 
+                                Health, 1990).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.008</doi>
+							<resource>https://elifesciences.org/articles/00666#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. The representation of the Major Subject Areas, Research Organisms and author keywords on the eLife HTML page</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.009</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 2. Representation of figure with figure supplements on the HTML view.</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.010</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#fig2s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Figure with figure supplements and figure supplement with source data and a video (see Koch, 1959) .</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.011</doi>
+							<resource>https://elifesciences.org/articles/00666#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. Title of the figure supplement</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.012</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1—Source data 1. Title of the figure supplement source data.</title>
+							<subtitle>Legend of the figure supplement source data.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.013</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#fig3sdata1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—Video 1. 
                                     A description of the eLife editorial process.
-                                </title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.00666.035</doi><resource>https://elifesciences.org/articles/00666#fig3video1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Single figure with source code.</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.014</doi><resource>https://elifesciences.org/articles/00666#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—Source code 1. Title of the source code.</title><subtitle>Legend of the source code.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.00666.015</doi><resource>https://elifesciences.org/articles/00666/figures#fig4scode1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 1. 
+                                </title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.035</doi>
+							<resource>https://elifesciences.org/articles/00666#fig3video1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Single figure with source code.</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.014</doi>
+							<resource>https://elifesciences.org/articles/00666#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—Source code 1. Title of the source code.</title>
+							<subtitle>Legend of the source code.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.015</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#fig4scode1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 1. 
                                 A description of the eLife editorial process.
-                            </title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.00666.016</doi><resource>https://elifesciences.org/articles/00666#video1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 1—Source data 1. Title of the source code.</title><subtitle>Legend of the source code.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.00666.037</doi><resource>https://elifesciences.org/articles/00666/figures#video1sdata1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Animation 1. A demonstration of how to tag an animated gif file to ensure it is autolooped when on the eLife website.</title></titles><format mime_type="image/gif"/><doi_data><doi>10.7554/eLife.00666.038</doi><resource>https://elifesciences.org/articles/00666#video2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Box 1.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.017</doi><resource>https://elifesciences.org/articles/00666#box1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Box 2.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.018</doi><resource>https://elifesciences.org/articles/00666#box2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Box 2—Figure 1. Box figure</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.036</doi><resource>https://elifesciences.org/articles/00666#box2fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 1. This is the title of the supplementary file 1.</title><subtitle>A file containing underlying data.</subtitle></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.019</doi><resource>https://elifesciences.org/articles/00666/figures#supp1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Source data 1. This is the title of the source data that is not attached to a specific figure, but to the article as a whole.</title></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.00666.020</doi><resource>https://elifesciences.org/articles/00666/figures#sdata1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Source code 1. This is the title of the source code that is not attached to a specific figure, but to the article as a whole.</title></titles><format mime_type="application/xml"/><doi_data><doi>10.7554/eLife.00666.021</doi><resource>https://elifesciences.org/articles/00666/figures#scode1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Reporting Standard 1. CONSORT flow diagram.</title></titles><format mime_type="application/pdf"/><doi_data><doi>10.7554/eLife.00666.022</doi><resource>https://elifesciences.org/articles/00666/figures#repstand1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Preparation</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.023</doi><resource>https://elifesciences.org/articles/00666#None</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Appendix 1—Figure 1. Appendix figure title.
-                        </title><subtitle>If there is a caption to accompany the title it would display here (Koch, 1959).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.024</doi><resource>https://elifesciences.org/articles/00666#app1fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Appendix 1—Figure 1—Figure Supplement 1. Appendix figure supplement title.</title><subtitle>If there is a caption to accompany the title it would display here.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.025</doi><resource>https://elifesciences.org/articles/00666/figures#app1fig1s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Apendix 1—Table 1. This is the title.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.039</doi><resource>https://elifesciences.org/articles/00666#app1table1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Negotaition</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.026</doi><resource>https://elifesciences.org/articles/00666#None</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Appendix 2—Video 1. 
+                            </title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.016</doi>
+							<resource>https://elifesciences.org/articles/00666#video1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 1—Source data 1. Title of the source code.</title>
+							<subtitle>Legend of the source code.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.037</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#video1sdata1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Animation 1. A demonstration of how to tag an animated gif file to ensure it is autolooped when on the eLife website.</title>
+						</titles>
+						<format mime_type="image/gif"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.038</doi>
+							<resource>https://elifesciences.org/articles/00666#video2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Box 1.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.017</doi>
+							<resource>https://elifesciences.org/articles/00666#box1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Box 2.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.018</doi>
+							<resource>https://elifesciences.org/articles/00666#box2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Box 2—Figure 1. Box figure</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.036</doi>
+							<resource>https://elifesciences.org/articles/00666#box2fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 1. This is the title of the supplementary file 1.</title>
+							<subtitle>A file containing underlying data.</subtitle>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.019</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#supp1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Source data 1. This is the title of the source data that is not attached to a specific figure, but to the article as a whole.</title>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.020</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#sdata1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Source code 1. This is the title of the source code that is not attached to a specific figure, but to the article as a whole.</title>
+						</titles>
+						<format mime_type="application/xml"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.021</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#scode1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Reporting Standard 1. CONSORT flow diagram.</title>
+						</titles>
+						<format mime_type="application/pdf"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.022</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#repstand1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Preparation</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.023</doi>
+							<resource>https://elifesciences.org/articles/00666#None</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Appendix 1—Figure 1. Appendix figure title.
+                        </title>
+							<subtitle>If there is a caption to accompany the title it would display here (Koch, 1959).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.024</doi>
+							<resource>https://elifesciences.org/articles/00666#app1fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Appendix 1—Figure 1—Figure Supplement 1. Appendix figure supplement title.</title>
+							<subtitle>If there is a caption to accompany the title it would display here.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.025</doi>
+							<resource>https://elifesciences.org/articles/00666/figures#app1fig1s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Apendix 1—Table 1. This is the title.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.039</doi>
+							<resource>https://elifesciences.org/articles/00666#app1table1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Negotaition</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.026</doi>
+							<resource>https://elifesciences.org/articles/00666#None</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Appendix 2—Video 1. 
                                 A descirption of the eLife editorial process.
-                            </title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.00666.027</doi><resource>https://elifesciences.org/articles/00666#app2video1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Apendix 2—Table 1.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.028</doi><resource>https://elifesciences.org/articles/00666#app2table1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Appendix 3</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.034</doi><resource>https://elifesciences.org/articles/00666#None</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.029</doi><resource>https://elifesciences.org/articles/00666#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response image 1. Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.030</doi><resource>https://elifesciences.org/articles/00666#SA2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response image 1.</title><subtitle>Single figure: The header of an eLife article example on the HTML page.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.00666.031</doi><resource>https://elifesciences.org/articles/00666#respfig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response Table 1.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.00666.032</doi><resource>https://elifesciences.org/articles/00666#resptable1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response video 1.</title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.00666.033</doi><resource>https://elifesciences.org/articles/00666#respvideo1</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+                            </title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.027</doi>
+							<resource>https://elifesciences.org/articles/00666#app2video1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Apendix 2—Table 1.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.028</doi>
+							<resource>https://elifesciences.org/articles/00666#app2table1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Appendix 3</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.034</doi>
+							<resource>https://elifesciences.org/articles/00666#None</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.029</doi>
+							<resource>https://elifesciences.org/articles/00666#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response image 1. Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.030</doi>
+							<resource>https://elifesciences.org/articles/00666#SA2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response image 1.</title>
+							<subtitle>Single figure: The header of an eLife article example on the HTML page.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.031</doi>
+							<resource>https://elifesciences.org/articles/00666#respfig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response Table 1.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.032</doi>
+							<resource>https://elifesciences.org/articles/00666#resptable1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response video 1.</title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.00666.033</doi>
+							<resource>https://elifesciences.org/articles/00666#respvideo1</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-00666-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00666-20170717071707.xml
@@ -982,26 +982,6 @@
 					</component>
 					<component parent_relation="isPartOf">
 						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.00666.029</doi>
-							<resource>https://elifesciences.org/articles/00666#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response image 1. Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.00666.030</doi>
-							<resource>https://elifesciences.org/articles/00666#SA2</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
 							<title>Author response image 1.</title>
 							<subtitle>Single figure: The header of an eLife article example on the HTML page.</subtitle>
 						</titles>

--- a/tests/test_data/elife-crossref-02020-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02020-20170717071707.xml
@@ -1,1 +1,888 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-02020-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>06</month><day>24</day><year>2014</year></publication_date><journal_volume><volume>3</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Diagnostically relevant facial gestalt information from ordinary photos</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Quentin</given_name><surname>Ferry</surname><affiliation>Department of Engineering Science, University of Oxford, Oxford, United Kingdom</affiliation><affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Julia</given_name><surname>Steinberg</surname><affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation><affiliation>The Wellcome Trust Centre for Human Genetics, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Caleb</given_name><surname>Webber</surname><affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>David R</given_name><surname>FitzPatrick</surname><affiliation>Medical Research Council Human Genetics Unit, Institute of Genetics and Molecular Medicine, Edinburgh, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Chris P</given_name><surname>Ponting</surname><affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Andrew</given_name><surname>Zisserman</surname><affiliation>Department of Engineering Science, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Christoffer</given_name><surname>Nellåker</surname><affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation></person_name></contributors><jats:abstract><jats:p>Craniofacial characteristics are highly informative for clinical geneticists when diagnosing genetic diseases. As a first step towards the high-throughput diagnosis of ultra-rare developmental diseases we introduce an automatic approach that implements recent developments in computer vision. This algorithm extracts phenotypic information from ordinary non-clinical photographs and, using machine learning, models human facial dysmorphisms in a multidimensional 'Clinical Face Phenotype Space'. The space locates patients in the context of known syndromes and thereby facilitates the generation of diagnostic hypotheses. Consequently, the approach will aid clinicians by greatly narrowing (by 27.6-fold) the search space of potential diagnoses for patients with suspected developmental disorders. Furthermore, this Clinical Face Phenotype Space allows the clustering of patients by phenotype even when no known syndrome diagnosis exists, thereby aiding disease identification. We demonstrate that this approach provides a novel method for inferring causative genetic variants from clinical sequencing data through functional genetic pathway comparisons.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>Rare genetic disorders affect around 8% of people, many of whom live with symptoms that greatly reduce their quality of life. Genetic diagnoses can provide doctors with information that cannot be obtained by assessing clinical symptoms, and this allows them to select more suitable treatments for patients. However, only a minority of patients currently receive a genetic diagnosis.</jats:p><jats:p>Alterations in the face and skull are present in 30–40% of genetic disorders, and these alterations can help doctors to identify certain disorders, such as Down’s syndrome or Fragile X. Extending this approach, Ferry et al. trained a computer-based model to identify the patterns of facial abnormalities associated with different genetic disorders. The model compares data extracted from a photograph of the patient’s face with data on the facial characteristics of 91 disorders, and then provides a list of the most likely diagnoses for that individual. The model used 36 points to describe the space, including 7 for the jaw, 6 for the mouth, 7 for the nose, 8 for the eyes and 8 for the brow.</jats:p><jats:p>This approach of Ferry et al. has three advantages. First, it provides clinicians with information that can aid their diagnosis of a rare genetic disorder. Second, it can narrow down the range of possible disorders for patients who have the same ultra-rare disorder, even if that disorder is currently unknown. Third, it can identify groups of patients who can have their genomes sequenced in order to identify the genetic variants that are associated with specific disorders.</jats:p><jats:p>The work by Ferry et al. lays out the basic principles for automated approaches to analyze the shape of the face and skull. The next challenge is to integrate photos with genetic data for use in clinical settings.</jats:p></jats:abstract><publication_date media_type="online"><month>06</month><day>24</day><year>2014</year></publication_date><publisher_item><item_number item_number_type="article_number">e02020</item_number><identifier id_type="doi">10.7554/eLife.02020</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Medical Research Council (MRC)<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">European Research Council<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000781</fr:assertion></fr:assertion><fr:assertion name="award_number">228180 VisRec</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Oxford Biomedical Research Centre</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Medical Research Council (MRC)<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion></fr:assertion><fr:assertion name="award_number">Centenary Award</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/3.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/3.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/3.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.02020</doi><resource>https://elifesciences.org/articles/02020</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/02020/elife-02020-v1.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02020/elife-02020-v1.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>Nature</journal_title><author>Abecasis</author><volume>491</volume><first_page>56</first_page><cYear>2012</cYear><article_title>An integrated map of genetic variation from 1,092 human genomes</article_title><doi>10.1038/nature11632</doi></citation><citation key="bib2"><journal_title>Molecular Autism</journal_title><author>Aldridge</author><volume>2</volume><first_page>15</first_page><cYear>2011</cYear><article_title>Facial phenotypes in subgroups of prepubertal boys with autism spectrum disorders are correlated with clinical phenotypes</article_title><doi>10.1186/2040-2392-2-15</doi></citation><citation key="bib3"><journal_title>American Journal of Medical Genetics</journal_title><author>Allanson</author><volume>152A</volume><first_page>1960</first_page><cYear>2010</cYear><article_title>The face of Noonan syndrome: does phenotype predict genotype</article_title><doi>10.1002/ajmg.a.33518</doi></citation><citation key="bib4"><journal_title>American Journal of Human Genetics</journal_title><author>Baird</author><volume>42</volume><first_page>677</first_page><cYear>1988</cYear><article_title>Genetic disorders in children and young adults: a population study</article_title></citation><citation key="bib5"><journal_title>AAAI Publications, Third International AAAI Conference on Weblogs and Social Media</journal_title><author>Bastian</author><cYear>2009</cYear><article_title>Gephi: An open source software for exploring and manipulating networks</article_title></citation><citation key="bib6"><journal_title>Human Mutation</journal_title><author>Baynam</author><volume>34</volume><first_page>14</first_page><cYear>2013</cYear><article_title>The facial evolution: looking backward and moving forward</article_title><doi>10.1002/humu.22219</doi></citation><citation key="bib7"><author>Belhumeur</author><first_page>545</first_page><cYear>2011</cYear><article_title>Localizing parts of faces using a consensus of exemplars. Proceedings of the 2011 IEEE Conference on Computer Vision and Pattern Recognition</article_title></citation><citation key="bib8"><journal_title>Journal of Human Genetics</journal_title><author>Bertola</author><volume>52</volume><first_page>521</first_page><cYear>2007</cYear><article_title>Further evidence of genetic heterogeneity in Costello syndrome: involvement of the KRAS gene</article_title><doi>10.1007/s10038-007-0146-1</doi></citation><citation key="bib9"><author>Blanz</author><first_page>617</first_page><cYear>2006</cYear><article_title>Face recognition based on a 3D Morphable model. Proceedings Of the 7th International Conference of Automatic Face and Gesture Recognition</article_title></citation><citation key="bib10"><journal_title>American Journal of Medical Genetics</journal_title><author>Boehringer</author><volume>155A</volume><first_page>2161</first_page><cYear>2011</cYear><article_title>Automated syndrome detection in a set of clinical facial photographs</article_title><doi>10.1002/ajmg.a.34157</doi></citation><citation key="bib11"><journal_title>European Journal of Human Genetics</journal_title><author>Boehringer</author><volume>14</volume><first_page>1082</first_page><cYear>2006</cYear><article_title>Syndrome identification based on 2D analysis software</article_title><doi>10.1038/sj.ejhg.5201673</doi></citation><citation key="bib12"><journal_title>Studi in Onore del Professore Salvatore Ortu Carboni</journal_title><author>Bonferroni</author><cYear>1935</cYear><article_title>Il calcolo delle assicurazioni su gruppi di teste</article_title></citation><citation key="bib13"><journal_title>Pubblicazioni del R Istituto Superiore di Scienze Economiche e Commerciali di Firenze</journal_title><author>Bonferroni</author><first_page>3</first_page><cYear>1936</cYear><article_title>Teoria statistica delle classi e calcolo delle probabilità</article_title></citation><citation key="bib14"><journal_title>Dr. Dobb's Journal of Software Tools</journal_title><author>Bradski</author><cYear>2000</cYear><article_title>The OpenCV Library</article_title></citation><citation key="bib15"><journal_title>The American Journal of Psychiatry</journal_title><author>Buckley</author><volume>162</volume><first_page>606</first_page><cYear>2005</cYear><article_title>A three-dimensional morphometric study of craniofacial shape in schizophrenia</article_title><doi>10.1176/appi.ajp.162.3.606</doi></citation><citation key="bib16"><author>Cootes</author><first_page>484</first_page><cYear>1998</cYear><article_title>Active appearance models. IEEE Transactions on Pattern Analysis and Machine Intelligence</article_title></citation><citation key="bib17"><journal_title>Nature Genetics</journal_title><author>Cordeddu</author><volume>41</volume><first_page>1022</first_page><cYear>2009</cYear><article_title>Mutation of SHOC2 promotes aberrant protein N-myristoylation and causes Noonan-like syndrome with loose anagen hair</article_title><doi>10.1038/ng.425</doi></citation><citation key="bib18"><journal_title>Computer Methods and Programs in Biomedicine</journal_title><author>Dalal</author><volume>85</volume><first_page>165</first_page><cYear>2007</cYear><article_title>Morphometric analysis of face in dysmorphology</article_title><doi>10.1016/j.cmpb.2006.10.005</doi></citation><citation key="bib19"><journal_title>The New England Journal of Medicine</journal_title><author>de Ligt</author><volume>367</volume><first_page>1921</first_page><cYear>2012</cYear><article_title>Diagnostic exome sequencing in persons with severe intellectual disability</article_title><doi>10.1056/NEJMoa1206524</doi></citation><citation key="bib20"><journal_title>Numerische Mathematik</journal_title><author>Dijkstra</author><volume>1</volume><first_page>269</first_page><cYear>1959</cYear><article_title>A note on two problems in connexion with graphs</article_title><doi>10.1007/BF01386390</doi></citation><citation key="bib21"><journal_title>Image and Vision Computing</journal_title><author>Everingham</author><volume>27</volume><cYear>2009</cYear><article_title>Taking the bite out of automatic naming of characters in TV video</article_title></citation><citation key="bib22"><journal_title>European Journal of Medical Genetics</journal_title><author>Ferrero</author><volume>50</volume><first_page>327</first_page><cYear>2007</cYear><article_title>Presenting phenotype and clinical evaluation in a cohort of 22 Williams-Beuren syndrome patients</article_title><doi>10.1016/j.ejmg.2007.05.005</doi></citation><citation key="bib23"><journal_title>IEEE Transactions on Computer</journal_title><author>Fischler</author><first_page>67</first_page><cYear>1973</cYear><article_title>The representation and matching of pictorial structures</article_title></citation><citation key="bib24"><journal_title>Bioinformatics</journal_title><author>Goodstadt</author><volume>26</volume><first_page>2778</first_page><cYear>2010</cYear><article_title>Ruffus: a lightweight Python library for computational pipelines</article_title><doi>10.1093/bioinformatics/btq524</doi></citation><citation key="bib25"><journal_title>The Journal of the Kentucky Medical Association</journal_title><author>Gordon</author><volume>60</volume><first_page>249</first_page><cYear>1962</cYear><article_title>Abraham Lincoln–a medical appraisal</article_title></citation><citation key="bib26"><journal_title>American Journal of Medical Genetics Part A</journal_title><author>Gripp</author><volume>143A</volume><first_page>1472</first_page><cYear>2007</cYear><article_title>Further delineation of the phenotype resulting from BRAF or MEK1 germline mutations helps differentiate cardio-facio-cutaneous syndrome from Costello syndrome</article_title><doi>10.1002/ajmg.a.31815</doi></citation><citation key="bib27"><journal_title>Archives of Disease in Childhood</journal_title><author>Hammond</author><volume>92</volume><first_page>1120</first_page><cYear>2007</cYear><article_title>The use of 3D face shape modelling in dysmorphology</article_title><doi>10.1136/adc.2006.103507</doi></citation><citation key="bib28"><journal_title>American Journal of Human Genetics</journal_title><author>Hammond</author><volume>77</volume><first_page>999</first_page><cYear>2005</cYear><article_title>Discriminating power of localized three-dimensional facial morphology</article_title></citation><citation key="bib29"><journal_title>Human Mutation</journal_title><author>Hammond</author><volume>33</volume><first_page>817</first_page><cYear>2012</cYear><article_title>Large-scale objective phenotyping of 3D facial morphology</article_title><doi>10.1002/humu.22054</doi></citation><citation key="bib30"><journal_title>Orthodontics &amp; Craniofacial Research</journal_title><author>Hart</author><volume>12</volume><first_page>212</first_page><cYear>2009</cYear><article_title>Genetic studies of craniofacial anomalies: clinical implications and applications</article_title><doi>10.1111/j.1601-6343.2009.01455.x</doi></citation><citation key="bib31"><journal_title>Human Mutation</journal_title><author>Hennekam</author><volume>33</volume><first_page>884</first_page><cYear>2012</cYear><article_title>Next-generation sequencing demands next-generation phenotyping</article_title><doi>10.1002/humu.22048</doi></citation><citation key="bib32"><journal_title>Biological Psychiatry</journal_title><author>Hennessy</author><volume>61</volume><first_page>1187</first_page><cYear>2007</cYear><article_title>Three-dimensional laser surface imaging and geometric morphometrics resolve frontonasal dysmorphology in schizophrenia</article_title><doi>10.1016/j.biopsych.2006.08.045</doi></citation><citation key="bib33"><journal_title>The Journal of Neuropsychiatry and Clinical Neurosciences</journal_title><author>Hennessy</author><volume>18</volume><first_page>73</first_page><cYear>2006</cYear><article_title>Facial shape and asymmetry by three-dimensional laser surface scanning covary with cognition in a sexually dimorphic manner</article_title><doi>10.1176/appi.neuropsych.18.1.73</doi></citation><citation key="bib34"><journal_title>Plastic and Reconstructive Surgery</journal_title><author>Hopper</author><volume>132</volume><first_page>129</first_page><cYear>2013</cYear><article_title>Normalizing facial ratios in apert syndrome patients with Le Fort II midface distraction and simultaneous zygomatic repositioning</article_title><doi>10.1097/PRS.0b013e318290fa8a</doi></citation><citation key="bib35"><journal_title>European Journal of Human Genetics</journal_title><author>Kleefstra</author><volume>19</volume><first_page>138</first_page><cYear>2011</cYear><article_title>Mitochondrial dysfunction and organic aciduria in five patients carrying mutations in the Ras-MAPK pathway</article_title><doi>10.1038/ejhg.2010.171</doi></citation><citation key="bib36"><journal_title>American Journal of Medical Genetics Part A</journal_title><author>Kratz</author><volume>149A</volume><first_page>1036</first_page><cYear>2009</cYear><article_title>Craniosynostosis in patients with Noonan syndrome caused by germline KRAS mutations</article_title><doi>10.1002/ajmg.a.32786</doi></citation><citation key="bib37"><journal_title>Journal of the American Statistical Association</journal_title><author>Kruskal</author><volume>47</volume><first_page>583</first_page><cYear>1952</cYear><article_title>Use of ranks in one-Criterion variance analysis</article_title><doi>10.1080/01621459.1952.10483441</doi></citation><citation key="bib38"><journal_title>Human Mutation</journal_title><author>Lepri</author><volume>32</volume><first_page>760</first_page><cYear>2011</cYear><article_title>SOS1 mutations in Noonan syndrome: molecular spectrum, structural insights on pathogenic effects, and genotype-phenotype correlations</article_title><doi>10.1002/humu.21492</doi></citation><citation key="bib39"><journal_title>European Journal of Human Genetics</journal_title><author>Loos</author><volume>11</volume><first_page>555</first_page><cYear>2003</cYear><article_title>Computer-based recognition of dysmorphic faces</article_title><doi>10.1038/sj.ejhg.5200997</doi></citation><citation key="bib40"><journal_title>Journal of Pediatric Hematology/oncology</journal_title><author>Makita</author><volume>29</volume><first_page>287</first_page><cYear>2007</cYear><article_title>Leukemia in Cardio-facio-cutaneous (CFC) syndrome: a patient with a germline mutation in BRAF proto-oncogene</article_title><doi>10.1097/MPH.0b013e3180547136</doi></citation><citation key="bib42"><journal_title>Journal of Medical Genetics</journal_title><author>Nystrom</author><volume>45</volume><first_page>500</first_page><cYear>2008</cYear><article_title>Noonan and cardio-facio-cutaneous syndromes: two clinically and genetically overlapping disorders</article_title><doi>10.1136/jmg.2008.057653</doi></citation><citation key="bib43"><volume_title>Orphanet Report Series</volume_title><author>Orphanet</author><cYear>2013</cYear><article_title>Prevalence of rare diseases: Bibliographic data</article_title></citation><citation key="bib44"><journal_title>Clinical Genetics</journal_title><author>Oti</author><volume>71</volume><first_page>1</first_page><cYear>2007</cYear><article_title>The modular nature of genetic diseases</article_title><doi>10.1111/j.1399-0004.2006.00708.x</doi></citation><citation key="bib45"><journal_title>International Journal of Computer Vision</journal_title><author>Ramnath</author><volume>76</volume><first_page>183</first_page><cYear>2008</cYear><article_title>Multi-view AAM fitting and construction</article_title><doi>10.1007/s11263-007-0050-3</doi></citation><citation key="bib46"><volume_title>GeneReviews</volume_title><author>Rauen</author><cYear>1993</cYear><article_title>Cardiofaciocutaneous syndrome</article_title></citation><citation key="bib47"><journal_title>American Journal of Medical Genetics Part A</journal_title><author>Rauen</author><volume>140</volume><first_page>1681</first_page><cYear>2006</cYear><article_title>Distinguishing Costello versus cardio-facio-cutaneous syndrome: BRAF mutations in patients with a Costello phenotype</article_title><doi>10.1002/ajmg.a.31315</doi></citation><citation key="bib48"><journal_title>Clinical Genetics</journal_title><author>Rauen</author><volume>71</volume><first_page>101</first_page><cYear>2007</cYear><article_title>HRAS and the Costello syndrome</article_title><doi>10.1111/j.1399-0004.2007.00743.x</doi></citation><citation key="bib49"><journal_title>Pediatric Research</journal_title><author>Rimoin</author><volume>56</volume><first_page>150</first_page><cYear>2004</cYear><article_title>A history of medical genetics in pediatrics</article_title><doi>10.1203/01.PDR.0000129659.32875.84</doi></citation><citation key="bib50"><journal_title>PLOS Genetics</journal_title><author>Rossin</author><volume>7</volume><first_page>e1001273</first_page><cYear>2011</cYear><article_title>Proteins encoded in genomic regions associated with immune-mediated disease physically interact and suggest underlying biology</article_title><doi>10.1371/journal.pgen.1001273</doi></citation><citation key="bib51"><journal_title>Clinical Genetics</journal_title><author>Schulz</author><volume>73</volume><first_page>62</first_page><cYear>2008</cYear><article_title>Mutation and phenotypic spectrum in patients with cardio-facio-cutaneous and Costello syndrome</article_title><doi>10.1111/j.1399-0004.2007.00931.x</doi></citation><citation key="bib52"><journal_title>American Journal of Human Genetics</journal_title><author>Schuurs-Hoeijmakers</author><volume>91</volume><first_page>1122</first_page><cYear>2012</cYear><article_title>Recurrent de novo mutations in PACS1 cause defective cranial-neural-crest migration and define a recognizable intellectual-disability syndrome</article_title><doi>10.1016/j.ajhg.2012.10.013</doi></citation><citation key="bib53"><journal_title>The British Journal of Dermatology</journal_title><author>Siegel</author><volume>164</volume><first_page>521</first_page><cYear>2011</cYear><article_title>Dermatological findings in 61 mutation-positive individuals with cardiofaciocutaneous syndrome</article_title><doi>10.1111/j.1365-2133.2010.10122.x</doi></citation><citation key="bib54"><journal_title>British Machine Vision Conference</journal_title><author>Simonyan</author><cYear>2013</cYear><article_title>Fisher Vector Faces in the Wild</article_title></citation><citation key="bib55"><journal_title>Clinical Dysmorphology</journal_title><author>Sotos</author><volume>21</volume><first_page>131</first_page><cYear>2012</cYear><article_title>Abraham Lincoln's marfanoid mother: the earliest known case of multiple endocrine neoplasia type 2B?</article_title><doi>10.1097/MCD.0b013e328353ae0c</doi></citation><citation key="bib56"><journal_title>Pediatrics</journal_title><author>Suttie</author><volume>131</volume><first_page>e779</first_page><cYear>2013</cYear><article_title>Facial dysmorphism across the fetal alcohol spectrum</article_title><doi>10.1542/peds.2012-1371</doi></citation><citation key="bib57"><journal_title>Expert Reviews in Molecular Medicine</journal_title><author>Tidyman</author><volume>10</volume><first_page>e37</first_page><cYear>2008</cYear><article_title>Noonan, Costello and cardio-facio-cutaneous syndromes: dysregulation of the Ras-MAPK pathway</article_title><doi>10.1017/S1462399408000902</doi></citation><citation key="bib58"><journal_title>Nature Genetics</journal_title><author>Twigg</author><volume>45</volume><first_page>308</first_page><cYear>2013</cYear><article_title>Reduced dosage of ERF causes complex craniosynostosis in humans and mice and links ERK1/2 signaling to regulation of osteogenesis</article_title><doi>10.1038/ng.2539</doi></citation><citation key="bib59"><author>Viola</author><cYear>2001</cYear><article_title>Rapid object detection using a boosted cascade of simple features. Computer Vision and Pattern Recognition, 2001. CVPR 2001. Proceedings of the 2001 IEEE Computer Society Conference on, 2001</article_title></citation><citation key="bib60"><journal_title>European Journal of Medical Genetics</journal_title><author>Vollmar</author><volume>51</volume><first_page>44</first_page><cYear>2008</cYear><article_title>Impact of geometry and viewing angle on classification accuracy of 2D based analysis of dysmorphic faces</article_title><doi>10.1016/j.ejmg.2007.10.002</doi></citation><citation key="bib61"><journal_title>Journal of Machine Learning Research</journal_title><author>Weinberger</author><volume>10</volume><first_page>207</first_page><cYear>2009</cYear><article_title>Distance metric learning for large margin nearest neighbor classification</article_title></citation><citation key="bib62"><journal_title>Nature Reviews Genetics</journal_title><author>Weischenfeldt</author><volume>14</volume><first_page>125</first_page><cYear>2013</cYear><article_title>Phenotypic impact of genomic structural variation: insights from and for human disease</article_title><doi>10.1038/nrg3373</doi></citation><citation key="bib63"><journal_title>Archives of Disease in Childhood</journal_title><author>Wright</author><volume>95</volume><first_page>724</first_page><cYear>2010</cYear><article_title>RAS-MAPK pathway disorders: important causes of congenital heart disease, feeding difficulties, developmental delay and short stature</article_title><doi>10.1136/adc.2009.160069</doi></citation><citation key="bib64"><journal_title>Human Mutation</journal_title><author>Zampino</author><volume>28</volume><first_page>265</first_page><cYear>2007</cYear><article_title>Diversity, parental germline origin, and phenotypic spectrum of de novo HRAS missense changes in Costello syndrome</article_title><doi>10.1002/humu.20431</doi></citation><citation key="bib65"><journal_title>Hormone Research</journal_title><author>Zenker</author><volume>72</volume><first_page>57</first_page><cYear>2009</cYear><article_title>Genetic and pathogenetic aspects of Noonan syndrome and related disorders</article_title><doi>10.1159/000243782</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02020.001</doi><resource>https://elifesciences.org/articles/02020#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02020.002</doi><resource>https://elifesciences.org/articles/02020#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Overview of the computational approach and average faces of syndromes.</title><subtitle>(A) A photo is automatically analyzed to detect faces and feature points are placed using computer vision algorithms. Facial feature annotation points delineate the supra-orbital ridge (8 points), the eyes (mid points of the eyelids and eye canthi, 8 points), nose (nasion, tip, ala, subnasale and outer nares, 7 points), mouth (vermilion border lateral and vertical midpoints, 6 points) and the jaw (zygoma mandibular border, gonion, mental protrubance and chin midpoint, 7 points). Shape and Appearance feature vectors are then extracted based on feature points and these determine the photo's location in Clinical Face Phenotype Space (further details on feature points in Figure 1—figure supplement 1). This location is then analyzed in the context of existing points in Clinical Face Phenotype Space to extract phenotype similarities and diagnosis hypotheses (further details on Clinical Face Phenotype Space with simulation examples in Figure 1—figure supplement 2). (B) Average faces of syndromes in the database constructed using AAM models (‘Materials and methods’) and number of individuals which each average face represents. See online version of this manuscript for animated morphing images that show facial features differing between controls and syndromes (Figure 2).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.003</doi><resource>https://elifesciences.org/articles/02020#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 1.</title><subtitle>(A) The 36 facial feature points annotated by the automatic image analysis algorithm. Supra-orbital ridge (8 points), the eyes (mid points of the eyelids and eye canthi, 8 points), nose (nasion, tip, ala, subnasale and outer nares, 7 points), mouth (vermilion border lateral and vertical midpoints, 6 points), and the jaw (zygoma mandibular border, gonion, mental protrubance and chin midpoint, 7 points). (B) The annotation accuracies relative to the manually annotated ground truth of each of the computer vision modules. Points 1–8 refer to the supra-orbital ridge, points 30–36 refer to the jaw points. Accuracies for the points annotated by the modules FLA, improved FLA and CoE are shown for each syndrome and control groups. Accuracies are shown as the average error relative to the width of an eye.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.004</doi><resource>https://elifesciences.org/articles/02020/figures#fig1s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 2. Phenotypic vs spurious feature variation in Clinical Face Phenotype Space using simulated faces.</title><subtitle>Simulated 3D faces were used to visualize the influence of spurious variation in raw feature space and Clinical Face Phenotype Space. (A) 100 faces with controlled phenotype, lighting, and rotation variation were rendered. (B) Visualization of a population of simulated faces in the first two Multi-Dimensional Scaling (MDS) modes. Face clustering in raw feature space and Clinical Face Phenotype Space colored by lighting, rotation, and face phenotype, respectively. In the raw feature space lighting is the dominating clustering factor, in Clinical Face Phenotype Space phenotype underlies the primary clustering. (C) The first 16 modes of PCA decomposition of the raw feature vectors and in the Clinical Face Phenotype Space colored by lighting and rotation of the simulated faces. In the raw feature space, lighting, and rotation variation are encoded in the 2nd and 1st modes, indicating that clustering is dominated by spurious variation. In the Clinical Face Phenotype Space, lighting is represented in the 9th mode, whereas rotation is no longer represented in the first 16 modes. This shows that the Clinical Face Phenotype Space transformation reduces the influence of spurious variation on clustering of phenotypes.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.005</doi><resource>https://elifesciences.org/articles/02020/figures#fig1s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 1.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02020.006</doi><resource>https://elifesciences.org/articles/02020#tbl1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Animated morphs of average faces from controls to syndromes.</title><subtitle>(A) Angelman, (B) Apert, (C) Cornelia de Lange, (D) Down, (E) Fragile X, (F) Progeria, (G) Treacher-Collins, (H) Williams-Beuren. Delineation of syndrome gestalt relative to controls with distortion graphs in Figure 2—figure supplement 1.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.008</doi><resource>https://elifesciences.org/articles/02020#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. Distortion graphs representing the characteristic deformation of syndrome faces relative to the average control face.</title><subtitle>Each line reflects whether the distance is extended or contracted compared with the control face. White—the distance is similar to controls, blue—shorter relative to controls, and red—extended in patients relative to controls.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.009</doi><resource>https://elifesciences.org/articles/02020/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Clinical Face Phenotype Space enhances the separation of different dysmorphic syndromes.</title><subtitle>The graph shows a two dimensional representation of the full Clinical Face Phenotype Space, with links to the 10 nearest neighbors of each photo (circle) and photos placed with force-directed graphing. The Clustering Improvement Factor (CIF, fold better clustering than random expectation) estimate for each of the syndromes is shown along the periphery.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.010</doi><resource>https://elifesciences.org/articles/02020#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Clinical Face Phenotype Space is generalizable to dysmorphic syndromes that are absent from a training set.</title><subtitle>(A) Clustering Improvement Factor (CIF) estimates are plotted vs the number of individuals per syndrome grouping in the Gorlin collection or patients with similar genetic variant diagnoses. As expected, the stochastic variance in CIF is inversely proportional to the number of individuals available for sampling. The median CIF across all groups is 27.6-fold over what is expected by clustering syndromes randomly. That is to say, the CIF of a randomly placed set is 1. The maximum CIF is fixed by the total number of images in the database and by the cardinality of a syndrome set: the theoretical maximal CIF upper bound is plotted as a red dotted line. The CIF for the minimum and maximum, Cutislaxa syndrome and Otodental syndrome, were 1.0 and 700.0 respectively. (B) Average probabilistic classification accuracies of each individual face placed in Clinical Face Phenotype Space (class prioritization by 20 nearest neighbors weighted by prevalence in the database). The 8 initial syndromes used to train Clinical Face Phenotype Space are shown in color. For syndromes with fewer than 50 examples, accuracies were averaged across all syndromes binned by data set size (i.e., the average accuracy is shown for syndromes with 2–5, 6–10, 11–25, and 26–50 images in the database, Supplementary file 1). Classification accuracies increase proportional to the number of individuals with the syndrome present in the database. Accuracies using support vector machines with binary and forced choice classifications are shown in Figure 4—figure supplement 1 and Figure 4—figure supplement 2. A simulation example of probabilistic querying of Clinical Face Phenotype Space is shown in Figure 4—figure supplement 3.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.011</doi><resource>https://elifesciences.org/articles/02020#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 1. SVM binary classification accuracies among the 8 syndromes in Table 1.</title><subtitle>SVM classifier accuracies when tuned for equal false positive and false negative error rates.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.012</doi><resource>https://elifesciences.org/articles/02020/figures#fig4s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 2. SVM forced choice classification accuracies among the 8 syndromes in Table 1.</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.013</doi><resource>https://elifesciences.org/articles/02020/figures#fig4s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 3. Simulated example illustrating the Clustering Improvement Factor.</title><subtitle>A random scattering of 100 points in 2 dimensions is used as a background set (black circles with white fill). The 20 red plus symbols (within the red shaded area) are a random set of points lying within the same limits as the background set and have a CIF of 0.9. This is the actual degree of clustering of the red points with respect to the expectation of clustering them with 95% confidence (E(r) = 5.6). The filled green circles (within the green shaded area) are the red points shifted by +0.5 units in each dimension and have a CIF of 2.7. The black points (within the gray shaded area) are the red plus symbol positions scaled by 0.5 and then shifted by +1.5 units in dimension 1. The black points are non-overlapping with the background and represent the maximal CIF (of 5.6) in this example.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.014</doi><resource>https://elifesciences.org/articles/02020/figures#fig4s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 4. Simulated example of probabilistic querying of Clinical Face Phenotype Space.</title><subtitle>(A) Visualization of a population of simulated faces in the first two Multi-Dimensional Scaling (MDS) modes. 7 classes of points (simulated 'syndrome groups') are shown with different distributions and variances. A central 'query' face is indicated by the boxed cross. The 20 nearest neighbors of the query are encircled with a black border. (B) Inset bar graph shows diagnosis hypothesis ranked by class priority. The class priority ranking weights the dispersion and prevalence (spread and number) of a class in the Clinical Face Phenotype Space with the nearest neighbors to assign the most probable diagnosis hypotheses. In the example, the ranked diagnosis estimates of the query point would be class 7, then class 6, and thirdly class 4. The scatter plot shows the individual similarity p0p1 estimates, reflecting their relative closeness in the space as compared to local neighborhood, for the 20 nearest neighbors of the query. The first nearest neighbor is estimated to be 2.6-fold closer to the query than the average based on the local density of neighbors. The dotted line indicates the average relative distance between points among the 20 nearest neighbors. (C) Inset bar graph shows the number of neighbors of the query per class. A scatterplot of dispersion vs cardinality, i.e. relative spread of points and what proportion of the total number of points belong to that class in the simulated space. Plots (B) and (C) allow objective assessment of the distribution of points shown in (A), and aid the interpretation of classification confidence.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.015</doi><resource>https://elifesciences.org/articles/02020/figures#fig4s4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Clinical Face Phenotype Space recapitulates features of functional gene links between syndromes.</title><subtitle>Protein–protein interaction distances of 1–3 for genetically characterized syndromes are associated with significantly shorter Euclidean distance (arbitrary units) between syndromes in Clinical Face Phenotype Space as compared to syndromes with distance 4 or no known interaction distance (shown in orange) (Kruskal–Wallis tests with Bonferroni corrected p-values indicated as *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001). The Spearman correlation across all distances was r = 0.09, p&lt;0.001. The numbers of pairwise syndrome comparisons underlying each of the interaction distances are listed within the respective boxes.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02020.016</doi><resource>https://elifesciences.org/articles/02020#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6. Class priority of diagnostic classifications for images.</title><subtitle>The full computer vision algorithm and Clinical Face Phenotype Space analysis procedure with diagnostic hypothesis generation exemplified by: (A) a patient (Ferrero et al., 2007) with Williams-Beuren. (B) Abraham Lincoln. The former US President is thought to have had a marfanoid disorder, if not Marfan syndrome (Gordon, 1962; Sotos, 2012). Bar graphs show class prioritization of diagnostic hypotheses determined by 20 nearest neighbors weighted by prevalence in the database. As expected, the classification of Marfan is not successfully assigned in the first instance as there were only 18 faces of individuals with Marfan in the database (making this an example of a difficult case with the current database). However, the seventh suggestion is Marfan, despite this being among 90 different syndromes and 2754 faces.</subtitle></titles><format mime_type="image/tiff"/><ai:program name="AccessIndicators"><ai:license_ref>https://submit.elifesciences.org/html/elife_author_instructions.html#policies</ai:license_ref></ai:program><doi_data><doi>10.7554/eLife.02020.017</doi><resource>https://elifesciences.org/articles/02020#fig6</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 1.</title><subtitle>Tinyurl links to sources for the database. Prefix the 7 characters with http://tinyurl.com/. Links are expected to decay with time; the full dataset will be released to researchers at the discretion of a Data Access Committee.</subtitle></titles><format mime_type="application/msword"/><doi_data><doi>10.7554/eLife.02020.007</doi><resource>https://elifesciences.org/articles/02020/figures#SD1-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02020.018</doi><resource>https://elifesciences.org/articles/02020#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02020.019</doi><resource>https://elifesciences.org/articles/02020#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-02020-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>06</month>
+					<day>24</day>
+					<year>2014</year>
+				</publication_date>
+				<journal_volume>
+					<volume>3</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Diagnostically relevant facial gestalt information from ordinary photos</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Quentin</given_name>
+						<surname>Ferry</surname>
+						<affiliation>Department of Engineering Science, University of Oxford, Oxford, United Kingdom</affiliation>
+						<affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Julia</given_name>
+						<surname>Steinberg</surname>
+						<affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation>
+						<affiliation>The Wellcome Trust Centre for Human Genetics, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Caleb</given_name>
+						<surname>Webber</surname>
+						<affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>David R</given_name>
+						<surname>FitzPatrick</surname>
+						<affiliation>Medical Research Council Human Genetics Unit, Institute of Genetics and Molecular Medicine, Edinburgh, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Chris P</given_name>
+						<surname>Ponting</surname>
+						<affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Andrew</given_name>
+						<surname>Zisserman</surname>
+						<affiliation>Department of Engineering Science, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Christoffer</given_name>
+						<surname>Nellåker</surname>
+						<affiliation>Medical Research Council Functional Genomics Unit, Department of Physiology, Anatomy and Genetics, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Craniofacial characteristics are highly informative for clinical geneticists when diagnosing genetic diseases. As a first step towards the high-throughput diagnosis of ultra-rare developmental diseases we introduce an automatic approach that implements recent developments in computer vision. This algorithm extracts phenotypic information from ordinary non-clinical photographs and, using machine learning, models human facial dysmorphisms in a multidimensional 'Clinical Face Phenotype Space'. The space locates patients in the context of known syndromes and thereby facilitates the generation of diagnostic hypotheses. Consequently, the approach will aid clinicians by greatly narrowing (by 27.6-fold) the search space of potential diagnoses for patients with suspected developmental disorders. Furthermore, this Clinical Face Phenotype Space allows the clustering of patients by phenotype even when no known syndrome diagnosis exists, thereby aiding disease identification. We demonstrate that this approach provides a novel method for inferring causative genetic variants from clinical sequencing data through functional genetic pathway comparisons.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>Rare genetic disorders affect around 8% of people, many of whom live with symptoms that greatly reduce their quality of life. Genetic diagnoses can provide doctors with information that cannot be obtained by assessing clinical symptoms, and this allows them to select more suitable treatments for patients. However, only a minority of patients currently receive a genetic diagnosis.</jats:p>
+					<jats:p>Alterations in the face and skull are present in 30–40% of genetic disorders, and these alterations can help doctors to identify certain disorders, such as Down’s syndrome or Fragile X. Extending this approach, Ferry et al. trained a computer-based model to identify the patterns of facial abnormalities associated with different genetic disorders. The model compares data extracted from a photograph of the patient’s face with data on the facial characteristics of 91 disorders, and then provides a list of the most likely diagnoses for that individual. The model used 36 points to describe the space, including 7 for the jaw, 6 for the mouth, 7 for the nose, 8 for the eyes and 8 for the brow.</jats:p>
+					<jats:p>This approach of Ferry et al. has three advantages. First, it provides clinicians with information that can aid their diagnosis of a rare genetic disorder. Second, it can narrow down the range of possible disorders for patients who have the same ultra-rare disorder, even if that disorder is currently unknown. Third, it can identify groups of patients who can have their genomes sequenced in order to identify the genetic variants that are associated with specific disorders.</jats:p>
+					<jats:p>The work by Ferry et al. lays out the basic principles for automated approaches to analyze the shape of the face and skull. The next challenge is to integrate photos with genetic data for use in clinical settings.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>06</month>
+					<day>24</day>
+					<year>2014</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e02020</item_number>
+					<identifier id_type="doi">10.7554/eLife.02020</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Medical Research Council (MRC)
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							European Research Council
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000781</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">228180 VisRec</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Oxford Biomedical Research Centre</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Medical Research Council (MRC)
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Centenary Award</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.02020</doi>
+					<resource>https://elifesciences.org/articles/02020</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/02020/elife-02020-v1.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02020/elife-02020-v1.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>Nature</journal_title>
+						<author>Abecasis</author>
+						<volume>491</volume>
+						<first_page>56</first_page>
+						<cYear>2012</cYear>
+						<article_title>An integrated map of genetic variation from 1,092 human genomes</article_title>
+						<doi>10.1038/nature11632</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Molecular Autism</journal_title>
+						<author>Aldridge</author>
+						<volume>2</volume>
+						<first_page>15</first_page>
+						<cYear>2011</cYear>
+						<article_title>Facial phenotypes in subgroups of prepubertal boys with autism spectrum disorders are correlated with clinical phenotypes</article_title>
+						<doi>10.1186/2040-2392-2-15</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>American Journal of Medical Genetics</journal_title>
+						<author>Allanson</author>
+						<volume>152A</volume>
+						<first_page>1960</first_page>
+						<cYear>2010</cYear>
+						<article_title>The face of Noonan syndrome: does phenotype predict genotype</article_title>
+						<doi>10.1002/ajmg.a.33518</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Baird</author>
+						<volume>42</volume>
+						<first_page>677</first_page>
+						<cYear>1988</cYear>
+						<article_title>Genetic disorders in children and young adults: a population study</article_title>
+					</citation>
+					<citation key="bib5">
+						<journal_title>AAAI Publications, Third International AAAI Conference on Weblogs and Social Media</journal_title>
+						<author>Bastian</author>
+						<cYear>2009</cYear>
+						<article_title>Gephi: An open source software for exploring and manipulating networks</article_title>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Human Mutation</journal_title>
+						<author>Baynam</author>
+						<volume>34</volume>
+						<first_page>14</first_page>
+						<cYear>2013</cYear>
+						<article_title>The facial evolution: looking backward and moving forward</article_title>
+						<doi>10.1002/humu.22219</doi>
+					</citation>
+					<citation key="bib7">
+						<author>Belhumeur</author>
+						<first_page>545</first_page>
+						<cYear>2011</cYear>
+						<article_title>Localizing parts of faces using a consensus of exemplars. Proceedings of the 2011 IEEE Conference on Computer Vision and Pattern Recognition</article_title>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Journal of Human Genetics</journal_title>
+						<author>Bertola</author>
+						<volume>52</volume>
+						<first_page>521</first_page>
+						<cYear>2007</cYear>
+						<article_title>Further evidence of genetic heterogeneity in Costello syndrome: involvement of the KRAS gene</article_title>
+						<doi>10.1007/s10038-007-0146-1</doi>
+					</citation>
+					<citation key="bib9">
+						<author>Blanz</author>
+						<first_page>617</first_page>
+						<cYear>2006</cYear>
+						<article_title>Face recognition based on a 3D Morphable model. Proceedings Of the 7th International Conference of Automatic Face and Gesture Recognition</article_title>
+					</citation>
+					<citation key="bib10">
+						<journal_title>American Journal of Medical Genetics</journal_title>
+						<author>Boehringer</author>
+						<volume>155A</volume>
+						<first_page>2161</first_page>
+						<cYear>2011</cYear>
+						<article_title>Automated syndrome detection in a set of clinical facial photographs</article_title>
+						<doi>10.1002/ajmg.a.34157</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>European Journal of Human Genetics</journal_title>
+						<author>Boehringer</author>
+						<volume>14</volume>
+						<first_page>1082</first_page>
+						<cYear>2006</cYear>
+						<article_title>Syndrome identification based on 2D analysis software</article_title>
+						<doi>10.1038/sj.ejhg.5201673</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Studi in Onore del Professore Salvatore Ortu Carboni</journal_title>
+						<author>Bonferroni</author>
+						<cYear>1935</cYear>
+						<article_title>Il calcolo delle assicurazioni su gruppi di teste</article_title>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Pubblicazioni del R Istituto Superiore di Scienze Economiche e Commerciali di Firenze</journal_title>
+						<author>Bonferroni</author>
+						<first_page>3</first_page>
+						<cYear>1936</cYear>
+						<article_title>Teoria statistica delle classi e calcolo delle probabilità</article_title>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Dr. Dobb's Journal of Software Tools</journal_title>
+						<author>Bradski</author>
+						<cYear>2000</cYear>
+						<article_title>The OpenCV Library</article_title>
+					</citation>
+					<citation key="bib15">
+						<journal_title>The American Journal of Psychiatry</journal_title>
+						<author>Buckley</author>
+						<volume>162</volume>
+						<first_page>606</first_page>
+						<cYear>2005</cYear>
+						<article_title>A three-dimensional morphometric study of craniofacial shape in schizophrenia</article_title>
+						<doi>10.1176/appi.ajp.162.3.606</doi>
+					</citation>
+					<citation key="bib16">
+						<author>Cootes</author>
+						<first_page>484</first_page>
+						<cYear>1998</cYear>
+						<article_title>Active appearance models. IEEE Transactions on Pattern Analysis and Machine Intelligence</article_title>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Cordeddu</author>
+						<volume>41</volume>
+						<first_page>1022</first_page>
+						<cYear>2009</cYear>
+						<article_title>Mutation of SHOC2 promotes aberrant protein N-myristoylation and causes Noonan-like syndrome with loose anagen hair</article_title>
+						<doi>10.1038/ng.425</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Computer Methods and Programs in Biomedicine</journal_title>
+						<author>Dalal</author>
+						<volume>85</volume>
+						<first_page>165</first_page>
+						<cYear>2007</cYear>
+						<article_title>Morphometric analysis of face in dysmorphology</article_title>
+						<doi>10.1016/j.cmpb.2006.10.005</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>The New England Journal of Medicine</journal_title>
+						<author>de Ligt</author>
+						<volume>367</volume>
+						<first_page>1921</first_page>
+						<cYear>2012</cYear>
+						<article_title>Diagnostic exome sequencing in persons with severe intellectual disability</article_title>
+						<doi>10.1056/NEJMoa1206524</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Numerische Mathematik</journal_title>
+						<author>Dijkstra</author>
+						<volume>1</volume>
+						<first_page>269</first_page>
+						<cYear>1959</cYear>
+						<article_title>A note on two problems in connexion with graphs</article_title>
+						<doi>10.1007/BF01386390</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Image and Vision Computing</journal_title>
+						<author>Everingham</author>
+						<volume>27</volume>
+						<cYear>2009</cYear>
+						<article_title>Taking the bite out of automatic naming of characters in TV video</article_title>
+					</citation>
+					<citation key="bib22">
+						<journal_title>European Journal of Medical Genetics</journal_title>
+						<author>Ferrero</author>
+						<volume>50</volume>
+						<first_page>327</first_page>
+						<cYear>2007</cYear>
+						<article_title>Presenting phenotype and clinical evaluation in a cohort of 22 Williams-Beuren syndrome patients</article_title>
+						<doi>10.1016/j.ejmg.2007.05.005</doi>
+					</citation>
+					<citation key="bib23">
+						<journal_title>IEEE Transactions on Computer</journal_title>
+						<author>Fischler</author>
+						<first_page>67</first_page>
+						<cYear>1973</cYear>
+						<article_title>The representation and matching of pictorial structures</article_title>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Bioinformatics</journal_title>
+						<author>Goodstadt</author>
+						<volume>26</volume>
+						<first_page>2778</first_page>
+						<cYear>2010</cYear>
+						<article_title>Ruffus: a lightweight Python library for computational pipelines</article_title>
+						<doi>10.1093/bioinformatics/btq524</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>The Journal of the Kentucky Medical Association</journal_title>
+						<author>Gordon</author>
+						<volume>60</volume>
+						<first_page>249</first_page>
+						<cYear>1962</cYear>
+						<article_title>Abraham Lincoln–a medical appraisal</article_title>
+					</citation>
+					<citation key="bib26">
+						<journal_title>American Journal of Medical Genetics Part A</journal_title>
+						<author>Gripp</author>
+						<volume>143A</volume>
+						<first_page>1472</first_page>
+						<cYear>2007</cYear>
+						<article_title>Further delineation of the phenotype resulting from BRAF or MEK1 germline mutations helps differentiate cardio-facio-cutaneous syndrome from Costello syndrome</article_title>
+						<doi>10.1002/ajmg.a.31815</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Archives of Disease in Childhood</journal_title>
+						<author>Hammond</author>
+						<volume>92</volume>
+						<first_page>1120</first_page>
+						<cYear>2007</cYear>
+						<article_title>The use of 3D face shape modelling in dysmorphology</article_title>
+						<doi>10.1136/adc.2006.103507</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Hammond</author>
+						<volume>77</volume>
+						<first_page>999</first_page>
+						<cYear>2005</cYear>
+						<article_title>Discriminating power of localized three-dimensional facial morphology</article_title>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Human Mutation</journal_title>
+						<author>Hammond</author>
+						<volume>33</volume>
+						<first_page>817</first_page>
+						<cYear>2012</cYear>
+						<article_title>Large-scale objective phenotyping of 3D facial morphology</article_title>
+						<doi>10.1002/humu.22054</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Orthodontics &amp; Craniofacial Research</journal_title>
+						<author>Hart</author>
+						<volume>12</volume>
+						<first_page>212</first_page>
+						<cYear>2009</cYear>
+						<article_title>Genetic studies of craniofacial anomalies: clinical implications and applications</article_title>
+						<doi>10.1111/j.1601-6343.2009.01455.x</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Human Mutation</journal_title>
+						<author>Hennekam</author>
+						<volume>33</volume>
+						<first_page>884</first_page>
+						<cYear>2012</cYear>
+						<article_title>Next-generation sequencing demands next-generation phenotyping</article_title>
+						<doi>10.1002/humu.22048</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Biological Psychiatry</journal_title>
+						<author>Hennessy</author>
+						<volume>61</volume>
+						<first_page>1187</first_page>
+						<cYear>2007</cYear>
+						<article_title>Three-dimensional laser surface imaging and geometric morphometrics resolve frontonasal dysmorphology in schizophrenia</article_title>
+						<doi>10.1016/j.biopsych.2006.08.045</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>The Journal of Neuropsychiatry and Clinical Neurosciences</journal_title>
+						<author>Hennessy</author>
+						<volume>18</volume>
+						<first_page>73</first_page>
+						<cYear>2006</cYear>
+						<article_title>Facial shape and asymmetry by three-dimensional laser surface scanning covary with cognition in a sexually dimorphic manner</article_title>
+						<doi>10.1176/appi.neuropsych.18.1.73</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>Plastic and Reconstructive Surgery</journal_title>
+						<author>Hopper</author>
+						<volume>132</volume>
+						<first_page>129</first_page>
+						<cYear>2013</cYear>
+						<article_title>Normalizing facial ratios in apert syndrome patients with Le Fort II midface distraction and simultaneous zygomatic repositioning</article_title>
+						<doi>10.1097/PRS.0b013e318290fa8a</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>European Journal of Human Genetics</journal_title>
+						<author>Kleefstra</author>
+						<volume>19</volume>
+						<first_page>138</first_page>
+						<cYear>2011</cYear>
+						<article_title>Mitochondrial dysfunction and organic aciduria in five patients carrying mutations in the Ras-MAPK pathway</article_title>
+						<doi>10.1038/ejhg.2010.171</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>American Journal of Medical Genetics Part A</journal_title>
+						<author>Kratz</author>
+						<volume>149A</volume>
+						<first_page>1036</first_page>
+						<cYear>2009</cYear>
+						<article_title>Craniosynostosis in patients with Noonan syndrome caused by germline KRAS mutations</article_title>
+						<doi>10.1002/ajmg.a.32786</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Journal of the American Statistical Association</journal_title>
+						<author>Kruskal</author>
+						<volume>47</volume>
+						<first_page>583</first_page>
+						<cYear>1952</cYear>
+						<article_title>Use of ranks in one-Criterion variance analysis</article_title>
+						<doi>10.1080/01621459.1952.10483441</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Human Mutation</journal_title>
+						<author>Lepri</author>
+						<volume>32</volume>
+						<first_page>760</first_page>
+						<cYear>2011</cYear>
+						<article_title>SOS1 mutations in Noonan syndrome: molecular spectrum, structural insights on pathogenic effects, and genotype-phenotype correlations</article_title>
+						<doi>10.1002/humu.21492</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>European Journal of Human Genetics</journal_title>
+						<author>Loos</author>
+						<volume>11</volume>
+						<first_page>555</first_page>
+						<cYear>2003</cYear>
+						<article_title>Computer-based recognition of dysmorphic faces</article_title>
+						<doi>10.1038/sj.ejhg.5200997</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Journal of Pediatric Hematology/oncology</journal_title>
+						<author>Makita</author>
+						<volume>29</volume>
+						<first_page>287</first_page>
+						<cYear>2007</cYear>
+						<article_title>Leukemia in Cardio-facio-cutaneous (CFC) syndrome: a patient with a germline mutation in BRAF proto-oncogene</article_title>
+						<doi>10.1097/MPH.0b013e3180547136</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Journal of Medical Genetics</journal_title>
+						<author>Nystrom</author>
+						<volume>45</volume>
+						<first_page>500</first_page>
+						<cYear>2008</cYear>
+						<article_title>Noonan and cardio-facio-cutaneous syndromes: two clinically and genetically overlapping disorders</article_title>
+						<doi>10.1136/jmg.2008.057653</doi>
+					</citation>
+					<citation key="bib43">
+						<volume_title>Orphanet Report Series</volume_title>
+						<author>Orphanet</author>
+						<cYear>2013</cYear>
+						<article_title>Prevalence of rare diseases: Bibliographic data</article_title>
+					</citation>
+					<citation key="bib44">
+						<journal_title>Clinical Genetics</journal_title>
+						<author>Oti</author>
+						<volume>71</volume>
+						<first_page>1</first_page>
+						<cYear>2007</cYear>
+						<article_title>The modular nature of genetic diseases</article_title>
+						<doi>10.1111/j.1399-0004.2006.00708.x</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>International Journal of Computer Vision</journal_title>
+						<author>Ramnath</author>
+						<volume>76</volume>
+						<first_page>183</first_page>
+						<cYear>2008</cYear>
+						<article_title>Multi-view AAM fitting and construction</article_title>
+						<doi>10.1007/s11263-007-0050-3</doi>
+					</citation>
+					<citation key="bib46">
+						<volume_title>GeneReviews</volume_title>
+						<author>Rauen</author>
+						<cYear>1993</cYear>
+						<article_title>Cardiofaciocutaneous syndrome</article_title>
+					</citation>
+					<citation key="bib47">
+						<journal_title>American Journal of Medical Genetics Part A</journal_title>
+						<author>Rauen</author>
+						<volume>140</volume>
+						<first_page>1681</first_page>
+						<cYear>2006</cYear>
+						<article_title>Distinguishing Costello versus cardio-facio-cutaneous syndrome: BRAF mutations in patients with a Costello phenotype</article_title>
+						<doi>10.1002/ajmg.a.31315</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Clinical Genetics</journal_title>
+						<author>Rauen</author>
+						<volume>71</volume>
+						<first_page>101</first_page>
+						<cYear>2007</cYear>
+						<article_title>HRAS and the Costello syndrome</article_title>
+						<doi>10.1111/j.1399-0004.2007.00743.x</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Pediatric Research</journal_title>
+						<author>Rimoin</author>
+						<volume>56</volume>
+						<first_page>150</first_page>
+						<cYear>2004</cYear>
+						<article_title>A history of medical genetics in pediatrics</article_title>
+						<doi>10.1203/01.PDR.0000129659.32875.84</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>Rossin</author>
+						<volume>7</volume>
+						<first_page>e1001273</first_page>
+						<cYear>2011</cYear>
+						<article_title>Proteins encoded in genomic regions associated with immune-mediated disease physically interact and suggest underlying biology</article_title>
+						<doi>10.1371/journal.pgen.1001273</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Clinical Genetics</journal_title>
+						<author>Schulz</author>
+						<volume>73</volume>
+						<first_page>62</first_page>
+						<cYear>2008</cYear>
+						<article_title>Mutation and phenotypic spectrum in patients with cardio-facio-cutaneous and Costello syndrome</article_title>
+						<doi>10.1111/j.1399-0004.2007.00931.x</doi>
+					</citation>
+					<citation key="bib52">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Schuurs-Hoeijmakers</author>
+						<volume>91</volume>
+						<first_page>1122</first_page>
+						<cYear>2012</cYear>
+						<article_title>Recurrent de novo mutations in PACS1 cause defective cranial-neural-crest migration and define a recognizable intellectual-disability syndrome</article_title>
+						<doi>10.1016/j.ajhg.2012.10.013</doi>
+					</citation>
+					<citation key="bib53">
+						<journal_title>The British Journal of Dermatology</journal_title>
+						<author>Siegel</author>
+						<volume>164</volume>
+						<first_page>521</first_page>
+						<cYear>2011</cYear>
+						<article_title>Dermatological findings in 61 mutation-positive individuals with cardiofaciocutaneous syndrome</article_title>
+						<doi>10.1111/j.1365-2133.2010.10122.x</doi>
+					</citation>
+					<citation key="bib54">
+						<journal_title>British Machine Vision Conference</journal_title>
+						<author>Simonyan</author>
+						<cYear>2013</cYear>
+						<article_title>Fisher Vector Faces in the Wild</article_title>
+					</citation>
+					<citation key="bib55">
+						<journal_title>Clinical Dysmorphology</journal_title>
+						<author>Sotos</author>
+						<volume>21</volume>
+						<first_page>131</first_page>
+						<cYear>2012</cYear>
+						<article_title>Abraham Lincoln's marfanoid mother: the earliest known case of multiple endocrine neoplasia type 2B?</article_title>
+						<doi>10.1097/MCD.0b013e328353ae0c</doi>
+					</citation>
+					<citation key="bib56">
+						<journal_title>Pediatrics</journal_title>
+						<author>Suttie</author>
+						<volume>131</volume>
+						<first_page>e779</first_page>
+						<cYear>2013</cYear>
+						<article_title>Facial dysmorphism across the fetal alcohol spectrum</article_title>
+						<doi>10.1542/peds.2012-1371</doi>
+					</citation>
+					<citation key="bib57">
+						<journal_title>Expert Reviews in Molecular Medicine</journal_title>
+						<author>Tidyman</author>
+						<volume>10</volume>
+						<first_page>e37</first_page>
+						<cYear>2008</cYear>
+						<article_title>Noonan, Costello and cardio-facio-cutaneous syndromes: dysregulation of the Ras-MAPK pathway</article_title>
+						<doi>10.1017/S1462399408000902</doi>
+					</citation>
+					<citation key="bib58">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Twigg</author>
+						<volume>45</volume>
+						<first_page>308</first_page>
+						<cYear>2013</cYear>
+						<article_title>Reduced dosage of ERF causes complex craniosynostosis in humans and mice and links ERK1/2 signaling to regulation of osteogenesis</article_title>
+						<doi>10.1038/ng.2539</doi>
+					</citation>
+					<citation key="bib59">
+						<author>Viola</author>
+						<cYear>2001</cYear>
+						<article_title>Rapid object detection using a boosted cascade of simple features. Computer Vision and Pattern Recognition, 2001. CVPR 2001. Proceedings of the 2001 IEEE Computer Society Conference on, 2001</article_title>
+					</citation>
+					<citation key="bib60">
+						<journal_title>European Journal of Medical Genetics</journal_title>
+						<author>Vollmar</author>
+						<volume>51</volume>
+						<first_page>44</first_page>
+						<cYear>2008</cYear>
+						<article_title>Impact of geometry and viewing angle on classification accuracy of 2D based analysis of dysmorphic faces</article_title>
+						<doi>10.1016/j.ejmg.2007.10.002</doi>
+					</citation>
+					<citation key="bib61">
+						<journal_title>Journal of Machine Learning Research</journal_title>
+						<author>Weinberger</author>
+						<volume>10</volume>
+						<first_page>207</first_page>
+						<cYear>2009</cYear>
+						<article_title>Distance metric learning for large margin nearest neighbor classification</article_title>
+					</citation>
+					<citation key="bib62">
+						<journal_title>Nature Reviews Genetics</journal_title>
+						<author>Weischenfeldt</author>
+						<volume>14</volume>
+						<first_page>125</first_page>
+						<cYear>2013</cYear>
+						<article_title>Phenotypic impact of genomic structural variation: insights from and for human disease</article_title>
+						<doi>10.1038/nrg3373</doi>
+					</citation>
+					<citation key="bib63">
+						<journal_title>Archives of Disease in Childhood</journal_title>
+						<author>Wright</author>
+						<volume>95</volume>
+						<first_page>724</first_page>
+						<cYear>2010</cYear>
+						<article_title>RAS-MAPK pathway disorders: important causes of congenital heart disease, feeding difficulties, developmental delay and short stature</article_title>
+						<doi>10.1136/adc.2009.160069</doi>
+					</citation>
+					<citation key="bib64">
+						<journal_title>Human Mutation</journal_title>
+						<author>Zampino</author>
+						<volume>28</volume>
+						<first_page>265</first_page>
+						<cYear>2007</cYear>
+						<article_title>Diversity, parental germline origin, and phenotypic spectrum of de novo HRAS missense changes in Costello syndrome</article_title>
+						<doi>10.1002/humu.20431</doi>
+					</citation>
+					<citation key="bib65">
+						<journal_title>Hormone Research</journal_title>
+						<author>Zenker</author>
+						<volume>72</volume>
+						<first_page>57</first_page>
+						<cYear>2009</cYear>
+						<article_title>Genetic and pathogenetic aspects of Noonan syndrome and related disorders</article_title>
+						<doi>10.1159/000243782</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.001</doi>
+							<resource>https://elifesciences.org/articles/02020#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.002</doi>
+							<resource>https://elifesciences.org/articles/02020#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Overview of the computational approach and average faces of syndromes.</title>
+							<subtitle>(A) A photo is automatically analyzed to detect faces and feature points are placed using computer vision algorithms. Facial feature annotation points delineate the supra-orbital ridge (8 points), the eyes (mid points of the eyelids and eye canthi, 8 points), nose (nasion, tip, ala, subnasale and outer nares, 7 points), mouth (vermilion border lateral and vertical midpoints, 6 points) and the jaw (zygoma mandibular border, gonion, mental protrubance and chin midpoint, 7 points). Shape and Appearance feature vectors are then extracted based on feature points and these determine the photo's location in Clinical Face Phenotype Space (further details on feature points in Figure 1—figure supplement 1). This location is then analyzed in the context of existing points in Clinical Face Phenotype Space to extract phenotype similarities and diagnosis hypotheses (further details on Clinical Face Phenotype Space with simulation examples in Figure 1—figure supplement 2). (B) Average faces of syndromes in the database constructed using AAM models (‘Materials and methods’) and number of individuals which each average face represents. See online version of this manuscript for animated morphing images that show facial features differing between controls and syndromes (Figure 2).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.003</doi>
+							<resource>https://elifesciences.org/articles/02020#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 1.</title>
+							<subtitle>(A) The 36 facial feature points annotated by the automatic image analysis algorithm. Supra-orbital ridge (8 points), the eyes (mid points of the eyelids and eye canthi, 8 points), nose (nasion, tip, ala, subnasale and outer nares, 7 points), mouth (vermilion border lateral and vertical midpoints, 6 points), and the jaw (zygoma mandibular border, gonion, mental protrubance and chin midpoint, 7 points). (B) The annotation accuracies relative to the manually annotated ground truth of each of the computer vision modules. Points 1–8 refer to the supra-orbital ridge, points 30–36 refer to the jaw points. Accuracies for the points annotated by the modules FLA, improved FLA and CoE are shown for each syndrome and control groups. Accuracies are shown as the average error relative to the width of an eye.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.004</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig1s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 2. Phenotypic vs spurious feature variation in Clinical Face Phenotype Space using simulated faces.</title>
+							<subtitle>Simulated 3D faces were used to visualize the influence of spurious variation in raw feature space and Clinical Face Phenotype Space. (A) 100 faces with controlled phenotype, lighting, and rotation variation were rendered. (B) Visualization of a population of simulated faces in the first two Multi-Dimensional Scaling (MDS) modes. Face clustering in raw feature space and Clinical Face Phenotype Space colored by lighting, rotation, and face phenotype, respectively. In the raw feature space lighting is the dominating clustering factor, in Clinical Face Phenotype Space phenotype underlies the primary clustering. (C) The first 16 modes of PCA decomposition of the raw feature vectors and in the Clinical Face Phenotype Space colored by lighting and rotation of the simulated faces. In the raw feature space, lighting, and rotation variation are encoded in the 2nd and 1st modes, indicating that clustering is dominated by spurious variation. In the Clinical Face Phenotype Space, lighting is represented in the 9th mode, whereas rotation is no longer represented in the first 16 modes. This shows that the Clinical Face Phenotype Space transformation reduces the influence of spurious variation on clustering of phenotypes.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.005</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig1s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 1.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.006</doi>
+							<resource>https://elifesciences.org/articles/02020#tbl1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Animated morphs of average faces from controls to syndromes.</title>
+							<subtitle>(A) Angelman, (B) Apert, (C) Cornelia de Lange, (D) Down, (E) Fragile X, (F) Progeria, (G) Treacher-Collins, (H) Williams-Beuren. Delineation of syndrome gestalt relative to controls with distortion graphs in Figure 2—figure supplement 1.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.008</doi>
+							<resource>https://elifesciences.org/articles/02020#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. Distortion graphs representing the characteristic deformation of syndrome faces relative to the average control face.</title>
+							<subtitle>Each line reflects whether the distance is extended or contracted compared with the control face. White—the distance is similar to controls, blue—shorter relative to controls, and red—extended in patients relative to controls.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.009</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Clinical Face Phenotype Space enhances the separation of different dysmorphic syndromes.</title>
+							<subtitle>The graph shows a two dimensional representation of the full Clinical Face Phenotype Space, with links to the 10 nearest neighbors of each photo (circle) and photos placed with force-directed graphing. The Clustering Improvement Factor (CIF, fold better clustering than random expectation) estimate for each of the syndromes is shown along the periphery.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.010</doi>
+							<resource>https://elifesciences.org/articles/02020#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Clinical Face Phenotype Space is generalizable to dysmorphic syndromes that are absent from a training set.</title>
+							<subtitle>(A) Clustering Improvement Factor (CIF) estimates are plotted vs the number of individuals per syndrome grouping in the Gorlin collection or patients with similar genetic variant diagnoses. As expected, the stochastic variance in CIF is inversely proportional to the number of individuals available for sampling. The median CIF across all groups is 27.6-fold over what is expected by clustering syndromes randomly. That is to say, the CIF of a randomly placed set is 1. The maximum CIF is fixed by the total number of images in the database and by the cardinality of a syndrome set: the theoretical maximal CIF upper bound is plotted as a red dotted line. The CIF for the minimum and maximum, Cutislaxa syndrome and Otodental syndrome, were 1.0 and 700.0 respectively. (B) Average probabilistic classification accuracies of each individual face placed in Clinical Face Phenotype Space (class prioritization by 20 nearest neighbors weighted by prevalence in the database). The 8 initial syndromes used to train Clinical Face Phenotype Space are shown in color. For syndromes with fewer than 50 examples, accuracies were averaged across all syndromes binned by data set size (i.e., the average accuracy is shown for syndromes with 2–5, 6–10, 11–25, and 26–50 images in the database, Supplementary file 1). Classification accuracies increase proportional to the number of individuals with the syndrome present in the database. Accuracies using support vector machines with binary and forced choice classifications are shown in Figure 4—figure supplement 1 and Figure 4—figure supplement 2. A simulation example of probabilistic querying of Clinical Face Phenotype Space is shown in Figure 4—figure supplement 3.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.011</doi>
+							<resource>https://elifesciences.org/articles/02020#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 1. SVM binary classification accuracies among the 8 syndromes in Table 1.</title>
+							<subtitle>SVM classifier accuracies when tuned for equal false positive and false negative error rates.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.012</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig4s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 2. SVM forced choice classification accuracies among the 8 syndromes in Table 1.</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.013</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig4s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 3. Simulated example illustrating the Clustering Improvement Factor.</title>
+							<subtitle>A random scattering of 100 points in 2 dimensions is used as a background set (black circles with white fill). The 20 red plus symbols (within the red shaded area) are a random set of points lying within the same limits as the background set and have a CIF of 0.9. This is the actual degree of clustering of the red points with respect to the expectation of clustering them with 95% confidence (E(r) = 5.6). The filled green circles (within the green shaded area) are the red points shifted by +0.5 units in each dimension and have a CIF of 2.7. The black points (within the gray shaded area) are the red plus symbol positions scaled by 0.5 and then shifted by +1.5 units in dimension 1. The black points are non-overlapping with the background and represent the maximal CIF (of 5.6) in this example.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.014</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig4s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 4. Simulated example of probabilistic querying of Clinical Face Phenotype Space.</title>
+							<subtitle>(A) Visualization of a population of simulated faces in the first two Multi-Dimensional Scaling (MDS) modes. 7 classes of points (simulated 'syndrome groups') are shown with different distributions and variances. A central 'query' face is indicated by the boxed cross. The 20 nearest neighbors of the query are encircled with a black border. (B) Inset bar graph shows diagnosis hypothesis ranked by class priority. The class priority ranking weights the dispersion and prevalence (spread and number) of a class in the Clinical Face Phenotype Space with the nearest neighbors to assign the most probable diagnosis hypotheses. In the example, the ranked diagnosis estimates of the query point would be class 7, then class 6, and thirdly class 4. The scatter plot shows the individual similarity p0p1 estimates, reflecting their relative closeness in the space as compared to local neighborhood, for the 20 nearest neighbors of the query. The first nearest neighbor is estimated to be 2.6-fold closer to the query than the average based on the local density of neighbors. The dotted line indicates the average relative distance between points among the 20 nearest neighbors. (C) Inset bar graph shows the number of neighbors of the query per class. A scatterplot of dispersion vs cardinality, i.e. relative spread of points and what proportion of the total number of points belong to that class in the simulated space. Plots (B) and (C) allow objective assessment of the distribution of points shown in (A), and aid the interpretation of classification confidence.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.015</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#fig4s4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Clinical Face Phenotype Space recapitulates features of functional gene links between syndromes.</title>
+							<subtitle>Protein–protein interaction distances of 1–3 for genetically characterized syndromes are associated with significantly shorter Euclidean distance (arbitrary units) between syndromes in Clinical Face Phenotype Space as compared to syndromes with distance 4 or no known interaction distance (shown in orange) (Kruskal–Wallis tests with Bonferroni corrected p-values indicated as *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001). The Spearman correlation across all distances was r = 0.09, p&lt;0.001. The numbers of pairwise syndrome comparisons underlying each of the interaction distances are listed within the respective boxes.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.016</doi>
+							<resource>https://elifesciences.org/articles/02020#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6. Class priority of diagnostic classifications for images.</title>
+							<subtitle>The full computer vision algorithm and Clinical Face Phenotype Space analysis procedure with diagnostic hypothesis generation exemplified by: (A) a patient (Ferrero et al., 2007) with Williams-Beuren. (B) Abraham Lincoln. The former US President is thought to have had a marfanoid disorder, if not Marfan syndrome (Gordon, 1962; Sotos, 2012). Bar graphs show class prioritization of diagnostic hypotheses determined by 20 nearest neighbors weighted by prevalence in the database. As expected, the classification of Marfan is not successfully assigned in the first instance as there were only 18 faces of individuals with Marfan in the database (making this an example of a difficult case with the current database). However, the seventh suggestion is Marfan, despite this being among 90 different syndromes and 2754 faces.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<ai:program name="AccessIndicators">
+							<ai:license_ref>https://submit.elifesciences.org/html/elife_author_instructions.html#policies</ai:license_ref>
+						</ai:program>
+						<doi_data>
+							<doi>10.7554/eLife.02020.017</doi>
+							<resource>https://elifesciences.org/articles/02020#fig6</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 1.</title>
+							<subtitle>Tinyurl links to sources for the database. Prefix the 7 characters with http://tinyurl.com/. Links are expected to decay with time; the full dataset will be released to researchers at the discretion of a Data Access Committee.</subtitle>
+						</titles>
+						<format mime_type="application/msword"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.007</doi>
+							<resource>https://elifesciences.org/articles/02020/figures#SD1-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.018</doi>
+							<resource>https://elifesciences.org/articles/02020#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02020.019</doi>
+							<resource>https://elifesciences.org/articles/02020#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-02020-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02020-20170717071707.xml
@@ -861,26 +861,6 @@
 							<resource>https://elifesciences.org/articles/02020/figures#SD1-data</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.02020.018</doi>
-							<resource>https://elifesciences.org/articles/02020#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.02020.019</doi>
-							<resource>https://elifesciences.org/articles/02020#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_data/elife-crossref-02043-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02043-20170717071707.xml
@@ -1,1 +1,758 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-02043-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>04</month><day>29</day><year>2014</year></publication_date><journal_volume><volume>3</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Systems analysis of the CO2 concentrating mechanism in cyanobacteria</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Niall M</given_name><surname>Mangan</surname><affiliation>School of Engineering and Applied Sciences and Kavli Institute for Bionano Science and Technology, Harvard University, Cambridge, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Michael P</given_name><surname>Brenner</surname><affiliation>School of Engineering and Applied Sciences and Kavli Institute for Bionano Science and Technology, Harvard University, Cambridge, United States</affiliation></person_name></contributors><jats:abstract><jats:p>Cyanobacteria are photosynthetic bacteria with a unique CO2 concentrating mechanism (CCM), enhancing carbon fixation. Understanding the CCM requires a systems level perspective of how molecular components work together to enhance CO2 fixation. We present a mathematical model of the cyanobacterial CCM, giving the parameter regime (expression levels, catalytic rates, permeability of carboxysome shell) for efficient carbon fixation. Efficiency requires saturating the RuBisCO reaction, staying below saturation for carbonic anhydrase, and avoiding wasteful oxygenation reactions. We find selectivity at the carboxysome shell is not necessary; there is an optimal non-specific carboxysome shell permeability. We compare the efficacy of facilitated CO2 uptake, CO2 scavenging, and <mml:math><mml:mrow><mml:msubsup><mml:mrow><mml:mtext>HCO</mml:mtext></mml:mrow><mml:mn>3</mml:mn><mml:mo>−</mml:mo></mml:msubsup></mml:mrow></mml:math> transport with varying external pH. At the optimal carboxysome permeability, contributions from CO2 scavenging at the cell membrane are small. We examine the cumulative benefits of CCM spatial organization strategies: enzyme co-localization and compartmentalization.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>Cyanobacteria are microorganisms that live in water and, like plants, they capture energy from the sun to convert carbon dioxide into sugars and other useful compounds. This process—called photosynthesis—releases oxygen as a by-product. Cyanobacteria were crucial in making the atmosphere of the early Earth habitable for other organisms, and they created the vast carbon-rich deposits that now supply us with fossil fuels. Modern cyanobacteria continue to sustain life on Earth by providing oxygen and food for other organisms, and researchers are trying to bioengineer cyanobacteria to produce alternative, cleaner, fuels.</jats:p><jats:p>Understanding how cyanobacteria can be as efficient as possible at harnessing sunlight to ‘fix’ carbon dioxide into carbon-rich molecules is an important step in this endeavor. Carbon dioxide can readily pass through cell membranes, so instead cyanobacteria accumulate molecules of bicarbonate inside their cells. This molecule is then converted back into carbon dioxide by an enzyme found in specials compartments within cells called carboxysomes. The enzyme that fixes the carbon is also found in the carboxysomes. However, several important details in this process are not fully understood.</jats:p><jats:p>Here, Mangan and Brenner further extend a mathematical model of the mechanism that cyanobacteria use to concentrate carbon dioxide in order to explore the factors that optimize carbon fixation by these microorganisms. Carbon fixation is deemed efficient when there is more carbon dioxide in the carboxysome than the carbon-fixing enzyme can immediately use (which also avoids wasteful side-reactions that use oxygen instead of carbon dioxide). However, there should not be too much bicarbonate, otherwise the enzyme that converts it to carbon dioxide is overwhelmed and cannot take advantage of the extra bicarbonate.</jats:p><jats:p>Mangan and Brenner's model based the rates that carbon dioxide and bicarbonate could move in and out of the cell, and the rates that the two enzymes work, on previously published experiments. The model varied the location of the enzymes (either free in the cell or inside a carboxysome), and the rate at which carbon dioxide and bicarbonate could diffuse in and out of the carboxysome (the carboxysome's permeability). Mangan and Brenner found that containing the enzymes within a carboxysome increased the concentration of carbon dioxide inside the cell by an order of magnitude. The model also revealed the optimal permeability for the carboxysome outer-shell that would maximize carbon fixation.</jats:p><jats:p>In addition to being of interest to researchers working on biofuels, if the model can be adapted to work for plant photosynthesis, it may help efforts to boost crop production to feed the world’s growing population.</jats:p></jats:abstract><publication_date media_type="online"><month>04</month><day>29</day><year>2014</year></publication_date><publisher_item><item_number item_number_type="article_number">e02043</item_number><identifier id_type="doi">10.7554/eLife.02043</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">NSF Harvard Materials Research Science and Engineering Center</fr:assertion><fr:assertion name="award_number">DMR-0820484</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">NSF Division of Mathematical Sciences<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000121</fr:assertion></fr:assertion><fr:assertion name="award_number">DMS-0907985</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institute of General Medical Sciences<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000057</fr:assertion></fr:assertion><fr:assertion name="award_number">Grant GM068763 for National Centers of Systems Biology </fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/3.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/3.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/3.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.02043</doi><resource>https://elifesciences.org/articles/02043</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/02043/elife-02043-v2.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02043/elife-02043-v2.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>Nature Chemical Biology</journal_title><author>Agapakis</author><volume>8</volume><first_page>527</first_page><cYear>2012</cYear><article_title>Natural strategies for the spatial optimization of metabolism in synthetic biology</article_title><doi>10.1038/nchembio.975</doi></citation><citation key="bib2"><journal_title>Annual Review of Microbiology</journal_title><author>Allen</author><volume>38</volume><first_page>1</first_page><cYear>1984</cYear><article_title>Cyanobacterial cell inclusions</article_title><doi>10.1146/annurev.mi.38.100184.000245</doi></citation><citation key="bib4"><journal_title>Physiologia Plantarium</journal_title><author>Badger</author><volume>90</volume><first_page>529</first_page><cYear>1994</cYear><article_title>Measurement of CO2 and HCO3− fluxes in cyanobacteria and microalgae during steady-state photosynthesis</article_title><doi>10.1111/j.1399-3054.1994.tb08811.x</doi></citation><citation key="bib3"><journal_title>Journal of Experimental Botany</journal_title><author>Badger</author><volume>54</volume><first_page>609</first_page><cYear>2003</cYear><article_title>CO2 concentrating mechanisms in cyanobacteria: molecular components and their diversity and evolution</article_title><doi>10.1093/jxb/erg076</doi></citation><citation key="bib6"><journal_title>Applied and Environmental Microbiology</journal_title><author>Cannon</author><volume>67</volume><first_page>5351</first_page><cYear>2001</cYear><article_title>Microcompartments in prokaryotes: carboxysomes and related polyhedra</article_title><doi>10.1128/AEM.67.12.5351-5361.2001</doi></citation><citation key="bib5"><journal_title>Journal of Bacteriology</journal_title><author>Cannon</author><volume>173</volume><first_page>1565</first_page><cYear>1991</cYear><article_title>In situ assay of ribulose-1,5-bisphosphate carboxylase/oxygenase in Thiobacillus neapolitanus</article_title></citation><citation key="bib7"><journal_title>PLOS ONE</journal_title><author>Chen</author><volume>8</volume><first_page>e76127</first_page><cYear>2013</cYear><article_title>The bacterial carbon-fixing organelle is formed by shell envelopment of preassembled cargo</article_title><doi>10.1371/journal.pone.0076127</doi></citation><citation key="bib8"><journal_title>Bioessays</journal_title><author>Cheng</author><volume>30</volume><first_page>1084</first_page><cYear>2008</cYear><article_title>Bacterial microcompartments: their properties and paradoxes</article_title><doi>10.1002/bies.20830</doi></citation><citation key="bib9"><journal_title>Journal of Bacteriology</journal_title><author>Cot</author><volume>190</volume><first_page>936</first_page><cYear>2008</cYear><article_title>A multiprotein bicarbonate dehydration complex essential to carboxysome function in cyanobacteria</article_title><doi>10.1128/JB.01283-07</doi></citation><citation key="bib10"><journal_title>Journal of the American Chemical Society</journal_title><author>DeVoe</author><volume>83</volume><first_page>274</first_page><cYear>1961</cYear><article_title>The enzymatic kinetics of carbonic anhydrase from bovine and human erythrocytes</article_title><doi>10.1021/ja01463a004</doi></citation><citation key="bib11"><journal_title>The Journal of Biological Chemistry</journal_title><author>Dou</author><volume>283</volume><first_page>10377</first_page><cYear>2008</cYear><article_title>CO2 fixation kinetics of Halothiobacilus neapolitanus mutant carboxysomes lacking carbonic anhydrase suggest the shell acts as a diffusional barrier for co2</article_title><doi>10.1074/jbc.M709285200</doi></citation><citation key="bib12"><journal_title>Current Opinion in Chemical Biology</journal_title><author>Ducat</author><volume>16</volume><first_page>337</first_page><cYear>2012</cYear><article_title>Improving carbon fixation pathways</article_title><doi>10.1016/j.cbpa.2012.05.002</doi></citation><citation key="bib13"><journal_title>Journal of Biotechnology</journal_title><author>Frank</author><volume>163</volume><first_page>273</first_page><cYear>2013</cYear><article_title>Bacterial microcompartments moving into a synthetic biology world</article_title><doi>10.1016/j.jbiotec.2012.09.002</doi></citation><citation key="bib14"><journal_title>Bio Systems</journal_title><author>Fridlyand</author><volume>37</volume><first_page>229</first_page><cYear>1996</cYear><article_title>Quantitative evaluation of the role of a putative CO2-scavenging entity in the cyanobacterial CO2-concentrating mechanism</article_title><doi>10.1016/0303-2647(95)01561-2</doi></citation><citation key="bib15"><journal_title>The Journal of General Physiology</journal_title><author>Gutknecht</author><volume>69</volume><first_page>779</first_page><cYear>1977</cYear><article_title>Diffusion of carbon dioxide through lipid bilayer membranes: effects of carbonic anyhdrase, bicarbonate, and unstirred layers</article_title><doi>10.1085/jgp.69.6.779</doi></citation><citation key="bib16"><journal_title>Planta</journal_title><author>Hackenberg</author><volume>230</volume><first_page>625</first_page><cYear>2009</cYear><article_title>Photorespiratory 2-phosphoglycolate metabolism and photoreduciton of o2 cooperate in high-light acclimation of Synechocystis sp. strain PCC 6803</article_title><doi>10.1007/s00425-009-0972-9</doi></citation><citation key="bib17"><journal_title>Journal of Bacteriology</journal_title><author>Heinhorst</author><volume>188</volume><first_page>8087</first_page><cYear>2006</cYear><article_title>Characterization of the carboxysomal carbonic anhydrase CsoSCA from Halothiobacillus neapolitanus</article_title><doi>10.1128/JB.00990-06</doi></citation><citation key="bib18"><journal_title>Nature</journal_title><author>Jordan</author><volume>291</volume><first_page>513</first_page><cYear>1981</cYear><article_title>Species variation in the specificity of ribulose bisphosphate carboxylase/oxygenase</article_title></citation><citation key="bib19"><journal_title>Annual Review of Plant Physiology and Plant Molecular Biology</journal_title><author>Kaplan</author><volume>50</volume><first_page>539</first_page><cYear>1999</cYear><article_title>CO2 concentrating mechanisms in photosynthetic microorganisms</article_title><doi>10.1146/annurev.arplant.50.1.539</doi></citation><citation key="bib21"><journal_title>Plant Physiology</journal_title><author>Keren</author><volume>135</volume><first_page>1666</first_page><cYear>2004</cYear><article_title>Critical roles of bacterioferritins in iron storage and proliferation of cyanobacteria</article_title><doi>10.1104/pp.104.042770</doi></citation><citation key="bib20"><journal_title>Biochemistry</journal_title><author>Keren</author><volume>41</volume><first_page>15085</first_page><cYear>2002</cYear><article_title>A light-dependent mechanism for massive accumulation of manganese in the photosynthetic bacterium Synechocystis sp. PCC 6803</article_title><doi>10.1021/bi026892s</doi></citation><citation key="bib22"><journal_title>The Journal of Biological Chemistry</journal_title><author>Long</author><volume>282</volume><first_page>29323</first_page><cYear>2008</cYear><article_title>Analysis of carboxysomes from Synechococcus PCC7942 reveals multiple RuBisCO complexes with carboxysomal proteins CcmM and CcaA</article_title><doi>10.1074/jbc.M703896200</doi></citation><citation key="bib23"><journal_title>Molecular Microbiology</journal_title><author>Maeda</author><volume>43</volume><first_page>425</first_page><cYear>2002</cYear><article_title>Novel gene products associated with NdhD3/D4-containing NDH-1 complexes are involved in photosynthetic CO2 hydration in the cyanobacterium, Synechococcus sp. strain PCC7942</article_title><doi>10.1046/j.1365-2958.2002.02753.x</doi></citation><citation key="bib24"><journal_title>European Journal of Phyology</journal_title><author>Mahlmann</author><volume>43</volume><first_page>355</first_page><cYear>2008</cYear><article_title>Rapid determination of the dry weight of single living cyanobacterial cells using the Mach-Zehnder double-beam interference microscop</article_title><doi>10.1080/09670260802168625</doi></citation><citation key="bib25"><journal_title>Plant Physiology</journal_title><author>Mayo</author><volume>90</volume><first_page>720</first_page><cYear>1989</cYear><article_title>The Relationship between Ribulose Bisphosphate Concentration, Dissolved Inorganic Carbon (DIC) Transport and DIC-Limited photoSynthesis in Cyanobacterium Synechococcus leopoliensis Grown at Different Concentrations of Inorganic Carbon</article_title><doi>10.1104/pp.90.2.720</doi></citation><citation key="bib26"><journal_title>The Journal of Cell Biology</journal_title><author>Miller</author><volume>68</volume><first_page>30</first_page><cYear>1979</cYear><article_title>Analysis of thylalkoid outer surface. Coupling factor is limited ot unstacked membrane regions</article_title><doi>10.1083/jcb.68.1.30</doi></citation><citation key="bib27"><journal_title>The Journal of Biological Chemistry</journal_title><author>Missner</author><volume>283</volume><first_page>25340</first_page><cYear>2008</cYear><article_title>Carbon dioxide transport through membranes</article_title><doi>10.1074/jbc.M800096200</doi></citation><citation key="bib28"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Omata</author><volume>96</volume><first_page>13571</first_page><cYear>1999</cYear><article_title>Identification of an ATP-binding cassette transporter involved in bicarbonate uptake in the cyanobacterium Synechococcus sp strain PCC7942</article_title><doi>10.1073/pnas.96.23.13571</doi></citation><citation key="bib29"><journal_title>Molecular Biosystems</journal_title><author>Papapostolou</author><volume>5</volume><first_page>723</first_page><cYear>2009</cYear><article_title>Engineering and exploiting protein assemblies in synthetic biology</article_title><doi>10.1039/b902440a</doi></citation><citation key="bib30"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Peña</author><volume>107</volume><first_page>2455</first_page><cYear>2010</cYear><article_title>Structural basis of the oxidative activation of carboxysomal γ-carbonic anhydrase, CcmM</article_title><doi>10.1073/pnas.0910866107</doi></citation><citation key="bib31"><journal_title>Plant Physiology</journal_title><author>Price</author><volume>91</volume><first_page>505</first_page><cYear>1989</cYear><article_title>Expression of Human Carbonic Anhydrase in the Cyanobacterium Synechococcus PCC7942 creates a High CO2-Requiring Phenotype</article_title><doi>10.1104/pp.91.2.505</doi></citation><citation key="bib32"><journal_title>Canadian Journal of Botany</journal_title><author>Price</author><volume>76</volume><first_page>973</first_page><cYear>1998</cYear><article_title>The functioning of the CO2 concentrating mechanism in several cyanobacterial strains: a review of general physiological characteristics, genes, proteins, and recent advances</article_title><doi>10.1139/b98-081</doi></citation><citation key="bib33"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Price</author><volume>101</volume><first_page>18228</first_page><cYear>2004</cYear><article_title>Identification of a SuIP-type bicarbonate transporter in marine cyanobacteria</article_title><doi>10.1073/pnas.0405211101</doi></citation><citation key="bib34"><journal_title>Journal of experimental botany</journal_title><author>Price</author><volume>58</volume><first_page>1441</first_page><cYear>2007</cYear><article_title>Advances in understanding the cyanobacterial CO2-concentrating-mechanism (CCM): functional components, Ci transporters, diversity, genetic regulation and prospects for engineering into plants</article_title><doi>10.1093/jxb/erm112</doi></citation><citation key="bib35"><journal_title>Journal of experimental botany</journal_title><author>Price</author><volume>59</volume><first_page>1441</first_page><cYear>2008</cYear><article_title>Advances in understanding the cyanobacterial CO2-concentrating-mechanism (CCM): functional components, Ci transporters, diversity, genetic regulation and prospects for engineering into plants</article_title><doi>10.1093/jxb/erm112</doi></citation><citation key="bib36"><journal_title>Photosynthesis Research</journal_title><author>Price</author><volume>109</volume><first_page>47</first_page><cYear>2011</cYear><article_title>Inorganic carbon transporters of the cyanobacterial CO2 concentrating mechanism</article_title><doi>10.1007/s11120-010-9608-y</doi></citation><citation key="bib38"><journal_title>Canadian Journal of Botany</journal_title><author>Reinhold</author><volume>69</volume><first_page>984</first_page><cYear>1991</cYear><article_title>A model for inorganic carbon fluxes and photosynthesis in cyanobacterial carboxysomes</article_title><doi>10.1139/b91-126</doi></citation><citation key="bib37"><journal_title>Plant Physiology and Biochemistry</journal_title><author>Reinhold</author><volume>27</volume><first_page>945</first_page><cYear>1989</cYear><article_title>A quantitative model for inorganic carbon fluxes and photosynthesis in cyanobacterial carboxysomes</article_title></citation><citation key="bib39"><journal_title>Journal of Biotechnology</journal_title><author>Rosgaard</author><volume>162</volume><first_page>134</first_page><cYear>2012</cYear><article_title>Bioengineering of carbon fixation, biofuels, and biochemcials in cyanobacteria and plants</article_title><doi>10.1016/j.jbiotec.2012.05.006</doi></citation><citation key="bib40"><journal_title>Science</journal_title><author>Savage</author><volume>327</volume><first_page>1258</first_page><cYear>2010</cYear><article_title>Spatially ordered dynamics of the bacterial carbon fixation machinery</article_title><doi>10.1126/science.1186090</doi></citation><citation key="bib41"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Savir</author><volume>107</volume><first_page>3475</first_page><cYear>2010</cYear><article_title>Cross-species analysis traces adaptation of Rubisco toward optimality in a low-dimensional landscape</article_title><doi>10.1073/pnas.0911663107</doi></citation><citation key="bib42"><journal_title>Journal of Molecular Biology</journal_title><author>Schmid</author><volume>364</volume><first_page>526</first_page><cYear>2006</cYear><article_title>Structure of Halothiobacillus neapolitanus carboxysomes by cryo-electron tomography</article_title><doi>10.1016/j.jmb.2006.09.024</doi></citation><citation key="bib43"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Shibata</author><volume>98</volume><first_page>11789</first_page><cYear>2001</cYear><article_title>Distinct constitutive and low-CO2-induced CO2 uptake systems in cyanobacteria: genes involved and their phylogenetic relationship with homologous genes in other organisms</article_title><doi>10.1073/pnas.191258298</doi></citation><citation key="bib44"><journal_title>Planta</journal_title><author>Sultemeyer</author><volume>197</volume><first_page>597</first_page><cYear>1995</cYear><article_title>Characterisation of carbon dioxide and bicarbonate transport during steady-state photosynthesis in the marine cyanobacterium Synechococcus strain PCC7002</article_title><doi>10.1007/BF00191566</doi></citation><citation key="bib45"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Tcherkez</author><volume>103</volume><first_page>7246</first_page><cYear>2006</cYear><article_title>Despite slow catalysis and confused substrate specificity, all ribulose bisphosphate carboxylases may be nearly optimized</article_title><doi>10.1073/pnas.0600605103</doi></citation><citation key="bib46"><journal_title>Current Biology</journal_title><author>Tchernov</author><volume>7</volume><first_page>723</first_page><cYear>1997</cYear><article_title>Sustained net CO2 evolution during photosynthesis by marine microorganisms</article_title><doi>10.1016/S0960-9822(06)00330-7</doi></citation><citation key="bib47"><journal_title>Photosynthesis Research</journal_title><author>Tchernov</author><volume>77</volume><first_page>95</first_page><cYear>2003</cYear><article_title>Massive light-dependent cycling of inorganic carbon between oxygenic photosynthetic microorganism and their surroundings</article_title><doi>10.1023/A:1025869600935</doi></citation><citation key="bib48"><journal_title>Plant Physiology</journal_title><author>Volokita</author><volume>76</volume><first_page>599</first_page><cYear>1984</cYear><article_title>Nature of the inorganic carbon species actively taken up by the cyanobacterium Anabaena variabilis</article_title><doi>10.1104/pp.76.3.599</doi></citation><citation key="bib49"><journal_title>Plant Physiology</journal_title><author>Whitehead</author><volume>165</volume><first_page>398</first_page><cYear>2014</cYear><article_title>Comparing the in vivo function of α- and β- carboxysomes in two model cyanobacteria</article_title><doi>10.1104/pp.114.237941</doi></citation><citation key="bib50"><journal_title>Plant Physiology</journal_title><author>Woodger</author><volume>139</volume><first_page>1959</first_page><cYear>2005</cYear><article_title>Sensing of inorganic carbon limitation in Synechococcus PCC7942 is correlated with the size of the internal inorganic carbon pool and involves oxygen</article_title><doi>10.1104/pp.105.069146</doi></citation><citation key="bib51"><journal_title>Biochemical Society Transactions</journal_title><author>Yeates</author><volume>35</volume><first_page>508</first_page><cYear>2007</cYear><article_title>Self-assembly in the carboxysome: a viral capsid-like protein shell in bacterial cells</article_title></citation><citation key="bib52"><journal_title>Naure Reviews Microbiology</journal_title><author>Yeates</author><volume>6</volume><first_page>681</first_page><cYear>2008</cYear><article_title>Protein-based organelles in bacteria: carboxysomes and related microcompartments</article_title><doi>10.1038/nrmicro1913</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02043.001</doi><resource>https://elifesciences.org/articles/02043#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02043.002</doi><resource>https://elifesciences.org/articles/02043#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Schematic of the CCM in cyanobacteria.</title><subtitle>Outer and cell membranes (in black), as well as, thylakoid membranes where the light reactions take place (in green) are treated together. Carboxysomes are shown as four hexagons evenly spaced along the centerline of the cell. The model treats a spherically symmetric cell, with one carboxysome at the center. Active HCO3− transport into the cell is indicated (in light blue), as well as active conversion from CO2 to HCO3−, sometimes called ‘facilitated uptake’ or ‘scavenging’, at membranes (in orange). Both CO2 and HCO3− can leak in and out of the cell, with CO2 leaking out much more readily. Both species passively diffuse across the carboxysome shell. Carbonic anhydrase (red) and RuBisCO (blue) are contained in the carboxysomes and facilitate reactions as shown.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.003</doi><resource>https://elifesciences.org/articles/02043#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 1.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02043.005</doi><resource>https://elifesciences.org/articles/02043#tbl1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 2.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02043.006</doi><resource>https://elifesciences.org/articles/02043#tbl2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Phase space for HCO3− transport, jc, and carboxysome permeability kc.</title><subtitle>Plotted are the parameter values at which the CO2 concentration reaches some critical value. The left most line (dark blue) indicates for what values of jc and kc the CO2 concentration in the carboxysome would half-saturate RuBisCO (Km). The middle line (light blue) indicates the parameter values which would result in a CO2 concentration where 99% of all RuBisCO reactions are carboxylation reactions and only 1% are oxygenation reactions when O2 concentration is 260 μM. The right most (red) line indicates the parameter values which result in carbonic anyhdrase saturating. Here α = 0, so there is no CO2 scavenging or facilitated uptake. The dotted line (grey) shows the kc and jc values, where the HCO3− concentration in the cytosol is 30 mM. The HCO3− concentration in the cytosol does not vary appreciably with kc in this parameter regime, and reaches 30 mM at jc≈0.6cms. All other parameters, such as reaction rates are held fixed and the value can be found in the Table 1 and Table 2.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.007</doi><resource>https://elifesciences.org/articles/02043#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. Phase space for HCO3− transport and carboxysome permeability.</title><subtitle>Solid lines show lines of constant CO2 concentration in the carboxysome for Dc=1e−5cm2s, or the diffusion constant of small molecule in water. Dashed lines show the same lines of constant CO2 concentration, bur for Dc=1e−7cm2s, or the diffusion constant of a small molecule in a 60% sucrose solution.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.008</doi><resource>https://elifesciences.org/articles/02043/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 2. Phase space for HCO3− transport, jc, and carboxysome permeability, kc.</title><subtitle>Plotted are the parameter values at which CO2 concentration reaches some critical value. The left most line (dark blue) indicates for what values of jc and kc the CO2 concentration in the carboxysome would saturate RuBisCO. The middle line (light blue) indicates the parameter values which would result in a CO2 concentration where 99% of all RuBisCO reactions are carboxylation reactions and only 1% are oxygenation reactions when O2 concentration is 260 µM. The right most (red) line indicates the parameter values which result in carbonic anyhdrase saturating. Here α=0cms (solid lines) and α=0cms (dashed line), showing the effect of CO2 scavenging or facilitated uptake on the phase space. All other parameters, such as reaction rates are held fixed and the value can be found Table 1.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.009</doi><resource>https://elifesciences.org/articles/02043/figures#fig2s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Numerical solution (diamonds and circles) and analytic solutions (carbonic anhydrase unsaturated, solid lines, and saturated, dashed lines) correspond well.</title><subtitle>HCO3− transport is varied, and all other system parameters are held constant. The CO2 concentration above which RuBisCO is saturated is Km (grey dashed line). The CO2 concentration where the oxygen reaction error rate will be 1% is C99% (grey dash-dotted line). The transition between carbonic anyhdrase being unsatruated and saturated happens where the two analytic solutions meet (where the dashed and solid red lines meet). Below a critical value of transport, jc≈10−3cms the level of transport is lower than the HCO3− leaking through the cell membrane. A value of kc=10−3 cm/s for the carboxysome permeability was used for these calculations.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.010</doi><resource>https://elifesciences.org/articles/02043#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. No effect of localizing carbonic anhydrase to the shell of the carboxysome.</title><subtitle>We assume the same amount of carbonic anhydrase and RuBisCO activity for each simulation and compare the case with the enzymes evenly distributed throughout the carboxysome to the case where the carbonic anhydrase is localized to the inner carboxysome shell. The (-.-) lines are for no organization and (x) for localization with Dc=10−5cm2s. The (…) lines are for no organization and (o) are for localization with Dc=10−7cm2s.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.011</doi><resource>https://elifesciences.org/articles/02043/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Concentration of CO2 in the carboxysome with varying carboxysome permeability (A).</title><subtitle>Numerical solution (diamonds and circles) and analytic solutions (carbonic anhydrase unsaturated, solid lines, and saturated, dashed lines) correspond well. On all plots CO2 (red circle) &lt; HCO3− (blue diamond). Concentration in the cell along the radius, r, with carboxysome permeability kc=10−5cms (B), kc=10−3cms (C), kc=1cms (D). Grey dotted lines in (B), (C), (D) indicate location of the carboxysome shell boundary. The transition from low CO2 at high permeability (D) to maximum CO2 concentration at optimal permeability (C) occurs at kc∗=DRc=2cms. At low carboxysome permeability (B) HCO3− diffusion into the carboxysome is slower than consumption. For all subplots α=0cms and jc=0.6cms. Qualitative results remain the same with varying jc, increasing α will increase the gradient of CO2 across the cell as CO2 is converted to HCO3− at the cell membrane.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.012</doi><resource>https://elifesciences.org/articles/02043#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 3.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02043.013</doi><resource>https://elifesciences.org/articles/02043#tbl3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 4.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02043.014</doi><resource>https://elifesciences.org/articles/02043#tbl4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Size of the HCO3− flux in one cell from varying sources, as the proportion of CO2 to HCO3− outside the cell changes changes.</title><subtitle>We show results for three carboxysome permeabilities, kc, and only the scavenging is effected. Total external inorganic carbon is 15μM, jc=1cms and αKα=1cms. Scavenging is negligibly small for all values of kc shown. Unless there is very little HCO3− in the environment, HCO3− transport seems to be more efficient than CO2 facilitated uptake.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.015</doi><resource>https://elifesciences.org/articles/02043#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6. Concentration of CO2 achieved through various cellular organizations of enzymes, where we have selected the HCO3− transport level such that the HCO3− concentration in the cytosol is 30 mM.</title><subtitle>O2 concentration is 260 μM. The oxygenation error rates, as a percent of total RuBisCO reactions are indicated on the concentration bars. The cellular organizations investigated are RuBisCO and carbonic anhydrase distributed throughout the entire cytosol, co-localizing RuBisCO and carbonic anhydrase on a scaffold at the center of the cell without a carboxysome shell, RuBisCO and carbonic anhydrase encapsulated in a carboxysome with high permeability at the center of the cell, and RuBisCO and carbonic anhydrase encapsulated in a carboxysome with optimal permeability at the center of the cell.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02043.004</doi><resource>https://elifesciences.org/articles/02043#fig6</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 1.</title><subtitle>Mathematical derivation appendix. Mathematical derivations of analytic solutions for a spherical cell with reactions organized in a variety of ways. We present analytic solutions for the concentration of CO2 and HCO3− a carboxysome located at the center of the cell. We derive analytic solutions assuming a number of different cases for the enzymatic rates in the carboxysome: RuBisCO reaction rate negligible with carbonic anhydrase saturated and unsaturated, RuBisCO reaction rate non-negligible with carbonic anhydrase unsaturated. Additionally we derive analytic solutions for the enzymatic reactions throughout the cell and localized to a scaffold without a carboxysome shell.</subtitle></titles><format mime_type="application/pdf"/><doi_data><doi>10.7554/eLife.02043.016</doi><resource>https://elifesciences.org/articles/02043/figures#SD1-data</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-02043-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>04</month>
+					<day>29</day>
+					<year>2014</year>
+				</publication_date>
+				<journal_volume>
+					<volume>3</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Systems analysis of the CO2 concentrating mechanism in cyanobacteria</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Niall M</given_name>
+						<surname>Mangan</surname>
+						<affiliation>School of Engineering and Applied Sciences and Kavli Institute for Bionano Science and Technology, Harvard University, Cambridge, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Michael P</given_name>
+						<surname>Brenner</surname>
+						<affiliation>School of Engineering and Applied Sciences and Kavli Institute for Bionano Science and Technology, Harvard University, Cambridge, United States</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>
+						Cyanobacteria are photosynthetic bacteria with a unique CO2 concentrating mechanism (CCM), enhancing carbon fixation. Understanding the CCM requires a systems level perspective of how molecular components work together to enhance CO2 fixation. We present a mathematical model of the cyanobacterial CCM, giving the parameter regime (expression levels, catalytic rates, permeability of carboxysome shell) for efficient carbon fixation. Efficiency requires saturating the RuBisCO reaction, staying below saturation for carbonic anhydrase, and avoiding wasteful oxygenation reactions. We find selectivity at the carboxysome shell is not necessary; there is an optimal non-specific carboxysome shell permeability. We compare the efficacy of facilitated CO2 uptake, CO2 scavenging, and 
+						<mml:math>
+							<mml:mrow>
+								<mml:msubsup>
+									<mml:mrow>
+										<mml:mtext>HCO</mml:mtext>
+									</mml:mrow>
+									<mml:mn>3</mml:mn>
+									<mml:mo>−</mml:mo>
+								</mml:msubsup>
+							</mml:mrow>
+						</mml:math>
+						 transport with varying external pH. At the optimal carboxysome permeability, contributions from CO2 scavenging at the cell membrane are small. We examine the cumulative benefits of CCM spatial organization strategies: enzyme co-localization and compartmentalization.
+					</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>Cyanobacteria are microorganisms that live in water and, like plants, they capture energy from the sun to convert carbon dioxide into sugars and other useful compounds. This process—called photosynthesis—releases oxygen as a by-product. Cyanobacteria were crucial in making the atmosphere of the early Earth habitable for other organisms, and they created the vast carbon-rich deposits that now supply us with fossil fuels. Modern cyanobacteria continue to sustain life on Earth by providing oxygen and food for other organisms, and researchers are trying to bioengineer cyanobacteria to produce alternative, cleaner, fuels.</jats:p>
+					<jats:p>Understanding how cyanobacteria can be as efficient as possible at harnessing sunlight to ‘fix’ carbon dioxide into carbon-rich molecules is an important step in this endeavor. Carbon dioxide can readily pass through cell membranes, so instead cyanobacteria accumulate molecules of bicarbonate inside their cells. This molecule is then converted back into carbon dioxide by an enzyme found in specials compartments within cells called carboxysomes. The enzyme that fixes the carbon is also found in the carboxysomes. However, several important details in this process are not fully understood.</jats:p>
+					<jats:p>Here, Mangan and Brenner further extend a mathematical model of the mechanism that cyanobacteria use to concentrate carbon dioxide in order to explore the factors that optimize carbon fixation by these microorganisms. Carbon fixation is deemed efficient when there is more carbon dioxide in the carboxysome than the carbon-fixing enzyme can immediately use (which also avoids wasteful side-reactions that use oxygen instead of carbon dioxide). However, there should not be too much bicarbonate, otherwise the enzyme that converts it to carbon dioxide is overwhelmed and cannot take advantage of the extra bicarbonate.</jats:p>
+					<jats:p>Mangan and Brenner's model based the rates that carbon dioxide and bicarbonate could move in and out of the cell, and the rates that the two enzymes work, on previously published experiments. The model varied the location of the enzymes (either free in the cell or inside a carboxysome), and the rate at which carbon dioxide and bicarbonate could diffuse in and out of the carboxysome (the carboxysome's permeability). Mangan and Brenner found that containing the enzymes within a carboxysome increased the concentration of carbon dioxide inside the cell by an order of magnitude. The model also revealed the optimal permeability for the carboxysome outer-shell that would maximize carbon fixation.</jats:p>
+					<jats:p>In addition to being of interest to researchers working on biofuels, if the model can be adapted to work for plant photosynthesis, it may help efforts to boost crop production to feed the world’s growing population.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>04</month>
+					<day>29</day>
+					<year>2014</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e02043</item_number>
+					<identifier id_type="doi">10.7554/eLife.02043</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">NSF Harvard Materials Research Science and Engineering Center</fr:assertion>
+						<fr:assertion name="award_number">DMR-0820484</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							NSF Division of Mathematical Sciences
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000121</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">DMS-0907985</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institute of General Medical Sciences
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000057</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Grant GM068763 for National Centers of Systems Biology </fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/3.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.02043</doi>
+					<resource>https://elifesciences.org/articles/02043</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/02043/elife-02043-v2.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02043/elife-02043-v2.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>Nature Chemical Biology</journal_title>
+						<author>Agapakis</author>
+						<volume>8</volume>
+						<first_page>527</first_page>
+						<cYear>2012</cYear>
+						<article_title>Natural strategies for the spatial optimization of metabolism in synthetic biology</article_title>
+						<doi>10.1038/nchembio.975</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Annual Review of Microbiology</journal_title>
+						<author>Allen</author>
+						<volume>38</volume>
+						<first_page>1</first_page>
+						<cYear>1984</cYear>
+						<article_title>Cyanobacterial cell inclusions</article_title>
+						<doi>10.1146/annurev.mi.38.100184.000245</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>Physiologia Plantarium</journal_title>
+						<author>Badger</author>
+						<volume>90</volume>
+						<first_page>529</first_page>
+						<cYear>1994</cYear>
+						<article_title>Measurement of CO2 and HCO3− fluxes in cyanobacteria and microalgae during steady-state photosynthesis</article_title>
+						<doi>10.1111/j.1399-3054.1994.tb08811.x</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Journal of Experimental Botany</journal_title>
+						<author>Badger</author>
+						<volume>54</volume>
+						<first_page>609</first_page>
+						<cYear>2003</cYear>
+						<article_title>CO2 concentrating mechanisms in cyanobacteria: molecular components and their diversity and evolution</article_title>
+						<doi>10.1093/jxb/erg076</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Applied and Environmental Microbiology</journal_title>
+						<author>Cannon</author>
+						<volume>67</volume>
+						<first_page>5351</first_page>
+						<cYear>2001</cYear>
+						<article_title>Microcompartments in prokaryotes: carboxysomes and related polyhedra</article_title>
+						<doi>10.1128/AEM.67.12.5351-5361.2001</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>Journal of Bacteriology</journal_title>
+						<author>Cannon</author>
+						<volume>173</volume>
+						<first_page>1565</first_page>
+						<cYear>1991</cYear>
+						<article_title>In situ assay of ribulose-1,5-bisphosphate carboxylase/oxygenase in Thiobacillus neapolitanus</article_title>
+					</citation>
+					<citation key="bib7">
+						<journal_title>PLOS ONE</journal_title>
+						<author>Chen</author>
+						<volume>8</volume>
+						<first_page>e76127</first_page>
+						<cYear>2013</cYear>
+						<article_title>The bacterial carbon-fixing organelle is formed by shell envelopment of preassembled cargo</article_title>
+						<doi>10.1371/journal.pone.0076127</doi>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Bioessays</journal_title>
+						<author>Cheng</author>
+						<volume>30</volume>
+						<first_page>1084</first_page>
+						<cYear>2008</cYear>
+						<article_title>Bacterial microcompartments: their properties and paradoxes</article_title>
+						<doi>10.1002/bies.20830</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Journal of Bacteriology</journal_title>
+						<author>Cot</author>
+						<volume>190</volume>
+						<first_page>936</first_page>
+						<cYear>2008</cYear>
+						<article_title>A multiprotein bicarbonate dehydration complex essential to carboxysome function in cyanobacteria</article_title>
+						<doi>10.1128/JB.01283-07</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Journal of the American Chemical Society</journal_title>
+						<author>DeVoe</author>
+						<volume>83</volume>
+						<first_page>274</first_page>
+						<cYear>1961</cYear>
+						<article_title>The enzymatic kinetics of carbonic anhydrase from bovine and human erythrocytes</article_title>
+						<doi>10.1021/ja01463a004</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Dou</author>
+						<volume>283</volume>
+						<first_page>10377</first_page>
+						<cYear>2008</cYear>
+						<article_title>CO2 fixation kinetics of Halothiobacilus neapolitanus mutant carboxysomes lacking carbonic anhydrase suggest the shell acts as a diffusional barrier for co2</article_title>
+						<doi>10.1074/jbc.M709285200</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Current Opinion in Chemical Biology</journal_title>
+						<author>Ducat</author>
+						<volume>16</volume>
+						<first_page>337</first_page>
+						<cYear>2012</cYear>
+						<article_title>Improving carbon fixation pathways</article_title>
+						<doi>10.1016/j.cbpa.2012.05.002</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Journal of Biotechnology</journal_title>
+						<author>Frank</author>
+						<volume>163</volume>
+						<first_page>273</first_page>
+						<cYear>2013</cYear>
+						<article_title>Bacterial microcompartments moving into a synthetic biology world</article_title>
+						<doi>10.1016/j.jbiotec.2012.09.002</doi>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Bio Systems</journal_title>
+						<author>Fridlyand</author>
+						<volume>37</volume>
+						<first_page>229</first_page>
+						<cYear>1996</cYear>
+						<article_title>Quantitative evaluation of the role of a putative CO2-scavenging entity in the cyanobacterial CO2-concentrating mechanism</article_title>
+						<doi>10.1016/0303-2647(95)01561-2</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>The Journal of General Physiology</journal_title>
+						<author>Gutknecht</author>
+						<volume>69</volume>
+						<first_page>779</first_page>
+						<cYear>1977</cYear>
+						<article_title>Diffusion of carbon dioxide through lipid bilayer membranes: effects of carbonic anyhdrase, bicarbonate, and unstirred layers</article_title>
+						<doi>10.1085/jgp.69.6.779</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>Planta</journal_title>
+						<author>Hackenberg</author>
+						<volume>230</volume>
+						<first_page>625</first_page>
+						<cYear>2009</cYear>
+						<article_title>Photorespiratory 2-phosphoglycolate metabolism and photoreduciton of o2 cooperate in high-light acclimation of Synechocystis sp. strain PCC 6803</article_title>
+						<doi>10.1007/s00425-009-0972-9</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Journal of Bacteriology</journal_title>
+						<author>Heinhorst</author>
+						<volume>188</volume>
+						<first_page>8087</first_page>
+						<cYear>2006</cYear>
+						<article_title>Characterization of the carboxysomal carbonic anhydrase CsoSCA from Halothiobacillus neapolitanus</article_title>
+						<doi>10.1128/JB.00990-06</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Nature</journal_title>
+						<author>Jordan</author>
+						<volume>291</volume>
+						<first_page>513</first_page>
+						<cYear>1981</cYear>
+						<article_title>Species variation in the specificity of ribulose bisphosphate carboxylase/oxygenase</article_title>
+					</citation>
+					<citation key="bib19">
+						<journal_title>Annual Review of Plant Physiology and Plant Molecular Biology</journal_title>
+						<author>Kaplan</author>
+						<volume>50</volume>
+						<first_page>539</first_page>
+						<cYear>1999</cYear>
+						<article_title>CO2 concentrating mechanisms in photosynthetic microorganisms</article_title>
+						<doi>10.1146/annurev.arplant.50.1.539</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Plant Physiology</journal_title>
+						<author>Keren</author>
+						<volume>135</volume>
+						<first_page>1666</first_page>
+						<cYear>2004</cYear>
+						<article_title>Critical roles of bacterioferritins in iron storage and proliferation of cyanobacteria</article_title>
+						<doi>10.1104/pp.104.042770</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Biochemistry</journal_title>
+						<author>Keren</author>
+						<volume>41</volume>
+						<first_page>15085</first_page>
+						<cYear>2002</cYear>
+						<article_title>A light-dependent mechanism for massive accumulation of manganese in the photosynthetic bacterium Synechocystis sp. PCC 6803</article_title>
+						<doi>10.1021/bi026892s</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Long</author>
+						<volume>282</volume>
+						<first_page>29323</first_page>
+						<cYear>2008</cYear>
+						<article_title>Analysis of carboxysomes from Synechococcus PCC7942 reveals multiple RuBisCO complexes with carboxysomal proteins CcmM and CcaA</article_title>
+						<doi>10.1074/jbc.M703896200</doi>
+					</citation>
+					<citation key="bib23">
+						<journal_title>Molecular Microbiology</journal_title>
+						<author>Maeda</author>
+						<volume>43</volume>
+						<first_page>425</first_page>
+						<cYear>2002</cYear>
+						<article_title>Novel gene products associated with NdhD3/D4-containing NDH-1 complexes are involved in photosynthetic CO2 hydration in the cyanobacterium, Synechococcus sp. strain PCC7942</article_title>
+						<doi>10.1046/j.1365-2958.2002.02753.x</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>European Journal of Phyology</journal_title>
+						<author>Mahlmann</author>
+						<volume>43</volume>
+						<first_page>355</first_page>
+						<cYear>2008</cYear>
+						<article_title>Rapid determination of the dry weight of single living cyanobacterial cells using the Mach-Zehnder double-beam interference microscop</article_title>
+						<doi>10.1080/09670260802168625</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>Plant Physiology</journal_title>
+						<author>Mayo</author>
+						<volume>90</volume>
+						<first_page>720</first_page>
+						<cYear>1989</cYear>
+						<article_title>The Relationship between Ribulose Bisphosphate Concentration, Dissolved Inorganic Carbon (DIC) Transport and DIC-Limited photoSynthesis in Cyanobacterium Synechococcus leopoliensis Grown at Different Concentrations of Inorganic Carbon</article_title>
+						<doi>10.1104/pp.90.2.720</doi>
+					</citation>
+					<citation key="bib26">
+						<journal_title>The Journal of Cell Biology</journal_title>
+						<author>Miller</author>
+						<volume>68</volume>
+						<first_page>30</first_page>
+						<cYear>1979</cYear>
+						<article_title>Analysis of thylalkoid outer surface. Coupling factor is limited ot unstacked membrane regions</article_title>
+						<doi>10.1083/jcb.68.1.30</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Missner</author>
+						<volume>283</volume>
+						<first_page>25340</first_page>
+						<cYear>2008</cYear>
+						<article_title>Carbon dioxide transport through membranes</article_title>
+						<doi>10.1074/jbc.M800096200</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Omata</author>
+						<volume>96</volume>
+						<first_page>13571</first_page>
+						<cYear>1999</cYear>
+						<article_title>Identification of an ATP-binding cassette transporter involved in bicarbonate uptake in the cyanobacterium Synechococcus sp strain PCC7942</article_title>
+						<doi>10.1073/pnas.96.23.13571</doi>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Molecular Biosystems</journal_title>
+						<author>Papapostolou</author>
+						<volume>5</volume>
+						<first_page>723</first_page>
+						<cYear>2009</cYear>
+						<article_title>Engineering and exploiting protein assemblies in synthetic biology</article_title>
+						<doi>10.1039/b902440a</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Peña</author>
+						<volume>107</volume>
+						<first_page>2455</first_page>
+						<cYear>2010</cYear>
+						<article_title>Structural basis of the oxidative activation of carboxysomal γ-carbonic anhydrase, CcmM</article_title>
+						<doi>10.1073/pnas.0910866107</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Plant Physiology</journal_title>
+						<author>Price</author>
+						<volume>91</volume>
+						<first_page>505</first_page>
+						<cYear>1989</cYear>
+						<article_title>Expression of Human Carbonic Anhydrase in the Cyanobacterium Synechococcus PCC7942 creates a High CO2-Requiring Phenotype</article_title>
+						<doi>10.1104/pp.91.2.505</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Canadian Journal of Botany</journal_title>
+						<author>Price</author>
+						<volume>76</volume>
+						<first_page>973</first_page>
+						<cYear>1998</cYear>
+						<article_title>The functioning of the CO2 concentrating mechanism in several cyanobacterial strains: a review of general physiological characteristics, genes, proteins, and recent advances</article_title>
+						<doi>10.1139/b98-081</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Price</author>
+						<volume>101</volume>
+						<first_page>18228</first_page>
+						<cYear>2004</cYear>
+						<article_title>Identification of a SuIP-type bicarbonate transporter in marine cyanobacteria</article_title>
+						<doi>10.1073/pnas.0405211101</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>Journal of experimental botany</journal_title>
+						<author>Price</author>
+						<volume>58</volume>
+						<first_page>1441</first_page>
+						<cYear>2007</cYear>
+						<article_title>Advances in understanding the cyanobacterial CO2-concentrating-mechanism (CCM): functional components, Ci transporters, diversity, genetic regulation and prospects for engineering into plants</article_title>
+						<doi>10.1093/jxb/erm112</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>Journal of experimental botany</journal_title>
+						<author>Price</author>
+						<volume>59</volume>
+						<first_page>1441</first_page>
+						<cYear>2008</cYear>
+						<article_title>Advances in understanding the cyanobacterial CO2-concentrating-mechanism (CCM): functional components, Ci transporters, diversity, genetic regulation and prospects for engineering into plants</article_title>
+						<doi>10.1093/jxb/erm112</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>Photosynthesis Research</journal_title>
+						<author>Price</author>
+						<volume>109</volume>
+						<first_page>47</first_page>
+						<cYear>2011</cYear>
+						<article_title>Inorganic carbon transporters of the cyanobacterial CO2 concentrating mechanism</article_title>
+						<doi>10.1007/s11120-010-9608-y</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Canadian Journal of Botany</journal_title>
+						<author>Reinhold</author>
+						<volume>69</volume>
+						<first_page>984</first_page>
+						<cYear>1991</cYear>
+						<article_title>A model for inorganic carbon fluxes and photosynthesis in cyanobacterial carboxysomes</article_title>
+						<doi>10.1139/b91-126</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Plant Physiology and Biochemistry</journal_title>
+						<author>Reinhold</author>
+						<volume>27</volume>
+						<first_page>945</first_page>
+						<cYear>1989</cYear>
+						<article_title>A quantitative model for inorganic carbon fluxes and photosynthesis in cyanobacterial carboxysomes</article_title>
+					</citation>
+					<citation key="bib39">
+						<journal_title>Journal of Biotechnology</journal_title>
+						<author>Rosgaard</author>
+						<volume>162</volume>
+						<first_page>134</first_page>
+						<cYear>2012</cYear>
+						<article_title>Bioengineering of carbon fixation, biofuels, and biochemcials in cyanobacteria and plants</article_title>
+						<doi>10.1016/j.jbiotec.2012.05.006</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Science</journal_title>
+						<author>Savage</author>
+						<volume>327</volume>
+						<first_page>1258</first_page>
+						<cYear>2010</cYear>
+						<article_title>Spatially ordered dynamics of the bacterial carbon fixation machinery</article_title>
+						<doi>10.1126/science.1186090</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Savir</author>
+						<volume>107</volume>
+						<first_page>3475</first_page>
+						<cYear>2010</cYear>
+						<article_title>Cross-species analysis traces adaptation of Rubisco toward optimality in a low-dimensional landscape</article_title>
+						<doi>10.1073/pnas.0911663107</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Journal of Molecular Biology</journal_title>
+						<author>Schmid</author>
+						<volume>364</volume>
+						<first_page>526</first_page>
+						<cYear>2006</cYear>
+						<article_title>Structure of Halothiobacillus neapolitanus carboxysomes by cryo-electron tomography</article_title>
+						<doi>10.1016/j.jmb.2006.09.024</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Shibata</author>
+						<volume>98</volume>
+						<first_page>11789</first_page>
+						<cYear>2001</cYear>
+						<article_title>Distinct constitutive and low-CO2-induced CO2 uptake systems in cyanobacteria: genes involved and their phylogenetic relationship with homologous genes in other organisms</article_title>
+						<doi>10.1073/pnas.191258298</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>Planta</journal_title>
+						<author>Sultemeyer</author>
+						<volume>197</volume>
+						<first_page>597</first_page>
+						<cYear>1995</cYear>
+						<article_title>Characterisation of carbon dioxide and bicarbonate transport during steady-state photosynthesis in the marine cyanobacterium Synechococcus strain PCC7002</article_title>
+						<doi>10.1007/BF00191566</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Tcherkez</author>
+						<volume>103</volume>
+						<first_page>7246</first_page>
+						<cYear>2006</cYear>
+						<article_title>Despite slow catalysis and confused substrate specificity, all ribulose bisphosphate carboxylases may be nearly optimized</article_title>
+						<doi>10.1073/pnas.0600605103</doi>
+					</citation>
+					<citation key="bib46">
+						<journal_title>Current Biology</journal_title>
+						<author>Tchernov</author>
+						<volume>7</volume>
+						<first_page>723</first_page>
+						<cYear>1997</cYear>
+						<article_title>Sustained net CO2 evolution during photosynthesis by marine microorganisms</article_title>
+						<doi>10.1016/S0960-9822(06)00330-7</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Photosynthesis Research</journal_title>
+						<author>Tchernov</author>
+						<volume>77</volume>
+						<first_page>95</first_page>
+						<cYear>2003</cYear>
+						<article_title>Massive light-dependent cycling of inorganic carbon between oxygenic photosynthetic microorganism and their surroundings</article_title>
+						<doi>10.1023/A:1025869600935</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Plant Physiology</journal_title>
+						<author>Volokita</author>
+						<volume>76</volume>
+						<first_page>599</first_page>
+						<cYear>1984</cYear>
+						<article_title>Nature of the inorganic carbon species actively taken up by the cyanobacterium Anabaena variabilis</article_title>
+						<doi>10.1104/pp.76.3.599</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Plant Physiology</journal_title>
+						<author>Whitehead</author>
+						<volume>165</volume>
+						<first_page>398</first_page>
+						<cYear>2014</cYear>
+						<article_title>Comparing the in vivo function of α- and β- carboxysomes in two model cyanobacteria</article_title>
+						<doi>10.1104/pp.114.237941</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>Plant Physiology</journal_title>
+						<author>Woodger</author>
+						<volume>139</volume>
+						<first_page>1959</first_page>
+						<cYear>2005</cYear>
+						<article_title>Sensing of inorganic carbon limitation in Synechococcus PCC7942 is correlated with the size of the internal inorganic carbon pool and involves oxygen</article_title>
+						<doi>10.1104/pp.105.069146</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Biochemical Society Transactions</journal_title>
+						<author>Yeates</author>
+						<volume>35</volume>
+						<first_page>508</first_page>
+						<cYear>2007</cYear>
+						<article_title>Self-assembly in the carboxysome: a viral capsid-like protein shell in bacterial cells</article_title>
+					</citation>
+					<citation key="bib52">
+						<journal_title>Naure Reviews Microbiology</journal_title>
+						<author>Yeates</author>
+						<volume>6</volume>
+						<first_page>681</first_page>
+						<cYear>2008</cYear>
+						<article_title>Protein-based organelles in bacteria: carboxysomes and related microcompartments</article_title>
+						<doi>10.1038/nrmicro1913</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.001</doi>
+							<resource>https://elifesciences.org/articles/02043#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.002</doi>
+							<resource>https://elifesciences.org/articles/02043#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Schematic of the CCM in cyanobacteria.</title>
+							<subtitle>Outer and cell membranes (in black), as well as, thylakoid membranes where the light reactions take place (in green) are treated together. Carboxysomes are shown as four hexagons evenly spaced along the centerline of the cell. The model treats a spherically symmetric cell, with one carboxysome at the center. Active HCO3− transport into the cell is indicated (in light blue), as well as active conversion from CO2 to HCO3−, sometimes called ‘facilitated uptake’ or ‘scavenging’, at membranes (in orange). Both CO2 and HCO3− can leak in and out of the cell, with CO2 leaking out much more readily. Both species passively diffuse across the carboxysome shell. Carbonic anhydrase (red) and RuBisCO (blue) are contained in the carboxysomes and facilitate reactions as shown.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.003</doi>
+							<resource>https://elifesciences.org/articles/02043#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 1.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.005</doi>
+							<resource>https://elifesciences.org/articles/02043#tbl1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 2.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.006</doi>
+							<resource>https://elifesciences.org/articles/02043#tbl2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Phase space for HCO3− transport, jc, and carboxysome permeability kc.</title>
+							<subtitle>Plotted are the parameter values at which the CO2 concentration reaches some critical value. The left most line (dark blue) indicates for what values of jc and kc the CO2 concentration in the carboxysome would half-saturate RuBisCO (Km). The middle line (light blue) indicates the parameter values which would result in a CO2 concentration where 99% of all RuBisCO reactions are carboxylation reactions and only 1% are oxygenation reactions when O2 concentration is 260 μM. The right most (red) line indicates the parameter values which result in carbonic anyhdrase saturating. Here α = 0, so there is no CO2 scavenging or facilitated uptake. The dotted line (grey) shows the kc and jc values, where the HCO3− concentration in the cytosol is 30 mM. The HCO3− concentration in the cytosol does not vary appreciably with kc in this parameter regime, and reaches 30 mM at jc≈0.6cms. All other parameters, such as reaction rates are held fixed and the value can be found in the Table 1 and Table 2.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.007</doi>
+							<resource>https://elifesciences.org/articles/02043#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. Phase space for HCO3− transport and carboxysome permeability.</title>
+							<subtitle>Solid lines show lines of constant CO2 concentration in the carboxysome for Dc=1e−5cm2s, or the diffusion constant of small molecule in water. Dashed lines show the same lines of constant CO2 concentration, bur for Dc=1e−7cm2s, or the diffusion constant of a small molecule in a 60% sucrose solution.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.008</doi>
+							<resource>https://elifesciences.org/articles/02043/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 2. Phase space for HCO3− transport, jc, and carboxysome permeability, kc.</title>
+							<subtitle>Plotted are the parameter values at which CO2 concentration reaches some critical value. The left most line (dark blue) indicates for what values of jc and kc the CO2 concentration in the carboxysome would saturate RuBisCO. The middle line (light blue) indicates the parameter values which would result in a CO2 concentration where 99% of all RuBisCO reactions are carboxylation reactions and only 1% are oxygenation reactions when O2 concentration is 260 µM. The right most (red) line indicates the parameter values which result in carbonic anyhdrase saturating. Here α=0cms (solid lines) and α=0cms (dashed line), showing the effect of CO2 scavenging or facilitated uptake on the phase space. All other parameters, such as reaction rates are held fixed and the value can be found Table 1.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.009</doi>
+							<resource>https://elifesciences.org/articles/02043/figures#fig2s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Numerical solution (diamonds and circles) and analytic solutions (carbonic anhydrase unsaturated, solid lines, and saturated, dashed lines) correspond well.</title>
+							<subtitle>HCO3− transport is varied, and all other system parameters are held constant. The CO2 concentration above which RuBisCO is saturated is Km (grey dashed line). The CO2 concentration where the oxygen reaction error rate will be 1% is C99% (grey dash-dotted line). The transition between carbonic anyhdrase being unsatruated and saturated happens where the two analytic solutions meet (where the dashed and solid red lines meet). Below a critical value of transport, jc≈10−3cms the level of transport is lower than the HCO3− leaking through the cell membrane. A value of kc=10−3 cm/s for the carboxysome permeability was used for these calculations.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.010</doi>
+							<resource>https://elifesciences.org/articles/02043#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. No effect of localizing carbonic anhydrase to the shell of the carboxysome.</title>
+							<subtitle>We assume the same amount of carbonic anhydrase and RuBisCO activity for each simulation and compare the case with the enzymes evenly distributed throughout the carboxysome to the case where the carbonic anhydrase is localized to the inner carboxysome shell. The (-.-) lines are for no organization and (x) for localization with Dc=10−5cm2s. The (…) lines are for no organization and (o) are for localization with Dc=10−7cm2s.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.011</doi>
+							<resource>https://elifesciences.org/articles/02043/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Concentration of CO2 in the carboxysome with varying carboxysome permeability (A).</title>
+							<subtitle>Numerical solution (diamonds and circles) and analytic solutions (carbonic anhydrase unsaturated, solid lines, and saturated, dashed lines) correspond well. On all plots CO2 (red circle) &lt; HCO3− (blue diamond). Concentration in the cell along the radius, r, with carboxysome permeability kc=10−5cms (B), kc=10−3cms (C), kc=1cms (D). Grey dotted lines in (B), (C), (D) indicate location of the carboxysome shell boundary. The transition from low CO2 at high permeability (D) to maximum CO2 concentration at optimal permeability (C) occurs at kc∗=DRc=2cms. At low carboxysome permeability (B) HCO3− diffusion into the carboxysome is slower than consumption. For all subplots α=0cms and jc=0.6cms. Qualitative results remain the same with varying jc, increasing α will increase the gradient of CO2 across the cell as CO2 is converted to HCO3− at the cell membrane.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.012</doi>
+							<resource>https://elifesciences.org/articles/02043#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 3.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.013</doi>
+							<resource>https://elifesciences.org/articles/02043#tbl3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 4.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.014</doi>
+							<resource>https://elifesciences.org/articles/02043#tbl4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Size of the HCO3− flux in one cell from varying sources, as the proportion of CO2 to HCO3− outside the cell changes changes.</title>
+							<subtitle>We show results for three carboxysome permeabilities, kc, and only the scavenging is effected. Total external inorganic carbon is 15μM, jc=1cms and αKα=1cms. Scavenging is negligibly small for all values of kc shown. Unless there is very little HCO3− in the environment, HCO3− transport seems to be more efficient than CO2 facilitated uptake.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.015</doi>
+							<resource>https://elifesciences.org/articles/02043#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6. Concentration of CO2 achieved through various cellular organizations of enzymes, where we have selected the HCO3− transport level such that the HCO3− concentration in the cytosol is 30 mM.</title>
+							<subtitle>O2 concentration is 260 μM. The oxygenation error rates, as a percent of total RuBisCO reactions are indicated on the concentration bars. The cellular organizations investigated are RuBisCO and carbonic anhydrase distributed throughout the entire cytosol, co-localizing RuBisCO and carbonic anhydrase on a scaffold at the center of the cell without a carboxysome shell, RuBisCO and carbonic anhydrase encapsulated in a carboxysome with high permeability at the center of the cell, and RuBisCO and carbonic anhydrase encapsulated in a carboxysome with optimal permeability at the center of the cell.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.004</doi>
+							<resource>https://elifesciences.org/articles/02043#fig6</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 1.</title>
+							<subtitle>Mathematical derivation appendix. Mathematical derivations of analytic solutions for a spherical cell with reactions organized in a variety of ways. We present analytic solutions for the concentration of CO2 and HCO3− a carboxysome located at the center of the cell. We derive analytic solutions assuming a number of different cases for the enzymatic rates in the carboxysome: RuBisCO reaction rate negligible with carbonic anhydrase saturated and unsaturated, RuBisCO reaction rate non-negligible with carbonic anhydrase unsaturated. Additionally we derive analytic solutions for the enzymatic reactions throughout the cell and localized to a scaffold without a carboxysome shell.</subtitle>
+						</titles>
+						<format mime_type="application/pdf"/>
+						<doi_data>
+							<doi>10.7554/eLife.02043.016</doi>
+							<resource>https://elifesciences.org/articles/02043/figures#SD1-data</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-02725-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02725-20170717071707.xml
@@ -1,1 +1,149 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-02725-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>07</month><day>17</day><year>2017</year></publication_date><journal_volume><volume>6</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Mismatch repair deficiency endows tumors with a unique mutation signature and sensitivity to DNA double-strand breaks</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Hui</given_name><surname>Zhao</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Bernard</given_name><surname>Thienpont</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation><ORCID authenticated="true">http://orcid.org/0000-0002-8772-6845</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>Betül Tuba</given_name><surname>Yesilyurt</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Matthieu</given_name><surname>Moisse</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation><ORCID authenticated="true">http://orcid.org/0000-0001-8880-9311</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>Joke</given_name><surname>Reumers</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Lieve</given_name><surname>Coenegrachts</surname><affiliation>Division of Gynaecologic Oncology, Department of Obstetrics and Gynaecology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Xavier</given_name><surname>Sagaert</surname><affiliation>Division of Pathology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Stefanie</given_name><surname>Schrauwen</surname><affiliation>Division of Gynaecologic Oncology, Department of Obstetrics and Gynaecology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Dominiek</given_name><surname>Smeets</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Gert</given_name><surname>Matthijs</surname><affiliation>Department of Human Genetics, KU Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Stein</given_name><surname>Aerts</surname><affiliation>Department of Human Genetics, University of Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Jan</given_name><surname>Cools</surname><affiliation>Department of Human Genetics, KU Leuven, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Alex</given_name><surname>Metcalf</surname><affiliation>Division of Genetics and Computational Biology, Queensland Institute of Medical Research, Brisbane, Australia</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Amanda</given_name><surname>Spurdle</surname><affiliation>Division of Genetics and Computational Biology, Queensland Institute of Medical Research, Brisbane, Australia</affiliation></person_name><organization contributor_role="author" sequence="additional">ANECS</organization><person_name contributor_role="author" sequence="additional"><given_name>Frederic</given_name><surname>Amant</surname><affiliation>Division of Gynaecologic Oncology, Department of Obstetrics and Gynaecology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Diether</given_name><surname>Lambrechts</surname><affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation></person_name></contributors><jats:abstract><jats:p>An abstract</jats:p></jats:abstract><publication_date media_type="online"><month>07</month><day>17</day><year>2017</year></publication_date><publisher_item><item_number item_number_type="article_number">e02725</item_number><identifier id_type="doi">10.7554/eLife.02725</identifier></publisher_item><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.02725</doi><resource>https://elifesciences.org/articles/02725</resource><collection property="text-mining"><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02725/elife-02725.xml</resource></item></collection></doi_data></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-02725-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>07</month>
+					<day>17</day>
+					<year>2017</year>
+				</publication_date>
+				<journal_volume>
+					<volume>6</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Mismatch repair deficiency endows tumors with a unique mutation signature and sensitivity to DNA double-strand breaks</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Hui</given_name>
+						<surname>Zhao</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Bernard</given_name>
+						<surname>Thienpont</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0002-8772-6845</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Betül Tuba</given_name>
+						<surname>Yesilyurt</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Matthieu</given_name>
+						<surname>Moisse</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0001-8880-9311</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Joke</given_name>
+						<surname>Reumers</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Lieve</given_name>
+						<surname>Coenegrachts</surname>
+						<affiliation>Division of Gynaecologic Oncology, Department of Obstetrics and Gynaecology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Xavier</given_name>
+						<surname>Sagaert</surname>
+						<affiliation>Division of Pathology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Stefanie</given_name>
+						<surname>Schrauwen</surname>
+						<affiliation>Division of Gynaecologic Oncology, Department of Obstetrics and Gynaecology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Dominiek</given_name>
+						<surname>Smeets</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Gert</given_name>
+						<surname>Matthijs</surname>
+						<affiliation>Department of Human Genetics, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Stein</given_name>
+						<surname>Aerts</surname>
+						<affiliation>Department of Human Genetics, University of Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Jan</given_name>
+						<surname>Cools</surname>
+						<affiliation>Department of Human Genetics, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Alex</given_name>
+						<surname>Metcalf</surname>
+						<affiliation>Division of Genetics and Computational Biology, Queensland Institute of Medical Research, Brisbane, Australia</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Amanda</given_name>
+						<surname>Spurdle</surname>
+						<affiliation>Division of Genetics and Computational Biology, Queensland Institute of Medical Research, Brisbane, Australia</affiliation>
+					</person_name>
+					<organization contributor_role="author" sequence="additional">ANECS</organization>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Frederic</given_name>
+						<surname>Amant</surname>
+						<affiliation>Division of Gynaecologic Oncology, Department of Obstetrics and Gynaecology, University Hospital Gasthuisberg, Leuven, Belgium</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Diether</given_name>
+						<surname>Lambrechts</surname>
+						<affiliation>VIB Vesalius Research Center, KU Leuven, Leuven, Belgium</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>An abstract</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>07</month>
+					<day>17</day>
+					<year>2017</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e02725</item_number>
+					<identifier id_type="doi">10.7554/eLife.02725</identifier>
+				</publisher_item>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.02725</doi>
+					<resource>https://elifesciences.org/articles/02725</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02725/elife-02725.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-02935-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02935-20170717071707.xml
@@ -1251,26 +1251,6 @@
 							<resource>https://elifesciences.org/articles/02935/figures#SD6-data</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.02935.027</doi>
-							<resource>https://elifesciences.org/articles/02935#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response image 1. Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.02935.028</doi>
-							<resource>https://elifesciences.org/articles/02935#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_data/elife-crossref-02935-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02935-20170717071707.xml
@@ -1,1 +1,1278 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-02935-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>10</month><day>01</day><year>2014</year></publication_date><journal_volume><volume>3</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Origins and functional consequences of somatic mitochondrial DNA mutations in human cancer</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Young Seok</given_name><surname>Ju</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ludmil B</given_name><surname>Alexandrov</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Moritz</given_name><surname>Gerstung</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Inigo</given_name><surname>Martincorena</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Serena</given_name><surname>Nik-Zainal</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Manasa</given_name><surname>Ramakrishna</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Helen R</given_name><surname>Davies</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Elli</given_name><surname>Papaemmanuil</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Gunes</given_name><surname>Gundem</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Adam</given_name><surname>Shlien</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Niccolo</given_name><surname>Bolli</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Sam</given_name><surname>Behjati</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Patrick S</given_name><surname>Tarpey</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Jyoti</given_name><surname>Nangalia</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation><affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Charles E</given_name><surname>Massie</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation><affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Adam P</given_name><surname>Butler</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Jon W</given_name><surname>Teague</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>George S</given_name><surname>Vassiliou</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation><affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Anthony R</given_name><surname>Green</surname><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation><affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ming-Qing</given_name><surname>Du</surname><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ashwin</given_name><surname>Unnikrishnan</surname><affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>John E</given_name><surname>Pimanda</surname><affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Bin Tean</given_name><surname>Teh</surname><affiliation>Laboratory of Cancer Epigenome, National Cancer Centre, Singapore, Singapore</affiliation><affiliation>Duke-NUS Graduate Medical School, Singapore, Singapore</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Nikhil</given_name><surname>Munshi</surname><affiliation>Department of Hematologic Oncology, Dana-Farber Cancer Institute, Boston, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Mel</given_name><surname>Greaves</surname><affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Paresh</given_name><surname>Vyas</surname><affiliation>Weatherall Institute for Molecular Medicine, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Adel K</given_name><surname>El-Naggar</surname><affiliation>Department of Pathology, MD Anderson Cancer Center, Houston, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Tom</given_name><surname>Santarius</surname><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>V Peter</given_name><surname>Collins</surname><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Richard</given_name><surname>Grundy</surname><affiliation>Children's Brain Tumour Research Centre, University of Nottingham, Nottingham, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Jack A</given_name><surname>Taylor</surname><affiliation>National Institute of Environmental Health Sciences, National Institute of Health, Triangle, North Carolina, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>D Neil</given_name><surname>Hayes</surname><affiliation>Department of Internal Medicine, University of North Carolina, Chapel Hill, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>David</given_name><surname>Malkin</surname><affiliation>Hospital for Sick Children, University of Toronto, Toronto, Canada</affiliation></person_name><organization contributor_role="author" sequence="additional">ICGC Breast Cancer Group</organization><organization contributor_role="author" sequence="additional">ICGC Chronic Myeloid Disorders Group</organization><organization contributor_role="author" sequence="additional">ICGC Prostate Cancer Group</organization><person_name contributor_role="author" sequence="additional"><given_name>Christopher S</given_name><surname>Foster</surname><affiliation>Department of Molecular and Clinical Cancer Medicine, University of Liverpool, London, United Kingdom</affiliation><affiliation>HCA Pathology Laboratories, London, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Anne Y</given_name><surname>Warren</surname><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Hayley C</given_name><surname>Whitaker</surname><affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Daniel</given_name><surname>Brewer</surname><affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation><affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Rosalind</given_name><surname>Eeles</surname><affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Colin</given_name><surname>Cooper</surname><affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation><affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>David</given_name><surname>Neal</surname><affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Tapio</given_name><surname>Visakorpi</surname><affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>William B</given_name><surname>Isaacs</surname><affiliation>Department of Oncology, Johns Hopkins University, Baltimore, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>G Steven</given_name><surname>Bova</surname><affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Adrienne M</given_name><surname>Flanagan</surname><affiliation>Department of Histopathology, Royal National Orthopaedic Hospital, Middlesex, United Kingdom</affiliation><affiliation>University College London Cancer Institute, University College London, London, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>P Andrew</given_name><surname>Futreal</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation><affiliation>Department of Genomic Medicine, The University of Texas, MD Anderson Cancer Center, Houston, Texas, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Andy G</given_name><surname>Lynch</surname><affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Patrick F</given_name><surname>Chinnery</surname><affiliation>Wellcome Trust Centre for Mitochondrial Research, Institute of Genetic Medicine, Newcastle University, Newcastle-upon-tyne, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ultan</given_name><surname>McDermott</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Michael R</given_name><surname>Stratton</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Peter J</given_name><surname>Campbell</surname><affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation><affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation><affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation></person_name></contributors><jats:abstract><jats:p>Recent sequencing studies have extensively explored the somatic alterations present in the nuclear genomes of cancers. Although mitochondria control energy metabolism and apoptosis, the origins and impact of cancer-associated mutations in mtDNA are unclear. In this study, we analyzed somatic alterations in mtDNA from 1675 tumors. We identified 1907 somatic substitutions, which exhibited dramatic replicative strand bias, predominantly C &gt; T and A &gt; G on the mitochondrial heavy strand. This strand-asymmetric signature differs from those found in nuclear cancer genomes but matches the inferred germline process shaping primate mtDNA sequence content. A number of mtDNA mutations showed considerable heterogeneity across tumor types. Missense mutations were selectively neutral and often gradually drifted towards homoplasmy over time. In contrast, mutations resulting in protein truncation undergo negative selection and were almost exclusively heteroplasmic. Our findings indicate that the endogenous mutational mechanism has far greater impact than any other external mutagens in mitochondria and is fundamentally linked to mtDNA replication.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>The DNA in a cell's nucleus must be copied faithfully, and divided equally, when a cell divides to produce two new cells. Mistakes—or mutations—are sometimes made during the copying process, and mutations can also be introduced by exposing DNA to damaging agents known as mutagens, such as UV light or cigarette smoke. These mutations are then maintained in all of the descendants of the cell. Most of these mutations have no impact on the cell's characteristics (‘passenger mutations’). However, ‘driver mutations’ that allow cells to divide uncontrollably and spread to other body sites can lead to cancer.</jats:p><jats:p>Mitochondria are cellular compartments that are responsible for generating the energy a cell needs to survive and are also responsible for initiating programmed cell death. Mitochondria contain their own DNA—entirely separate from that in the nucleus of the cell—that encodes the proteins most essential for energy production. Mitochondrial DNA molecules are frequently exposed to damaging molecules called reactive oxygen species that are produced by the mitochondria. Therefore, these reactive oxygen species have been thought to be one of the most important causes of mitochondrial DNA mutations. In addition, because cancer cells produce energy differently to normal cells, mutations in the mitochondrial DNA that change the ability of the mitochondria to produce energy have been conventionally thought to help normal cells to become cancerous. However, conclusive evidence for a link between cancer and mitochondrial DNA mutations is lacking.</jats:p><jats:p>Ju et al. examined the mitochondrial DNA sequences taken from 1675 cancer biopsies from over thirty different types of cancer and compared these to normal tissue from the same patients. This revealed 1907 mutations in the mitochondrial DNA taken from the cancer cells. The pattern of the mutations suggests that the majority of the mutations are not introduced from reactive oxygen species, but from the errors the mitochondria themselves make in the process of duplicating their DNA when a cell divides. Unexpectedly, known mutagens, such as cigarette smoke or UV light, had a negligible effect on mitochondrial DNA mutations.</jats:p><jats:p>Contrary to conventional wisdom, Ju et al. found no evidence that the mitochondrial DNA mutations help cancer to develop or spread. Instead, like passenger mutations found in the DNA in the cell nucleus, most mitochondrial genome mutations have no discernible effect. However, Ju et al. revealed that DNA mutations that damage normal mitochondrial activity are less likely to be maintained in cancer cells. Presumably, mitochondria containing these proteins produce less energy, and so a cell containing too many of these mutations will find it harder to survive. This shows that having enough correctly functioning mitochondria is essential for even cancer cells to thrive.</jats:p></jats:abstract><publication_date media_type="online"><month>10</month><day>01</day><year>2014</year></publication_date><publisher_item><item_number item_number_type="article_number">e02935</item_number><identifier id_type="doi">10.7554/eLife.02935</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion><fr:assertion name="award_number">Health Innovation Challenge Fund (HICF)</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Kay Kendall Leukaemia Fund<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000402</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Chordoma Foundation</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Adenoid Cystic Carcinoma Research Foundation<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100006386</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">European Molecular Biology Organization<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004410</fr:assertion></fr:assertion><fr:assertion name="award_number">ALTF 1203_2012</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institute for Health Research<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000272</fr:assertion></fr:assertion><fr:assertion name="award_number">Biomedical Research Center at University College London Hospitals</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Leukaemia and Lymphoma Research<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000651</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Cancer Research UK<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000289</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Leukemia and Lymphoma Society<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100005189</fr:assertion></fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">European Union</fr:assertion><fr:assertion name="award_number">Breast Cancer Somatic Genetics Study (BASIS)</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Cancer Research Institute</fr:assertion><fr:assertion name="award_number">PROMPT: G0500966/75466</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institute of Environmental Health Sciences<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000066</fr:assertion></fr:assertion><fr:assertion name="award_number">Intramural Research Program of the NIH</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institute for Health Research<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000272</fr:assertion></fr:assertion><fr:assertion name="award_number">Cambridge Biomedical Research Center</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">European Molecular Biology Organization<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004410</fr:assertion></fr:assertion><fr:assertion name="award_number">ALTF 1287-2012</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Department of Health<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000276</fr:assertion></fr:assertion><fr:assertion name="award_number">Health Innovation Challenge Fund (HICF)</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref></ai:program><rel:program><rel:related_item><rel:description>Origins and functional consequences of somatic mitochondrial DNA mutations</rel:description><rel:inter_work_relation identifier-type="accession" relationship-type="isSupplementedBy">EGAS00001000968</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>TCGA DNA sequencing data</rel:description><rel:inter_work_relation identifier-type="uri" relationship-type="references">http://cghub.ucsc.edu</rel:inter_work_relation></rel:related_item></rel:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.02935</doi><resource>https://elifesciences.org/articles/02935</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/02935/elife-02935-v2.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02935/elife-02935-v2.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>Nature</journal_title><author>Alexandrov</author><volume>500</volume><first_page>415</first_page><cYear>2013</cYear><article_title>Signatures of mutational processes in human cancer</article_title><doi>10.1038/nature12477</doi></citation><citation key="bib2"><journal_title>Nature Genetics</journal_title><author>Andrews</author><volume>23</volume><first_page>147</first_page><cYear>1999</cYear><article_title>Reanalysis and revision of the Cambridge reference sequence for human mitochondrial DNA</article_title><doi>10.1038/13779</doi></citation><citation key="bib3"><journal_title>Human Molecular Genetics</journal_title><author>Avital</author><volume>21</volume><first_page>4214</first_page><cYear>2012</cYear><article_title>Mitochondrial DNA heteroplasmy in diabetes and normal adults: role of acquired and inherited mutational patterns in twins</article_title><doi>10.1093/hmg/dds245</doi></citation><citation key="bib4"><journal_title>Oncogene</journal_title><author>Brandon</author><volume>25</volume><first_page>4647</first_page><cYear>2006</cYear><article_title>Mitochondrial mutations in cancer</article_title><doi>10.1038/sj.onc.1209607</doi></citation><citation key="bib5"><journal_title>Annual Review of Genomics and Human Genetics</journal_title><author>Calvo</author><volume>11</volume><first_page>25</first_page><cYear>2010</cYear><article_title>The mitochondrial proteome and human disease</article_title><doi>10.1146/annurev-genom-082509-141720</doi></citation><citation key="bib6"><journal_title>Oncogene</journal_title><author>Chatterjee</author><volume>25</volume><first_page>4663</first_page><cYear>2006</cYear><article_title>Mitochondrial DNA mutations in human cancer</article_title><doi>10.1038/sj.onc.1209604</doi></citation><citation key="bib7"><journal_title>GeneReviews</journal_title><author>Chinnery</author><cYear>1993</cYear><article_title>Mitochondrial Disorders Overview</article_title></citation><citation key="bib8"><journal_title>Cell</journal_title><author>Clayton</author><volume>28</volume><first_page>693</first_page><cYear>1982</cYear><article_title>Replication of animal mitochondrial DNA</article_title><doi>10.1016/0092-8674(82)90049-6</doi></citation><citation key="bib9"><journal_title>Nature Genetics</journal_title><author>Coller</author><volume>28</volume><first_page>147</first_page><cYear>2001</cYear><article_title>High frequency of homoplasmic mitochondrial DNA mutations in human tumors can be explained without selection</article_title><doi>10.1038/88859</doi></citation><citation key="bib10"><journal_title>Hepatology</journal_title><author>De Alwis</author><volume>50</volume><first_page>992</first_page><cYear>2009</cYear><article_title>Human liver stem cells originate from the canals of Hering</article_title><doi>10.1002/hep.23160</doi></citation><citation key="bib11"><journal_title>Free Radical Research</journal_title><author>Delaney</author><volume>46</volume><first_page>420</first_page><cYear>2012</cYear><article_title>Chemical and biological consequences of oxidatively damaged guanine in DNA</article_title><doi>10.3109/10715762.2011.653968</doi></citation><citation key="bib12"><journal_title>PLOS genetics</journal_title><author>Ericson</author><volume>8</volume><first_page>e1002689</first_page><cYear>2012</cYear><article_title>Decreased mitochondrial DNA mutagenesis in human colorectal cancer</article_title><doi>10.1371/journal.pgen.1002689</doi></citation><citation key="bib13"><journal_title>Genetics</journal_title><author>Faith</author><volume>165</volume><first_page>735</first_page><cYear>2003</cYear><article_title>Likelihood analysis of asymmetrical mutation bias gradients in vertebrate mitochondrial genomes</article_title></citation><citation key="bib14"><journal_title>Discovery Medicine</journal_title><author>Falk</author><volume>14</volume><first_page>389</first_page><cYear>2012</cYear><article_title>Mitochondrial disease genetic diagnostics: optimized whole-exome analysis for all MitoCarta nuclear genes and the mitochondrial genome</article_title></citation><citation key="bib15"><journal_title>Annual Review of Biochemistry</journal_title><author>Falkenberg</author><volume>76</volume><first_page>679</first_page><cYear>2007</cYear><article_title>DNA replication and transcription in mammalian mitochondria</article_title><doi>10.1146/annurev.biochem.76.060305.152028</doi></citation><citation key="bib16"><journal_title>Genome biology</journal_title><author>Fisher</author><volume>12</volume><first_page>R1</first_page><cYear>2011</cYear><article_title>A scalable, fully automated process for construction of sequence-ready human exome targeted capture libraries</article_title><doi>10.1186/gb-2011-12-1-r1</doi></citation><citation key="bib17"><journal_title>Nature Genetics</journal_title><author>Freyer</author><volume>44</volume><first_page>1282</first_page><cYear>2012</cYear><article_title>Variation in germline mtDNA heteroplasmy is determined prenatally but modified during subsequent transmission</article_title><doi>10.1038/ng.2427</doi></citation><citation key="bib18"><journal_title>Nature</journal_title><author>1000 Genomes Project Consortium</author><volume>467</volume><first_page>1061</first_page><cYear>2010</cYear><article_title>A map of human genome variation from population-scale sequencing</article_title><doi>10.1038/nature09534</doi></citation><citation key="bib19"><journal_title>Genome Biology</journal_title><author>Goto</author><volume>12</volume><first_page>R59</first_page><cYear>2011</cYear><article_title>Dynamics of mitochondrial heteroplasmy in three families investigated via a repeatable re-sequencing study</article_title><doi>10.1186/gb-2011-12-6-r59</doi></citation><citation key="bib20"><journal_title>Science</journal_title><author>Gray</author><volume>283</volume><first_page>1476</first_page><cYear>1999</cYear><article_title>Mitochondrial evolution</article_title><doi>10.1126/science.283.5407.1476</doi></citation><citation key="bib21"><journal_title>Nature</journal_title><author>Greenman</author><volume>446</volume><first_page>153</first_page><cYear>2007</cYear><article_title>Patterns of somatic mutation in human cancer genomes</article_title><doi>10.1038/nature05610</doi></citation><citation key="bib22"><journal_title>Genetics</journal_title><author>Greenman</author><volume>173</volume><first_page>2187</first_page><cYear>2006</cYear><article_title>Statistical analysis of pathogenicity of somatic mutations in cancer</article_title><doi>10.1534/genetics.105.044677</doi></citation><citation key="bib23"><journal_title>Cell</journal_title><author>Hanahan</author><volume>144</volume><first_page>646</first_page><cYear>2011</cYear><article_title>Hallmarks of cancer: the next generation</article_title><doi>10.1016/j.cell.2011.02.013</doi></citation><citation key="bib24"><journal_title>Nature</journal_title><author>He</author><volume>464</volume><first_page>610</first_page><cYear>2010</cYear><article_title>Heteroplasmic mitochondrial DNA mutations in normal and tumour cells</article_title><doi>10.1038/nature08802</doi></citation><citation key="bib25"><journal_title>Cold Spring Harbor perspectives in biology</journal_title><author>Holt</author><volume>4</volume><first_page>a012971</first_page><cYear>2012</cYear><article_title>Human mitochondrial DNA replication</article_title><doi>10.1101/cshperspect.a012971</doi></citation><citation key="bib26"><journal_title>Human molecular genetics</journal_title><author>Hudson</author><volume>15</volume><first_page>R244</first_page><cYear>2006</cYear><article_title>Mitochondrial DNA polymerase-gamma and human disease</article_title><doi>10.1093/hmg/ddl233</doi></citation><citation key="bib27"><journal_title>Nucleic Acids Research</journal_title><author>Ingman</author><volume>34</volume><first_page>D749</first_page><cYear>2006</cYear><article_title>mtDB: human Mitochondrial Genome Database, a resource for population genetics and medical sciences</article_title><doi>10.1093/nar/gkj010</doi></citation><citation key="bib28"><volume_title>The neutral theory of molecular evolution</volume_title><author>Kimura</author><cYear>1984</cYear></citation><citation key="bib29"><journal_title>Genome Research</journal_title><author>Koboldt</author><volume>22</volume><first_page>568</first_page><cYear>2012</cYear><article_title>VarScan 2: somatic mutation and copy number alteration discovery in cancer by exome sequencing</article_title><doi>10.1101/gr.129684.111</doi></citation><citation key="bib30"><journal_title>Nature Reviews Cancer</journal_title><author>Koppenol</author><volume>11</volume><first_page>325</first_page><cYear>2011</cYear><article_title>Otto Warburg's contributions to current concepts of cancer metabolism</article_title><doi>10.1038/nrc3038</doi></citation><citation key="bib31"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Larman</author><volume>109</volume><first_page>14087</first_page><cYear>2012</cYear><article_title>Spectrum of somatic mitochondrial mutations in five cancers</article_title><doi>10.1073/pnas.1211502109</doi></citation><citation key="bib32"><journal_title>Journal of Cell Science</journal_title><author>Legros</author><volume>117</volume><first_page>2653</first_page><cYear>2004</cYear><article_title>Organization and dynamics of human mitochondrial DNA</article_title><doi>10.1242/jcs.01134</doi></citation><citation key="bib33"><journal_title>Genome Biology and Evolution</journal_title><author>Levin</author><volume>5</volume><first_page>876</first_page><cYear>2013</cYear><article_title>Functional recurrent mutations in the human mitochondrial phylogeny: dual roles in evolution and disease</article_title><doi>10.1093/gbe/evt058</doi></citation><citation key="bib34"><journal_title>Bioinformatics</journal_title><author>Li</author><volume>25</volume><first_page>1754</first_page><cYear>2009</cYear><article_title>Fast and accurate short read alignment with Burrows-Wheeler transform</article_title><doi>10.1093/bioinformatics/btp324</doi></citation><citation key="bib35"><journal_title>American Journal of Human Genetics</journal_title><author>Li</author><volume>87</volume><first_page>237</first_page><cYear>2010</cYear><article_title>Detecting heteroplasmy from high-throughput sequencing of complete human mitochondrial DNA genomes</article_title><doi>10.1016/j.ajhg.2010.07.014</doi></citation><citation key="bib36"><journal_title>Nature</journal_title><author>Lindahl</author><volume>362</volume><first_page>709</first_page><cYear>1993</cYear><article_title>Instability and decay of the primary structure of DNA</article_title><doi>10.1038/362709a0</doi></citation><citation key="bib37"><journal_title>Cell</journal_title><author>Nik-Zainal</author><volume>149</volume><first_page>979</first_page><cYear>2012a</cYear><article_title>Mutational processes molding the genomes of 21 breast cancers</article_title><doi>10.1016/j.cell.2012.04.024</doi></citation><citation key="bib38"><journal_title>Cell</journal_title><author>Nik-Zainal</author><volume>149</volume><first_page>994</first_page><cYear>2012b</cYear><article_title>The life history of 21 breast cancers</article_title><doi>10.1016/j.cell.2012.04.023</doi></citation><citation key="bib39"><journal_title>Gene</journal_title><author>Nikolaou</author><volume>381</volume><first_page>34</first_page><cYear>2006</cYear><article_title>Deviations from Chargaff's second parity rule in organellar DNA Insights into the evolution of organellar genomes</article_title><doi>10.1016/j.gene.2006.06.010</doi></citation><citation key="bib40"><journal_title>Current Biology</journal_title><author>Pavlov</author><volume>13</volume><first_page>744</first_page><cYear>2003</cYear><article_title>Evidence for preferential mismatch repair of lagging strand DNA replication errors in yeast</article_title><doi>10.1016/S0960-9822(03)00284-7</doi></citation><citation key="bib41"><journal_title>Molecular Cell</journal_title><author>Pavlov</author><volume>10</volume><first_page>207</first_page><cYear>2002</cYear><article_title>Yeast origins establish a strand bias for replicational mutagenesis</article_title><doi>10.1016/S1097-2765(02)00567-1</doi></citation><citation key="bib42"><journal_title>Human Molecular Genetics</journal_title><author>Payne</author><volume>22</volume><first_page>384</first_page><cYear>2013</cYear><article_title>Universal heteroplasmy of human mitochondrial DNA</article_title><doi>10.1093/hmg/dds435</doi></citation><citation key="bib43"><journal_title>Nature</journal_title><author>Pleasance</author><volume>463</volume><first_page>191</first_page><cYear>2010a</cYear><article_title>A comprehensive catalogue of somatic mutations from a human cancer genome</article_title><doi>10.1038/nature08658</doi></citation><citation key="bib44"><journal_title>Nature</journal_title><author>Pleasance</author><volume>463</volume><first_page>184</first_page><cYear>2010b</cYear><article_title>A small-cell lung cancer genome with complex signatures of tobacco exposure</article_title><doi>10.1038/nature08629</doi></citation><citation key="bib45"><journal_title>Nature Genetics</journal_title><author>Polyak</author><volume>20</volume><first_page>291</first_page><cYear>1998</cYear><article_title>Somatic mutations of the mitochondrial genome in human colorectal tumours</article_title><doi>10.1038/3108</doi></citation><citation key="bib46"><journal_title>Genetica</journal_title><author>Rand</author><volume>139</volume><first_page>685</first_page><cYear>2011</cYear><article_title>Population genetics of the cytoplasm and the units of selection on mitochondrial DNA in Drosophila melanogaster</article_title><doi>10.1007/s10709-011-9576-y</doi></citation><citation key="bib47"><journal_title>Nucleic Acids Research</journal_title><author>Ruiz-Pesini</author><volume>35</volume><first_page>D823</first_page><cYear>2007</cYear><article_title>An enhanced MITOMAP with a global mtDNA mutational phylogeny</article_title><doi>10.1093/nar/gkl927</doi></citation><citation key="bib48"><journal_title>Gene</journal_title><author>Saccone</author><volume>238</volume><first_page>195</first_page><cYear>1999</cYear><article_title>Evolutionary genomics in Metazoa: the mitochondrial DNA as a model system</article_title><doi>10.1016/S0378-1119(99)00270-X</doi></citation><citation key="bib49"><journal_title>Nature Reviews Genetics</journal_title><author>Schon</author><volume>13</volume><first_page>878</first_page><cYear>2012</cYear><article_title>Human mitochondrial DNA: roles of inherited and somatic mutations</article_title><doi>10.1038/nrg3275</doi></citation><citation key="bib50"><journal_title>Nature Reviews Genetics</journal_title><author>Smeitink</author><volume>2</volume><first_page>342</first_page><cYear>2001</cYear><article_title>The genetics and pathology of oxidative phosphorylation</article_title><doi>10.1038/35072063</doi></citation><citation key="bib51"><journal_title>Nature</journal_title><author>Stratton</author><volume>458</volume><first_page>719</first_page><cYear>2009</cYear><article_title>The cancer genome</article_title><doi>10.1038/nature07943</doi></citation><citation key="bib52"><journal_title>The Journal of Clinical Investigation</journal_title><author>Taylor</author><volume>112</volume><first_page>1351</first_page><cYear>2003</cYear><article_title>Mitochondrial DNA mutations in human colonic crypt stem cells</article_title><doi>10.1172/JCI19435</doi></citation><citation key="bib53"><journal_title>Nature Genetics</journal_title><author>Thilly</author><volume>34</volume><first_page>255</first_page><cYear>2003</cYear><article_title>Have environmental mutagens caused oncomutations in people?</article_title><doi>10.1038/ng1205</doi></citation><citation key="bib54"><journal_title>Brief Bioinform</journal_title><author>Thorvaldsdottir</author><volume>14</volume><first_page>178</first_page><cYear>2013</cYear><article_title>Integrative Genomics Viewer (IGV): high-performance genomics data visualization and exploration</article_title><doi>10.1093/bib/bbs017</doi></citation><citation key="bib55"><journal_title>Nature Reviews Cancer</journal_title><author>Wallace</author><volume>12</volume><first_page>685</first_page><cYear>2012</cYear><article_title>Mitochondria and cancer</article_title><doi>10.1038/nrc3365</doi></citation><citation key="bib56"><journal_title>Genetics</journal_title><author>Wright</author><volume>16</volume><first_page>97</first_page><cYear>1931</cYear><article_title>Evolution in Mendelian populations</article_title></citation><citation key="bib57"><journal_title>The EMBO Journal</journal_title><author>Yasukawa</author><volume>25</volume><first_page>5358</first_page><cYear>2006</cYear><article_title>Replication of vertebrate mitochondrial DNA entails transient ribonucleotide incorporation throughout the lagging strand</article_title><doi>10.1038/sj.emboj.7601392</doi></citation><citation key="bib58"><journal_title>Molecular Cell</journal_title><author>Yasukawa</author><volume>18</volume><first_page>651</first_page><cYear>2005</cYear><article_title>A bidirectional origin of replication maps to the major noncoding region of human mitochondrial DNA</article_title><doi>10.1016/j.molcel.2005.05.002</doi></citation><citation key="bib59"><journal_title>Mutation Research</journal_title><author>Zheng</author><volume>599</volume><first_page>11</first_page><cYear>2006</cYear><article_title>Origins of human mitochondrial point mutations as DNA polymerase gamma-mediated errors</article_title><doi>10.1016/j.mrfmmm.2005.12.012</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02935.001</doi><resource>https://elifesciences.org/articles/02935#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02935.002</doi><resource>https://elifesciences.org/articles/02935#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Table 1.</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02935.003</doi><resource>https://elifesciences.org/articles/02935#tbl1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Mitochondrial somatic substitutions identified from 1675 Tumor–Normal pairs.</title><subtitle>mtDNA genes and intergenic regions are shown. The strand of genes is shown based on mtDNA strand containing equivalent sequences of transcribed RNA. Substitution categories (silent, non-silent (missense and nonsense), non-coding (tRNA and rRNA), and intergenic) are shown by the shapes of each substitution. Six classes of substitutions are presented color-coded. The substitutions on the H, and L strand (when six substitutional classes were considered) are shown outside and inside of mtDNA genes, respectively. Vertical axes for H and L strand substitutions represent the VAF of each variant.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.004</doi><resource>https://elifesciences.org/articles/02935#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 1. Correlation in amount of mtDNA reads between whole-genome and whole-exome sequencing.</title><subtitle>139 DNA samples, either from tumors or bloods, sequenced by whole-genome sequencing were additionally sequenced by whole-exome sequencing. We compared the amount of mtDNA reads between whole-genome and whole-exome sequencing. As shown in this figure, we found strong positive correlation. * CGP; Cancer Genome Project, Wellcome Trust Sanger Institute, WUGSC; Washington University Genome Sequencing Center.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.005</doi><resource>https://elifesciences.org/articles/02935/figures#fig1s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 2. Correlation of heteroplasmy levels between whole-genome and whole-exome sequencing.</title><subtitle>To validate the sensitivity and specificity of variant calling in this study, 19 tumor and normal pairs (which were originally whole-genome sequenced) were whole-exome sequenced and mtDNA variants were assessed independently. We correlated the heteroplasmic levels of 20 mutations detected in common.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.006</doi><resource>https://elifesciences.org/articles/02935/figures#fig1s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 3. Validation of mtDNA somatic substitutions.</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.007</doi><resource>https://elifesciences.org/articles/02935/figures#fig1s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 4. Amount of off-target mtDNA reads across four sequencing centers.</title><subtitle>* CGP; Cancer Genome Project, Wellcome Trust Sanger Institute (n = 855), WUGSC; Washington University Genome Sequencing Center (n = 140), BCM; Baylor College of Medicine (n = 85), BI; Broad Institute (n = 435).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.008</doi><resource>https://elifesciences.org/articles/02935/figures#fig1s4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 5. Filtering samples of potential DNA contaminations.</title><subtitle>(A) A histogram presenting potential sample swaps in tumor–sample pairs. (B) A histogram presenting potential minor DNA cross-contamination in tumor samples. Cross-contamination levels were considered in filtering substitutions (see “Minor cross-contamination of DNA samples” section in Materials and Methods). (C) Histograms showing number of somatic substitutions overlapping with known inherited polymorphisms and (D) number of back mutations.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.009</doi><resource>https://elifesciences.org/articles/02935/figures#fig1s5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. mtDNA somatic substitutions of human cancer.</title><subtitle>(A) Number of somatic substitutions in a tumor sample. (B) Average number of somatic substitutions per sample across 31 tumor types. (C) Age of diagnosis and number of mtDNA somatic substitutions in breast cancers.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.010</doi><resource>https://elifesciences.org/articles/02935#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. VAFs of phased somatic mtDNA substitutions.</title><subtitle>This figure presents VAF pairs between co-clonal, sub-clonal, and different strand mtDNA substitutions. We expect similar VAFs for co-clonal pairs; lower VAF in sub-clonal mutations compared to clonal ones; and sum of a VAF pair is equal or less than 1.0.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.011</doi><resource>https://elifesciences.org/articles/02935/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Replicative strand bias for mtDNA somatic substitutions.</title><subtitle>(A) Replicative strand-specific substitution rate (# of observed/# of expected) by 96 trinucleotide context. Substitutions in a specific mtDNA segment (from Ori-b to OH) are not included, because they present a different substitutional signature. (B) Mutational signature across tumor types. Eighteen tumor types, which include at least 25 mtDNA mutations, were shown. (C) Inverted substitution signature in the Ori-b–OH.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.012</doi><resource>https://elifesciences.org/articles/02935#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. Replicative strand bias observed in mtDNA substitutions.</title><subtitle>(A) Mutational signature of mtDNA somatic substitutions on the 12 L strand genes by replicative strand (L/H strand). It agrees very well with the background mutational signature. (Chi-square p = 0.99999). (B) Mutational signature of mtDNA somatic substitutions on the H strand gene (MT-ND6) by replicative strand. It is very close to the background very close to the expected background signature (Chi-square p = 0.027). If we consider signature by transcriptional strand, the signature difference is very clear (Chi-square p = 1 × 10−21). These suggest the strand bias not to be transcription-coupled, but replication coupled. (C) Mutational spectrum of mtDNA somatic substitutions on the 22 tRNA genes by replicative strand. Again, it agrees very well with the background mutational signature (Chi-square p = 0.71). (D) Mutational spectrum of mtDNA somatic substitutions on the 22 tRNA genes by non-transcribed (coding) and transcribed (non-coding) strand. Strand bias was greatly subsided because somatic substitutions on 14 L strand and 8 H strand tRNAs neutralize the strand bias (CH &gt; TH and TL &gt; CL) each other. As a result, this signature of tRNA mutations by transcriptional strand is significantly different from the background one (Chi-square p = 3.3 × 10−12). Taken all together, we concluded that the cause of strand bias is not transcription-coupled but is replicative.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.013</doi><resource>https://elifesciences.org/articles/02935/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Mutational signature similar to processes shaping human mtDNA sequence over evolutionary time.</title><subtitle>(A) Triplet codon depletion in human mtDNA by equivalent (CH &gt; TH and TL &gt; CL) mutational pressure. Relative frequency of each triplet codon within synonymous pairs (NNT–NNC or NNA–NNG) is shown by color. The arrows beside the box highlight the T &gt; C (red) and G &gt; A (blue) substitutional pressures on the L strand in germline mtDNA. (B) Correlation of triplet codon frequencies between from observed and from simulated evolutions of a random sequence mtDNA by the mtDNA somatic mutational signature with constraining mitochondrial protein sequences.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.014</doi><resource>https://elifesciences.org/articles/02935#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 1. TC and GA skew for L strand mtDNA genes across 8 animal species.</title><subtitle>C. elegans (a nematode) and D. melanogaster (fruit fly) mtDNA appears to have GL &lt;&lt; AL (due to CH &gt; TH mutational pressure) and CL &gt;&gt; TL (due to CL &gt; TL mutational pressure) in the third base of triplet codon in L strand genes. Therefore they seem to have predominant C &gt; T mutational pressure without strand bias. D. rerio (zebrafish), X. laevis (frog), and M. musculus (mouse) present GL &lt;&lt; AL (due to CH &gt; TH mutational pressure), but similar number of CL and TL. Therefore, mtDNA of these sequences is thought to have CH &gt; TH, with strand bias. The existence of TL &gt; CL is not clear. Finally, mtDNA of H. sapiens, P. troglodytes (Chimpanzee), and G. domesticus (Chicken) shows clear CH &gt; TH and TL &gt; CL as mentioned in the main manuscript. Interestingly, TL &gt; CL seems to be slightly stronger in the mitochondria of chicken than that of human (or chimp). We suggest there would be some differences in the mechanism of mtDNA replication across the evolution tree.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.015</doi><resource>https://elifesciences.org/articles/02935/figures#fig4s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 2. Correlation of triplet codon frequencies between from observed and from simulated evolutions under the mtDNA somatic mutational signature.</title></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.016</doi><resource>https://elifesciences.org/articles/02935/figures#fig4s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Selection and mutational process for mtDNA somatic substitutions.</title><subtitle>(A) Truncating mutations (nonsense substitutions and frame-shifting (FS) coding indels) present significantly lower VAF. (B) Change of VAF of mtDNA somatic mutation between primary and metastatic (or late) cancer tissues. (C) Mutational signature for mtDNA across various tumor types. None of the three highlighted mechanisms or nuclear DNA double-strand breaks repair mechanism (BRCA) match with the mtDNA mutational signature. * Only substitutions in protein-coding genes considered. (D) A proposed model of mtDNA mutational process.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.017</doi><resource>https://elifesciences.org/articles/02935#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5—figure supplement 1. Number of recurrent substitutions between silent and missense substitutions.</title><subtitle>100 sites were randomly selected from silent substitutions (at third base of triplet codon) and missense substitutions (at first and second base of triplet codon). No significant difference was observed among these three groups.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.018</doi><resource>https://elifesciences.org/articles/02935/figures#fig5s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5—figure supplement 2. Comparison of VAF of protein-truncating mutations (nonsense substitution and indels) across tumor types.</title><subtitle>Four tumor types with more than 10 protein-truncating mutations are shown. Fisher's exact were applied between breast and other tissue types.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.019</doi><resource>https://elifesciences.org/articles/02935/figures#fig5s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5—figure supplement 3. Negligible impacts of external mutagens (UV and tobacco smoking) to the somatic mtDNA mutations.</title><subtitle>No evidence of UV and tobacco smoking was identified even in melanoma and lung cancers, respectively. (Left) We compared the proportion of C &gt; T (and G &gt; A) substitutions in the CpC (GpG) context (mutational signature for UV [Alexandrov et al., 2013]) between melanomas and breast cancers (controls). Because UV shows trivial impact to the nuclear DNA somatic mutations of breast cancers (Alexandrov et al., 2013), the vast majority of mtDNA C &gt; T substitutions in the CpC context from breast cancers were not generated by UV. (Right) We compared the proportion of C &gt; A (G &gt; T) substitutions between lung and breast (control) cancers. C &gt; A (G &gt; T) substitutions are dominantly generated by tobacco smoking. Like UV, the impact of tobacco smoking to the somatic mutations of breast cancers is trivial (Alexandrov et al., 2013).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.02935.020</doi><resource>https://elifesciences.org/articles/02935/figures#fig5s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 1.</title><subtitle>Sequencing information of 1675 tumor–normal pairs.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.02935.021</doi><resource>https://elifesciences.org/articles/02935/figures#SD1-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 2.</title><subtitle>Catalogs of somatic mutations (substitutions and indels) and inherited polymorphisms identified in this study.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.02935.022</doi><resource>https://elifesciences.org/articles/02935/figures#SD2-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 3.</title><subtitle>List of phased somatic substitutions.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.02935.023</doi><resource>https://elifesciences.org/articles/02935/figures#SD3-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 4.</title><subtitle>dN/dS for 13 protein-coding genes in mitochondria.</subtitle></titles><format mime_type="application/vnd.ms-excel"/><doi_data><doi>10.7554/eLife.02935.024</doi><resource>https://elifesciences.org/articles/02935/figures#SD4-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 5.</title><subtitle>List of somatic substitution with higher recurrent rate than expected.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.02935.025</doi><resource>https://elifesciences.org/articles/02935/figures#SD5-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Supplementary file 6.</title><subtitle>Data accession numbers.</subtitle></titles><format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/><doi_data><doi>10.7554/eLife.02935.026</doi><resource>https://elifesciences.org/articles/02935/figures#SD6-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02935.027</doi><resource>https://elifesciences.org/articles/02935#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response image 1. Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.02935.028</doi><resource>https://elifesciences.org/articles/02935#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-02935-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>10</month>
+					<day>01</day>
+					<year>2014</year>
+				</publication_date>
+				<journal_volume>
+					<volume>3</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Origins and functional consequences of somatic mitochondrial DNA mutations in human cancer</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Young Seok</given_name>
+						<surname>Ju</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Ludmil B</given_name>
+						<surname>Alexandrov</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Moritz</given_name>
+						<surname>Gerstung</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Inigo</given_name>
+						<surname>Martincorena</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Serena</given_name>
+						<surname>Nik-Zainal</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Manasa</given_name>
+						<surname>Ramakrishna</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Helen R</given_name>
+						<surname>Davies</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Elli</given_name>
+						<surname>Papaemmanuil</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Gunes</given_name>
+						<surname>Gundem</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Adam</given_name>
+						<surname>Shlien</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Niccolo</given_name>
+						<surname>Bolli</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Sam</given_name>
+						<surname>Behjati</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Patrick S</given_name>
+						<surname>Tarpey</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Jyoti</given_name>
+						<surname>Nangalia</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+						<affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Charles E</given_name>
+						<surname>Massie</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+						<affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Adam P</given_name>
+						<surname>Butler</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Jon W</given_name>
+						<surname>Teague</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>George S</given_name>
+						<surname>Vassiliou</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+						<affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Anthony R</given_name>
+						<surname>Green</surname>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+						<affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Ming-Qing</given_name>
+						<surname>Du</surname>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Ashwin</given_name>
+						<surname>Unnikrishnan</surname>
+						<affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>John E</given_name>
+						<surname>Pimanda</surname>
+						<affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Bin Tean</given_name>
+						<surname>Teh</surname>
+						<affiliation>Laboratory of Cancer Epigenome, National Cancer Centre, Singapore, Singapore</affiliation>
+						<affiliation>Duke-NUS Graduate Medical School, Singapore, Singapore</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Nikhil</given_name>
+						<surname>Munshi</surname>
+						<affiliation>Department of Hematologic Oncology, Dana-Farber Cancer Institute, Boston, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Mel</given_name>
+						<surname>Greaves</surname>
+						<affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Paresh</given_name>
+						<surname>Vyas</surname>
+						<affiliation>Weatherall Institute for Molecular Medicine, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Adel K</given_name>
+						<surname>El-Naggar</surname>
+						<affiliation>Department of Pathology, MD Anderson Cancer Center, Houston, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Tom</given_name>
+						<surname>Santarius</surname>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>V Peter</given_name>
+						<surname>Collins</surname>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Richard</given_name>
+						<surname>Grundy</surname>
+						<affiliation>Children's Brain Tumour Research Centre, University of Nottingham, Nottingham, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Jack A</given_name>
+						<surname>Taylor</surname>
+						<affiliation>National Institute of Environmental Health Sciences, National Institute of Health, Triangle, North Carolina, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>D Neil</given_name>
+						<surname>Hayes</surname>
+						<affiliation>Department of Internal Medicine, University of North Carolina, Chapel Hill, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>David</given_name>
+						<surname>Malkin</surname>
+						<affiliation>Hospital for Sick Children, University of Toronto, Toronto, Canada</affiliation>
+					</person_name>
+					<organization contributor_role="author" sequence="additional">ICGC Breast Cancer Group</organization>
+					<organization contributor_role="author" sequence="additional">ICGC Chronic Myeloid Disorders Group</organization>
+					<organization contributor_role="author" sequence="additional">ICGC Prostate Cancer Group</organization>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Christopher S</given_name>
+						<surname>Foster</surname>
+						<affiliation>Department of Molecular and Clinical Cancer Medicine, University of Liverpool, London, United Kingdom</affiliation>
+						<affiliation>HCA Pathology Laboratories, London, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Anne Y</given_name>
+						<surname>Warren</surname>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Hayley C</given_name>
+						<surname>Whitaker</surname>
+						<affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Daniel</given_name>
+						<surname>Brewer</surname>
+						<affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation>
+						<affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Rosalind</given_name>
+						<surname>Eeles</surname>
+						<affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Colin</given_name>
+						<surname>Cooper</surname>
+						<affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</affiliation>
+						<affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>David</given_name>
+						<surname>Neal</surname>
+						<affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Tapio</given_name>
+						<surname>Visakorpi</surname>
+						<affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>William B</given_name>
+						<surname>Isaacs</surname>
+						<affiliation>Department of Oncology, Johns Hopkins University, Baltimore, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>G Steven</given_name>
+						<surname>Bova</surname>
+						<affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Adrienne M</given_name>
+						<surname>Flanagan</surname>
+						<affiliation>Department of Histopathology, Royal National Orthopaedic Hospital, Middlesex, United Kingdom</affiliation>
+						<affiliation>University College London Cancer Institute, University College London, London, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>P Andrew</given_name>
+						<surname>Futreal</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+						<affiliation>Department of Genomic Medicine, The University of Texas, MD Anderson Cancer Center, Houston, Texas, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Andy G</given_name>
+						<surname>Lynch</surname>
+						<affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Patrick F</given_name>
+						<surname>Chinnery</surname>
+						<affiliation>Wellcome Trust Centre for Mitochondrial Research, Institute of Genetic Medicine, Newcastle University, Newcastle-upon-tyne, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Ultan</given_name>
+						<surname>McDermott</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Michael R</given_name>
+						<surname>Stratton</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Peter J</given_name>
+						<surname>Campbell</surname>
+						<affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</affiliation>
+						<affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</affiliation>
+						<affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Recent sequencing studies have extensively explored the somatic alterations present in the nuclear genomes of cancers. Although mitochondria control energy metabolism and apoptosis, the origins and impact of cancer-associated mutations in mtDNA are unclear. In this study, we analyzed somatic alterations in mtDNA from 1675 tumors. We identified 1907 somatic substitutions, which exhibited dramatic replicative strand bias, predominantly C &gt; T and A &gt; G on the mitochondrial heavy strand. This strand-asymmetric signature differs from those found in nuclear cancer genomes but matches the inferred germline process shaping primate mtDNA sequence content. A number of mtDNA mutations showed considerable heterogeneity across tumor types. Missense mutations were selectively neutral and often gradually drifted towards homoplasmy over time. In contrast, mutations resulting in protein truncation undergo negative selection and were almost exclusively heteroplasmic. Our findings indicate that the endogenous mutational mechanism has far greater impact than any other external mutagens in mitochondria and is fundamentally linked to mtDNA replication.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>The DNA in a cell's nucleus must be copied faithfully, and divided equally, when a cell divides to produce two new cells. Mistakes—or mutations—are sometimes made during the copying process, and mutations can also be introduced by exposing DNA to damaging agents known as mutagens, such as UV light or cigarette smoke. These mutations are then maintained in all of the descendants of the cell. Most of these mutations have no impact on the cell's characteristics (‘passenger mutations’). However, ‘driver mutations’ that allow cells to divide uncontrollably and spread to other body sites can lead to cancer.</jats:p>
+					<jats:p>Mitochondria are cellular compartments that are responsible for generating the energy a cell needs to survive and are also responsible for initiating programmed cell death. Mitochondria contain their own DNA—entirely separate from that in the nucleus of the cell—that encodes the proteins most essential for energy production. Mitochondrial DNA molecules are frequently exposed to damaging molecules called reactive oxygen species that are produced by the mitochondria. Therefore, these reactive oxygen species have been thought to be one of the most important causes of mitochondrial DNA mutations. In addition, because cancer cells produce energy differently to normal cells, mutations in the mitochondrial DNA that change the ability of the mitochondria to produce energy have been conventionally thought to help normal cells to become cancerous. However, conclusive evidence for a link between cancer and mitochondrial DNA mutations is lacking.</jats:p>
+					<jats:p>Ju et al. examined the mitochondrial DNA sequences taken from 1675 cancer biopsies from over thirty different types of cancer and compared these to normal tissue from the same patients. This revealed 1907 mutations in the mitochondrial DNA taken from the cancer cells. The pattern of the mutations suggests that the majority of the mutations are not introduced from reactive oxygen species, but from the errors the mitochondria themselves make in the process of duplicating their DNA when a cell divides. Unexpectedly, known mutagens, such as cigarette smoke or UV light, had a negligible effect on mitochondrial DNA mutations.</jats:p>
+					<jats:p>Contrary to conventional wisdom, Ju et al. found no evidence that the mitochondrial DNA mutations help cancer to develop or spread. Instead, like passenger mutations found in the DNA in the cell nucleus, most mitochondrial genome mutations have no discernible effect. However, Ju et al. revealed that DNA mutations that damage normal mitochondrial activity are less likely to be maintained in cancer cells. Presumably, mitochondria containing these proteins produce less energy, and so a cell containing too many of these mutations will find it harder to survive. This shows that having enough correctly functioning mitochondria is essential for even cancer cells to thrive.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>10</month>
+					<day>01</day>
+					<year>2014</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e02935</item_number>
+					<identifier id_type="doi">10.7554/eLife.02935</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Health Innovation Challenge Fund (HICF)</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Kay Kendall Leukaemia Fund
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000402</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Chordoma Foundation</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Adenoid Cystic Carcinoma Research Foundation
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100006386</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							European Molecular Biology Organization
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004410</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">ALTF 1203_2012</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institute for Health Research
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000272</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Biomedical Research Center at University College London Hospitals</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Leukaemia and Lymphoma Research
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000651</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Cancer Research UK
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000289</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Leukemia and Lymphoma Society
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100005189</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">European Union</fr:assertion>
+						<fr:assertion name="award_number">Breast Cancer Somatic Genetics Study (BASIS)</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">National Cancer Research Institute</fr:assertion>
+						<fr:assertion name="award_number">PROMPT: G0500966/75466</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institute of Environmental Health Sciences
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000066</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Intramural Research Program of the NIH</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institute for Health Research
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000272</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Cambridge Biomedical Research Center</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							European Molecular Biology Organization
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004410</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">ALTF 1287-2012</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Department of Health
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000276</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Health Innovation Challenge Fund (HICF)</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+				</ai:program>
+				<rel:program>
+					<rel:related_item>
+						<rel:description>Origins and functional consequences of somatic mitochondrial DNA mutations</rel:description>
+						<rel:inter_work_relation identifier-type="accession" relationship-type="isSupplementedBy">EGAS00001000968</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>TCGA DNA sequencing data</rel:description>
+						<rel:inter_work_relation identifier-type="uri" relationship-type="references">http://cghub.ucsc.edu</rel:inter_work_relation>
+					</rel:related_item>
+				</rel:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.02935</doi>
+					<resource>https://elifesciences.org/articles/02935</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/02935/elife-02935-v2.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/02935/elife-02935-v2.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>Nature</journal_title>
+						<author>Alexandrov</author>
+						<volume>500</volume>
+						<first_page>415</first_page>
+						<cYear>2013</cYear>
+						<article_title>Signatures of mutational processes in human cancer</article_title>
+						<doi>10.1038/nature12477</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Andrews</author>
+						<volume>23</volume>
+						<first_page>147</first_page>
+						<cYear>1999</cYear>
+						<article_title>Reanalysis and revision of the Cambridge reference sequence for human mitochondrial DNA</article_title>
+						<doi>10.1038/13779</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Human Molecular Genetics</journal_title>
+						<author>Avital</author>
+						<volume>21</volume>
+						<first_page>4214</first_page>
+						<cYear>2012</cYear>
+						<article_title>Mitochondrial DNA heteroplasmy in diabetes and normal adults: role of acquired and inherited mutational patterns in twins</article_title>
+						<doi>10.1093/hmg/dds245</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>Oncogene</journal_title>
+						<author>Brandon</author>
+						<volume>25</volume>
+						<first_page>4647</first_page>
+						<cYear>2006</cYear>
+						<article_title>Mitochondrial mutations in cancer</article_title>
+						<doi>10.1038/sj.onc.1209607</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>Annual Review of Genomics and Human Genetics</journal_title>
+						<author>Calvo</author>
+						<volume>11</volume>
+						<first_page>25</first_page>
+						<cYear>2010</cYear>
+						<article_title>The mitochondrial proteome and human disease</article_title>
+						<doi>10.1146/annurev-genom-082509-141720</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Oncogene</journal_title>
+						<author>Chatterjee</author>
+						<volume>25</volume>
+						<first_page>4663</first_page>
+						<cYear>2006</cYear>
+						<article_title>Mitochondrial DNA mutations in human cancer</article_title>
+						<doi>10.1038/sj.onc.1209604</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>GeneReviews</journal_title>
+						<author>Chinnery</author>
+						<cYear>1993</cYear>
+						<article_title>Mitochondrial Disorders Overview</article_title>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Cell</journal_title>
+						<author>Clayton</author>
+						<volume>28</volume>
+						<first_page>693</first_page>
+						<cYear>1982</cYear>
+						<article_title>Replication of animal mitochondrial DNA</article_title>
+						<doi>10.1016/0092-8674(82)90049-6</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Coller</author>
+						<volume>28</volume>
+						<first_page>147</first_page>
+						<cYear>2001</cYear>
+						<article_title>High frequency of homoplasmic mitochondrial DNA mutations in human tumors can be explained without selection</article_title>
+						<doi>10.1038/88859</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Hepatology</journal_title>
+						<author>De Alwis</author>
+						<volume>50</volume>
+						<first_page>992</first_page>
+						<cYear>2009</cYear>
+						<article_title>Human liver stem cells originate from the canals of Hering</article_title>
+						<doi>10.1002/hep.23160</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>Free Radical Research</journal_title>
+						<author>Delaney</author>
+						<volume>46</volume>
+						<first_page>420</first_page>
+						<cYear>2012</cYear>
+						<article_title>Chemical and biological consequences of oxidatively damaged guanine in DNA</article_title>
+						<doi>10.3109/10715762.2011.653968</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>PLOS genetics</journal_title>
+						<author>Ericson</author>
+						<volume>8</volume>
+						<first_page>e1002689</first_page>
+						<cYear>2012</cYear>
+						<article_title>Decreased mitochondrial DNA mutagenesis in human colorectal cancer</article_title>
+						<doi>10.1371/journal.pgen.1002689</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Genetics</journal_title>
+						<author>Faith</author>
+						<volume>165</volume>
+						<first_page>735</first_page>
+						<cYear>2003</cYear>
+						<article_title>Likelihood analysis of asymmetrical mutation bias gradients in vertebrate mitochondrial genomes</article_title>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Discovery Medicine</journal_title>
+						<author>Falk</author>
+						<volume>14</volume>
+						<first_page>389</first_page>
+						<cYear>2012</cYear>
+						<article_title>Mitochondrial disease genetic diagnostics: optimized whole-exome analysis for all MitoCarta nuclear genes and the mitochondrial genome</article_title>
+					</citation>
+					<citation key="bib15">
+						<journal_title>Annual Review of Biochemistry</journal_title>
+						<author>Falkenberg</author>
+						<volume>76</volume>
+						<first_page>679</first_page>
+						<cYear>2007</cYear>
+						<article_title>DNA replication and transcription in mammalian mitochondria</article_title>
+						<doi>10.1146/annurev.biochem.76.060305.152028</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>Genome biology</journal_title>
+						<author>Fisher</author>
+						<volume>12</volume>
+						<first_page>R1</first_page>
+						<cYear>2011</cYear>
+						<article_title>A scalable, fully automated process for construction of sequence-ready human exome targeted capture libraries</article_title>
+						<doi>10.1186/gb-2011-12-1-r1</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Freyer</author>
+						<volume>44</volume>
+						<first_page>1282</first_page>
+						<cYear>2012</cYear>
+						<article_title>Variation in germline mtDNA heteroplasmy is determined prenatally but modified during subsequent transmission</article_title>
+						<doi>10.1038/ng.2427</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Nature</journal_title>
+						<author>1000 Genomes Project Consortium</author>
+						<volume>467</volume>
+						<first_page>1061</first_page>
+						<cYear>2010</cYear>
+						<article_title>A map of human genome variation from population-scale sequencing</article_title>
+						<doi>10.1038/nature09534</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>Genome Biology</journal_title>
+						<author>Goto</author>
+						<volume>12</volume>
+						<first_page>R59</first_page>
+						<cYear>2011</cYear>
+						<article_title>Dynamics of mitochondrial heteroplasmy in three families investigated via a repeatable re-sequencing study</article_title>
+						<doi>10.1186/gb-2011-12-6-r59</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Science</journal_title>
+						<author>Gray</author>
+						<volume>283</volume>
+						<first_page>1476</first_page>
+						<cYear>1999</cYear>
+						<article_title>Mitochondrial evolution</article_title>
+						<doi>10.1126/science.283.5407.1476</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Nature</journal_title>
+						<author>Greenman</author>
+						<volume>446</volume>
+						<first_page>153</first_page>
+						<cYear>2007</cYear>
+						<article_title>Patterns of somatic mutation in human cancer genomes</article_title>
+						<doi>10.1038/nature05610</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>Genetics</journal_title>
+						<author>Greenman</author>
+						<volume>173</volume>
+						<first_page>2187</first_page>
+						<cYear>2006</cYear>
+						<article_title>Statistical analysis of pathogenicity of somatic mutations in cancer</article_title>
+						<doi>10.1534/genetics.105.044677</doi>
+					</citation>
+					<citation key="bib23">
+						<journal_title>Cell</journal_title>
+						<author>Hanahan</author>
+						<volume>144</volume>
+						<first_page>646</first_page>
+						<cYear>2011</cYear>
+						<article_title>Hallmarks of cancer: the next generation</article_title>
+						<doi>10.1016/j.cell.2011.02.013</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Nature</journal_title>
+						<author>He</author>
+						<volume>464</volume>
+						<first_page>610</first_page>
+						<cYear>2010</cYear>
+						<article_title>Heteroplasmic mitochondrial DNA mutations in normal and tumour cells</article_title>
+						<doi>10.1038/nature08802</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>Cold Spring Harbor perspectives in biology</journal_title>
+						<author>Holt</author>
+						<volume>4</volume>
+						<first_page>a012971</first_page>
+						<cYear>2012</cYear>
+						<article_title>Human mitochondrial DNA replication</article_title>
+						<doi>10.1101/cshperspect.a012971</doi>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Human molecular genetics</journal_title>
+						<author>Hudson</author>
+						<volume>15</volume>
+						<first_page>R244</first_page>
+						<cYear>2006</cYear>
+						<article_title>Mitochondrial DNA polymerase-gamma and human disease</article_title>
+						<doi>10.1093/hmg/ddl233</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Ingman</author>
+						<volume>34</volume>
+						<first_page>D749</first_page>
+						<cYear>2006</cYear>
+						<article_title>mtDB: human Mitochondrial Genome Database, a resource for population genetics and medical sciences</article_title>
+						<doi>10.1093/nar/gkj010</doi>
+					</citation>
+					<citation key="bib28">
+						<volume_title>The neutral theory of molecular evolution</volume_title>
+						<author>Kimura</author>
+						<cYear>1984</cYear>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Genome Research</journal_title>
+						<author>Koboldt</author>
+						<volume>22</volume>
+						<first_page>568</first_page>
+						<cYear>2012</cYear>
+						<article_title>VarScan 2: somatic mutation and copy number alteration discovery in cancer by exome sequencing</article_title>
+						<doi>10.1101/gr.129684.111</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Nature Reviews Cancer</journal_title>
+						<author>Koppenol</author>
+						<volume>11</volume>
+						<first_page>325</first_page>
+						<cYear>2011</cYear>
+						<article_title>Otto Warburg's contributions to current concepts of cancer metabolism</article_title>
+						<doi>10.1038/nrc3038</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Larman</author>
+						<volume>109</volume>
+						<first_page>14087</first_page>
+						<cYear>2012</cYear>
+						<article_title>Spectrum of somatic mitochondrial mutations in five cancers</article_title>
+						<doi>10.1073/pnas.1211502109</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Journal of Cell Science</journal_title>
+						<author>Legros</author>
+						<volume>117</volume>
+						<first_page>2653</first_page>
+						<cYear>2004</cYear>
+						<article_title>Organization and dynamics of human mitochondrial DNA</article_title>
+						<doi>10.1242/jcs.01134</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Genome Biology and Evolution</journal_title>
+						<author>Levin</author>
+						<volume>5</volume>
+						<first_page>876</first_page>
+						<cYear>2013</cYear>
+						<article_title>Functional recurrent mutations in the human mitochondrial phylogeny: dual roles in evolution and disease</article_title>
+						<doi>10.1093/gbe/evt058</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>Bioinformatics</journal_title>
+						<author>Li</author>
+						<volume>25</volume>
+						<first_page>1754</first_page>
+						<cYear>2009</cYear>
+						<article_title>Fast and accurate short read alignment with Burrows-Wheeler transform</article_title>
+						<doi>10.1093/bioinformatics/btp324</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Li</author>
+						<volume>87</volume>
+						<first_page>237</first_page>
+						<cYear>2010</cYear>
+						<article_title>Detecting heteroplasmy from high-throughput sequencing of complete human mitochondrial DNA genomes</article_title>
+						<doi>10.1016/j.ajhg.2010.07.014</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>Nature</journal_title>
+						<author>Lindahl</author>
+						<volume>362</volume>
+						<first_page>709</first_page>
+						<cYear>1993</cYear>
+						<article_title>Instability and decay of the primary structure of DNA</article_title>
+						<doi>10.1038/362709a0</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Cell</journal_title>
+						<author>Nik-Zainal</author>
+						<volume>149</volume>
+						<first_page>979</first_page>
+						<cYear>2012a</cYear>
+						<article_title>Mutational processes molding the genomes of 21 breast cancers</article_title>
+						<doi>10.1016/j.cell.2012.04.024</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Cell</journal_title>
+						<author>Nik-Zainal</author>
+						<volume>149</volume>
+						<first_page>994</first_page>
+						<cYear>2012b</cYear>
+						<article_title>The life history of 21 breast cancers</article_title>
+						<doi>10.1016/j.cell.2012.04.023</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>Gene</journal_title>
+						<author>Nikolaou</author>
+						<volume>381</volume>
+						<first_page>34</first_page>
+						<cYear>2006</cYear>
+						<article_title>Deviations from Chargaff's second parity rule in organellar DNA Insights into the evolution of organellar genomes</article_title>
+						<doi>10.1016/j.gene.2006.06.010</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Current Biology</journal_title>
+						<author>Pavlov</author>
+						<volume>13</volume>
+						<first_page>744</first_page>
+						<cYear>2003</cYear>
+						<article_title>Evidence for preferential mismatch repair of lagging strand DNA replication errors in yeast</article_title>
+						<doi>10.1016/S0960-9822(03)00284-7</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Molecular Cell</journal_title>
+						<author>Pavlov</author>
+						<volume>10</volume>
+						<first_page>207</first_page>
+						<cYear>2002</cYear>
+						<article_title>Yeast origins establish a strand bias for replicational mutagenesis</article_title>
+						<doi>10.1016/S1097-2765(02)00567-1</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Human Molecular Genetics</journal_title>
+						<author>Payne</author>
+						<volume>22</volume>
+						<first_page>384</first_page>
+						<cYear>2013</cYear>
+						<article_title>Universal heteroplasmy of human mitochondrial DNA</article_title>
+						<doi>10.1093/hmg/dds435</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Nature</journal_title>
+						<author>Pleasance</author>
+						<volume>463</volume>
+						<first_page>191</first_page>
+						<cYear>2010a</cYear>
+						<article_title>A comprehensive catalogue of somatic mutations from a human cancer genome</article_title>
+						<doi>10.1038/nature08658</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>Nature</journal_title>
+						<author>Pleasance</author>
+						<volume>463</volume>
+						<first_page>184</first_page>
+						<cYear>2010b</cYear>
+						<article_title>A small-cell lung cancer genome with complex signatures of tobacco exposure</article_title>
+						<doi>10.1038/nature08629</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Polyak</author>
+						<volume>20</volume>
+						<first_page>291</first_page>
+						<cYear>1998</cYear>
+						<article_title>Somatic mutations of the mitochondrial genome in human colorectal tumours</article_title>
+						<doi>10.1038/3108</doi>
+					</citation>
+					<citation key="bib46">
+						<journal_title>Genetica</journal_title>
+						<author>Rand</author>
+						<volume>139</volume>
+						<first_page>685</first_page>
+						<cYear>2011</cYear>
+						<article_title>Population genetics of the cytoplasm and the units of selection on mitochondrial DNA in Drosophila melanogaster</article_title>
+						<doi>10.1007/s10709-011-9576-y</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Ruiz-Pesini</author>
+						<volume>35</volume>
+						<first_page>D823</first_page>
+						<cYear>2007</cYear>
+						<article_title>An enhanced MITOMAP with a global mtDNA mutational phylogeny</article_title>
+						<doi>10.1093/nar/gkl927</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Gene</journal_title>
+						<author>Saccone</author>
+						<volume>238</volume>
+						<first_page>195</first_page>
+						<cYear>1999</cYear>
+						<article_title>Evolutionary genomics in Metazoa: the mitochondrial DNA as a model system</article_title>
+						<doi>10.1016/S0378-1119(99)00270-X</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Nature Reviews Genetics</journal_title>
+						<author>Schon</author>
+						<volume>13</volume>
+						<first_page>878</first_page>
+						<cYear>2012</cYear>
+						<article_title>Human mitochondrial DNA: roles of inherited and somatic mutations</article_title>
+						<doi>10.1038/nrg3275</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>Nature Reviews Genetics</journal_title>
+						<author>Smeitink</author>
+						<volume>2</volume>
+						<first_page>342</first_page>
+						<cYear>2001</cYear>
+						<article_title>The genetics and pathology of oxidative phosphorylation</article_title>
+						<doi>10.1038/35072063</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Nature</journal_title>
+						<author>Stratton</author>
+						<volume>458</volume>
+						<first_page>719</first_page>
+						<cYear>2009</cYear>
+						<article_title>The cancer genome</article_title>
+						<doi>10.1038/nature07943</doi>
+					</citation>
+					<citation key="bib52">
+						<journal_title>The Journal of Clinical Investigation</journal_title>
+						<author>Taylor</author>
+						<volume>112</volume>
+						<first_page>1351</first_page>
+						<cYear>2003</cYear>
+						<article_title>Mitochondrial DNA mutations in human colonic crypt stem cells</article_title>
+						<doi>10.1172/JCI19435</doi>
+					</citation>
+					<citation key="bib53">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Thilly</author>
+						<volume>34</volume>
+						<first_page>255</first_page>
+						<cYear>2003</cYear>
+						<article_title>Have environmental mutagens caused oncomutations in people?</article_title>
+						<doi>10.1038/ng1205</doi>
+					</citation>
+					<citation key="bib54">
+						<journal_title>Brief Bioinform</journal_title>
+						<author>Thorvaldsdottir</author>
+						<volume>14</volume>
+						<first_page>178</first_page>
+						<cYear>2013</cYear>
+						<article_title>Integrative Genomics Viewer (IGV): high-performance genomics data visualization and exploration</article_title>
+						<doi>10.1093/bib/bbs017</doi>
+					</citation>
+					<citation key="bib55">
+						<journal_title>Nature Reviews Cancer</journal_title>
+						<author>Wallace</author>
+						<volume>12</volume>
+						<first_page>685</first_page>
+						<cYear>2012</cYear>
+						<article_title>Mitochondria and cancer</article_title>
+						<doi>10.1038/nrc3365</doi>
+					</citation>
+					<citation key="bib56">
+						<journal_title>Genetics</journal_title>
+						<author>Wright</author>
+						<volume>16</volume>
+						<first_page>97</first_page>
+						<cYear>1931</cYear>
+						<article_title>Evolution in Mendelian populations</article_title>
+					</citation>
+					<citation key="bib57">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Yasukawa</author>
+						<volume>25</volume>
+						<first_page>5358</first_page>
+						<cYear>2006</cYear>
+						<article_title>Replication of vertebrate mitochondrial DNA entails transient ribonucleotide incorporation throughout the lagging strand</article_title>
+						<doi>10.1038/sj.emboj.7601392</doi>
+					</citation>
+					<citation key="bib58">
+						<journal_title>Molecular Cell</journal_title>
+						<author>Yasukawa</author>
+						<volume>18</volume>
+						<first_page>651</first_page>
+						<cYear>2005</cYear>
+						<article_title>A bidirectional origin of replication maps to the major noncoding region of human mitochondrial DNA</article_title>
+						<doi>10.1016/j.molcel.2005.05.002</doi>
+					</citation>
+					<citation key="bib59">
+						<journal_title>Mutation Research</journal_title>
+						<author>Zheng</author>
+						<volume>599</volume>
+						<first_page>11</first_page>
+						<cYear>2006</cYear>
+						<article_title>Origins of human mitochondrial point mutations as DNA polymerase gamma-mediated errors</article_title>
+						<doi>10.1016/j.mrfmmm.2005.12.012</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.001</doi>
+							<resource>https://elifesciences.org/articles/02935#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.002</doi>
+							<resource>https://elifesciences.org/articles/02935#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Table 1.</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.003</doi>
+							<resource>https://elifesciences.org/articles/02935#tbl1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Mitochondrial somatic substitutions identified from 1675 Tumor–Normal pairs.</title>
+							<subtitle>mtDNA genes and intergenic regions are shown. The strand of genes is shown based on mtDNA strand containing equivalent sequences of transcribed RNA. Substitution categories (silent, non-silent (missense and nonsense), non-coding (tRNA and rRNA), and intergenic) are shown by the shapes of each substitution. Six classes of substitutions are presented color-coded. The substitutions on the H, and L strand (when six substitutional classes were considered) are shown outside and inside of mtDNA genes, respectively. Vertical axes for H and L strand substitutions represent the VAF of each variant.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.004</doi>
+							<resource>https://elifesciences.org/articles/02935#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 1. Correlation in amount of mtDNA reads between whole-genome and whole-exome sequencing.</title>
+							<subtitle>139 DNA samples, either from tumors or bloods, sequenced by whole-genome sequencing were additionally sequenced by whole-exome sequencing. We compared the amount of mtDNA reads between whole-genome and whole-exome sequencing. As shown in this figure, we found strong positive correlation. * CGP; Cancer Genome Project, Wellcome Trust Sanger Institute, WUGSC; Washington University Genome Sequencing Center.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.005</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig1s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 2. Correlation of heteroplasmy levels between whole-genome and whole-exome sequencing.</title>
+							<subtitle>To validate the sensitivity and specificity of variant calling in this study, 19 tumor and normal pairs (which were originally whole-genome sequenced) were whole-exome sequenced and mtDNA variants were assessed independently. We correlated the heteroplasmic levels of 20 mutations detected in common.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.006</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig1s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 3. Validation of mtDNA somatic substitutions.</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.007</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig1s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 4. Amount of off-target mtDNA reads across four sequencing centers.</title>
+							<subtitle>* CGP; Cancer Genome Project, Wellcome Trust Sanger Institute (n = 855), WUGSC; Washington University Genome Sequencing Center (n = 140), BCM; Baylor College of Medicine (n = 85), BI; Broad Institute (n = 435).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.008</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig1s4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 5. Filtering samples of potential DNA contaminations.</title>
+							<subtitle>(A) A histogram presenting potential sample swaps in tumor–sample pairs. (B) A histogram presenting potential minor DNA cross-contamination in tumor samples. Cross-contamination levels were considered in filtering substitutions (see “Minor cross-contamination of DNA samples” section in Materials and Methods). (C) Histograms showing number of somatic substitutions overlapping with known inherited polymorphisms and (D) number of back mutations.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.009</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig1s5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. mtDNA somatic substitutions of human cancer.</title>
+							<subtitle>(A) Number of somatic substitutions in a tumor sample. (B) Average number of somatic substitutions per sample across 31 tumor types. (C) Age of diagnosis and number of mtDNA somatic substitutions in breast cancers.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.010</doi>
+							<resource>https://elifesciences.org/articles/02935#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. VAFs of phased somatic mtDNA substitutions.</title>
+							<subtitle>This figure presents VAF pairs between co-clonal, sub-clonal, and different strand mtDNA substitutions. We expect similar VAFs for co-clonal pairs; lower VAF in sub-clonal mutations compared to clonal ones; and sum of a VAF pair is equal or less than 1.0.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.011</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Replicative strand bias for mtDNA somatic substitutions.</title>
+							<subtitle>(A) Replicative strand-specific substitution rate (# of observed/# of expected) by 96 trinucleotide context. Substitutions in a specific mtDNA segment (from Ori-b to OH) are not included, because they present a different substitutional signature. (B) Mutational signature across tumor types. Eighteen tumor types, which include at least 25 mtDNA mutations, were shown. (C) Inverted substitution signature in the Ori-b–OH.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.012</doi>
+							<resource>https://elifesciences.org/articles/02935#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. Replicative strand bias observed in mtDNA substitutions.</title>
+							<subtitle>(A) Mutational signature of mtDNA somatic substitutions on the 12 L strand genes by replicative strand (L/H strand). It agrees very well with the background mutational signature. (Chi-square p = 0.99999). (B) Mutational signature of mtDNA somatic substitutions on the H strand gene (MT-ND6) by replicative strand. It is very close to the background very close to the expected background signature (Chi-square p = 0.027). If we consider signature by transcriptional strand, the signature difference is very clear (Chi-square p = 1 × 10−21). These suggest the strand bias not to be transcription-coupled, but replication coupled. (C) Mutational spectrum of mtDNA somatic substitutions on the 22 tRNA genes by replicative strand. Again, it agrees very well with the background mutational signature (Chi-square p = 0.71). (D) Mutational spectrum of mtDNA somatic substitutions on the 22 tRNA genes by non-transcribed (coding) and transcribed (non-coding) strand. Strand bias was greatly subsided because somatic substitutions on 14 L strand and 8 H strand tRNAs neutralize the strand bias (CH &gt; TH and TL &gt; CL) each other. As a result, this signature of tRNA mutations by transcriptional strand is significantly different from the background one (Chi-square p = 3.3 × 10−12). Taken all together, we concluded that the cause of strand bias is not transcription-coupled but is replicative.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.013</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Mutational signature similar to processes shaping human mtDNA sequence over evolutionary time.</title>
+							<subtitle>(A) Triplet codon depletion in human mtDNA by equivalent (CH &gt; TH and TL &gt; CL) mutational pressure. Relative frequency of each triplet codon within synonymous pairs (NNT–NNC or NNA–NNG) is shown by color. The arrows beside the box highlight the T &gt; C (red) and G &gt; A (blue) substitutional pressures on the L strand in germline mtDNA. (B) Correlation of triplet codon frequencies between from observed and from simulated evolutions of a random sequence mtDNA by the mtDNA somatic mutational signature with constraining mitochondrial protein sequences.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.014</doi>
+							<resource>https://elifesciences.org/articles/02935#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 1. TC and GA skew for L strand mtDNA genes across 8 animal species.</title>
+							<subtitle>C. elegans (a nematode) and D. melanogaster (fruit fly) mtDNA appears to have GL &lt;&lt; AL (due to CH &gt; TH mutational pressure) and CL &gt;&gt; TL (due to CL &gt; TL mutational pressure) in the third base of triplet codon in L strand genes. Therefore they seem to have predominant C &gt; T mutational pressure without strand bias. D. rerio (zebrafish), X. laevis (frog), and M. musculus (mouse) present GL &lt;&lt; AL (due to CH &gt; TH mutational pressure), but similar number of CL and TL. Therefore, mtDNA of these sequences is thought to have CH &gt; TH, with strand bias. The existence of TL &gt; CL is not clear. Finally, mtDNA of H. sapiens, P. troglodytes (Chimpanzee), and G. domesticus (Chicken) shows clear CH &gt; TH and TL &gt; CL as mentioned in the main manuscript. Interestingly, TL &gt; CL seems to be slightly stronger in the mitochondria of chicken than that of human (or chimp). We suggest there would be some differences in the mechanism of mtDNA replication across the evolution tree.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.015</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig4s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 2. Correlation of triplet codon frequencies between from observed and from simulated evolutions under the mtDNA somatic mutational signature.</title>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.016</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig4s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Selection and mutational process for mtDNA somatic substitutions.</title>
+							<subtitle>(A) Truncating mutations (nonsense substitutions and frame-shifting (FS) coding indels) present significantly lower VAF. (B) Change of VAF of mtDNA somatic mutation between primary and metastatic (or late) cancer tissues. (C) Mutational signature for mtDNA across various tumor types. None of the three highlighted mechanisms or nuclear DNA double-strand breaks repair mechanism (BRCA) match with the mtDNA mutational signature. * Only substitutions in protein-coding genes considered. (D) A proposed model of mtDNA mutational process.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.017</doi>
+							<resource>https://elifesciences.org/articles/02935#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5—figure supplement 1. Number of recurrent substitutions between silent and missense substitutions.</title>
+							<subtitle>100 sites were randomly selected from silent substitutions (at third base of triplet codon) and missense substitutions (at first and second base of triplet codon). No significant difference was observed among these three groups.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.018</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig5s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5—figure supplement 2. Comparison of VAF of protein-truncating mutations (nonsense substitution and indels) across tumor types.</title>
+							<subtitle>Four tumor types with more than 10 protein-truncating mutations are shown. Fisher's exact were applied between breast and other tissue types.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.019</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig5s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5—figure supplement 3. Negligible impacts of external mutagens (UV and tobacco smoking) to the somatic mtDNA mutations.</title>
+							<subtitle>No evidence of UV and tobacco smoking was identified even in melanoma and lung cancers, respectively. (Left) We compared the proportion of C &gt; T (and G &gt; A) substitutions in the CpC (GpG) context (mutational signature for UV [Alexandrov et al., 2013]) between melanomas and breast cancers (controls). Because UV shows trivial impact to the nuclear DNA somatic mutations of breast cancers (Alexandrov et al., 2013), the vast majority of mtDNA C &gt; T substitutions in the CpC context from breast cancers were not generated by UV. (Right) We compared the proportion of C &gt; A (G &gt; T) substitutions between lung and breast (control) cancers. C &gt; A (G &gt; T) substitutions are dominantly generated by tobacco smoking. Like UV, the impact of tobacco smoking to the somatic mutations of breast cancers is trivial (Alexandrov et al., 2013).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.020</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#fig5s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 1.</title>
+							<subtitle>Sequencing information of 1675 tumor–normal pairs.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.021</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#SD1-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 2.</title>
+							<subtitle>Catalogs of somatic mutations (substitutions and indels) and inherited polymorphisms identified in this study.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.022</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#SD2-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 3.</title>
+							<subtitle>List of phased somatic substitutions.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.023</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#SD3-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 4.</title>
+							<subtitle>dN/dS for 13 protein-coding genes in mitochondria.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.ms-excel"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.024</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#SD4-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 5.</title>
+							<subtitle>List of somatic substitution with higher recurrent rate than expected.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.025</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#SD5-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Supplementary file 6.</title>
+							<subtitle>Data accession numbers.</subtitle>
+						</titles>
+						<format mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.026</doi>
+							<resource>https://elifesciences.org/articles/02935/figures#SD6-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.027</doi>
+							<resource>https://elifesciences.org/articles/02935#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response image 1. Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.02935.028</doi>
+							<resource>https://elifesciences.org/articles/02935#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-04637-20170717071707.xml
+++ b/tests/test_data/elife-crossref-04637-20170717071707.xml
@@ -743,26 +743,6 @@
 							<resource>https://elifesciences.org/articles/04637/figures#SD2-data</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.04637.011</doi>
-							<resource>https://elifesciences.org/articles/04637#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.04637.012</doi>
-							<resource>https://elifesciences.org/articles/04637#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_data/elife-crossref-04637-20170717071707.xml
+++ b/tests/test_data/elife-crossref-04637-20170717071707.xml
@@ -1,1 +1,770 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-04637-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>03</month><day>25</day><year>2015</year></publication_date><journal_volume><volume>4</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Non-crossover gene conversions show strong GC bias and unexpected clustering in humans</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Amy L</given_name><surname>Williams</surname><affiliation>Department of Biological Sciences, Columbia University, New York, United States</affiliation><affiliation>Department of Systems Biology, Columbia University, New York, United States</affiliation><affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Giulio</given_name><surname>Genovese</surname><affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Thomas</given_name><surname>Dyer</surname><affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Nicolas</given_name><surname>Altemose</surname><affiliation>Wellcome Trust Centre for Human Genetics, Oxford University, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Katherine</given_name><surname>Truax</surname><affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Goo</given_name><surname>Jun</surname><affiliation>Department of Biostatistics, University of Michigan, Ann Arbor, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Nick</given_name><surname>Patterson</surname><affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Simon R</given_name><surname>Myers</surname><affiliation>Wellcome Trust Centre for Human Genetics, Oxford University, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Joanne E</given_name><surname>Curran</surname><affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Ravi</given_name><surname>Duggirala</surname><affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>John</given_name><surname>Blangero</surname><affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>David</given_name><surname>Reich</surname><affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation><affiliation>Department of Genetics, Harvard Medical School, Boston, United States</affiliation><affiliation>Howard Hughes Medical Institute, Harvard Medical School, Boston, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Molly</given_name><surname>Przeworski</surname><affiliation>Department of Biological Sciences, Columbia University, New York, United States</affiliation><affiliation>Department of Systems Biology, Columbia University, New York, United States</affiliation></person_name><organization contributor_role="author" sequence="additional">on behalf of the T2D-GENES Consortium</organization></contributors><jats:abstract><jats:p>Although the past decade has seen tremendous progress in our understanding of fine-scale recombination, little is known about non-crossover (NCO) gene conversion. We report the first genome-wide study of NCO events in humans. Using SNP array data from 98 meioses, we identified 103 sites affected by NCO, of which 50/52 were confirmed in sequence data. Overlap with double strand break (DSB) hotspots indicates that most of the events are likely of meiotic origin. We estimate that a site is involved in a NCO at a rate of 5.9 × 10−6/bp/generation, consistent with sperm-typing studies, and infer that tract lengths span at least an order of magnitude. Observed NCO events show strong allelic bias at heterozygous AT/GC SNPs, with 68% (58–78%) transmitting GC alleles (p = 5 × 10−4). Strikingly, in 4 of 15 regions with resequencing data, multiple disjoint NCO tracts cluster in close proximity (∼20–30 kb), a phenomenon not previously seen in mammals.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>The genetic information inside our cells is stored in the form of chromosomes, which are carefully packaged strands of DNA. Most human cells contain a pair of each chromosome: one inherited from the mother and another from the father. Typically, when a human cell divides, it duplicates all of its chromosomes and then places one copy of each into the two new cells.</jats:p><jats:p>However, a different process—known as ‘meiosis’—occurs when a human cell divides to make the cells involved in sexual reproduction (i.e., egg cells in females and sperm cells in males). First, the cell duplicates all of its chromosomes as before, but then it pairs the chromosomes originally from the mother with the equivalent chromosomes from the father. These paired chromosomes then swap sections of DNA. Next, the cell divides, and the resulting cells divide again; this produces four new cells that each contain a single, unique copy of every chromosome.</jats:p><jats:p>In the process of swapping sections of DNA between chromosomes, the DNA molecule inside the chromosome is broken and different sections of DNA are then joined together. This can occur by one of two methods: ‘crossover events’ that produce a final chromosome made up of long sequences from each of the contributing chromosomes; and ‘non-crossover events’, where only a small section of DNA is swapped between the chromosomes.</jats:p><jats:p>Research has tended to focus on DNA breaks and crossover events. Now, Williams et al. have looked at the genetic sequences transmitted by both parents to 49 humans—revealing information about a total of 98 meioses—and scoured them for evidence of non-crossover events. In addition to finding 103 sites where these events occurred, Williams et al. discovered that non-crossover events are more frequent around sites where crossover events also have a higher frequency. This suggests that the mechanism that initiates non-crossover events is shared with crossovers, and that non-crossover events primarily occur during meiosis. Unexpectedly, in some areas non-crossover events were found close to each other in ‘clusters’, which had not previously been seen in humans.</jats:p><jats:p>Non-crossover events will only produce an observable change if the chromosomes involved have differences in the sequence of the DNA section that is swapped between them. The number of such variable genetic positions that non-crossover events affect in a generation is roughly the same number as the number of newly generated random mutations to the DNA sequence in a generation. Examining the DNA sequences transferred during non-crossover events also shows that two different types of DNA bases (cytosine and guanine) are more likely to be transmitted by a non-crossover event than are the other two bases (adenine and thymine). This bias indicates that non-crossover events are an important factor in driving genome evolution. In the future, sequencing the entire genome—the total genetic material—of many different people could provide further insights into non-crossover events in humans.</jats:p></jats:abstract><publication_date media_type="online"><month>03</month><day>25</day><year>2015</year></publication_date><publisher_item><item_number item_number_type="article_number">e04637</item_number><identifier id_type="doi">10.7554/eLife.04637</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institutes of Health (NIH)<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000002</fr:assertion></fr:assertion><fr:assertion name="award_number">T2D-GENES Consortium</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institutes of Health (NIH)<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000002</fr:assertion></fr:assertion><fr:assertion name="award_number">GM83098</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Howard Hughes Medical Institute (HHMI)<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000011</fr:assertion></fr:assertion><fr:assertion name="award_number">Early Career Scientist</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Howard Hughes Medical Institute (HHMI)<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000011</fr:assertion></fr:assertion><fr:assertion name="award_number">Investigator</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><rel:program><rel:related_item><rel:description>Family Investigation of Nephropathy and Diabetes (FIND) Study Genome-Wide Linkage Analyses of Type 2 Diabetes in Mexican Americans: The San Antonio Family Diabetes/Gallbladder Study</rel:description><rel:inter_work_relation identifier-type="uri" relationship-type="references">http://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000333.v1.p1</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>T2D-GENES Project 2: San Antonio Mexican American Family Studies</rel:description><rel:inter_work_relation identifier-type="uri" relationship-type="references">http://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000462.v1.p1</rel:inter_work_relation></rel:related_item></rel:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.04637</doi><resource>https://elifesciences.org/articles/04637</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/04637/elife-04637-v2.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/04637/elife-04637-v2.xml</resource></item></collection></doi_data><citation_list><citation key="bib2"><journal_title>Human Molecular Genetics</journal_title><author>Antonacci</author><volume>18</volume><first_page>2555</first_page><cYear>2009</cYear><article_title>Characterization of six human disease-associated inversion polymorphisms</article_title><doi>10.1093/hmg/ddp187</doi></citation><citation key="bib3"><journal_title>American Journal of Human Genetics</journal_title><author>Ardlie</author><volume>69</volume><first_page>582</first_page><cYear>2001</cYear><article_title>Lower-than-expected linkage disequilibrium between tightly linked markers in humans suggests a role for gene conversion</article_title><doi>10.1086/323251</doi></citation><citation key="bib4"><journal_title>Science</journal_title><author>Auton</author><volume>336</volume><first_page>193</first_page><cYear>2012</cYear><article_title>A Fine-Scale Chimpanzee genetic map from population sequencing</article_title><doi>10.1126/science.1216872</doi></citation><citation key="bib5"><journal_title>Science</journal_title><author>Bailey</author><volume>297</volume><first_page>1003</first_page><cYear>2002</cYear><article_title>Recent segmental duplications in the human genome</article_title><doi>10.1126/science.1072047</doi></citation><citation key="bib7"><journal_title>Science</journal_title><author>Baudat</author><volume>327</volume><first_page>836</first_page><cYear>2010</cYear><article_title>PRDM9 is a major Determinant of meiotic recombination hotspots in humans and Mice</article_title><doi>10.1126/science.1183439</doi></citation><citation key="bib6"><journal_title>Chromosome Research</journal_title><author>Baudat</author><volume>15</volume><first_page>565</first_page><cYear>2007</cYear><article_title>Regulating double-stranded DNA break repair towards crossover or non-crossover during mammalian meiosis</article_title><doi>10.1007/s10577-007-1140-3</doi></citation><citation key="bib8"><journal_title>Nature Reviews Genetics</journal_title><author>Baudat</author><volume>14</volume><first_page>794</first_page><cYear>2013</cYear><article_title>Meiotic recombination in mammals: localization and regulation</article_title><doi>10.1038/nrg3573</doi></citation><citation key="bib9"><journal_title>Nucleic Acids Research</journal_title><author>Benson</author><volume>42</volume><first_page>D32</first_page><cYear>2014</cYear><article_title>GenBank</article_title><doi>10.1093/nar/gkt1030</doi></citation><citation key="bib10"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Berg</author><volume>108</volume><first_page>12378</first_page><cYear>2011</cYear><article_title>Variants of the protein PRDM9 differentially regulate a set of human meiotic recombination hotspots highly active in African populations</article_title><doi>10.1073/pnas.1109531108</doi></citation><citation key="bib11"><volume_title>Science and statistics: a festschrift for terry speed</volume_title><author>Broman</author><first_page>237</first_page><cYear>2003</cYear><article_title>Common long human inversion polymorphism on chromosome 8p</article_title></citation><citation key="bib12"><journal_title>Nature Genetics</journal_title><author>Campbell</author><volume>44</volume><first_page>1277</first_page><cYear>2012</cYear><article_title>Estimating the human mutation rate using autozygosity in a founder population</article_title><doi>10.1038/ng.2418</doi></citation><citation key="bib14"><journal_title>Nature Cell Biology</journal_title><author>Cole</author><volume>14</volume><first_page>424</first_page><cYear>2012a</cYear><article_title>Homeostatic control of recombination is implemented progressively in mouse meiosis</article_title><doi>10.1038/ncb2451</doi></citation><citation key="bib13"><journal_title>Annals of the New York Academy of Sciences</journal_title><author>Cole</author><volume>1267</volume><first_page>95</first_page><cYear>2012b</cYear><article_title>Preaching about the converted: how meiotic gene conversion influences genomic diversity</article_title><doi>10.1111/j.1749-6632.2012.06595.x</doi></citation><citation key="bib15"><journal_title>Nature Genetics</journal_title><author>Cole</author><volume>46</volume><first_page>1072</first_page><cYear>2014</cYear><article_title>Mouse tetrad analysis provides insights into recombination mechanisms and hotspot evolutionary dynamics</article_title><doi>10.1038/ng.3068</doi></citation><citation key="bib16"><journal_title>The American Journal of Human Genetics</journal_title><author>Duggirala</author><volume>64</volume><first_page>1127</first_page><cYear>1999</cYear><article_title>Linkage of type 2 diabetes mellitus and of age at onset to a genetic location on chromosome 10q in mexican americans</article_title><doi>10.1086/302316</doi></citation><citation key="bib17"><journal_title>Annual Review of Genomics and Human Genetics</journal_title><author>Duret</author><volume>10</volume><first_page>285</first_page><cYear>2009</cYear><article_title>Biased gene conversion and the evolution of mammalian genomic Landscapes</article_title><doi>10.1146/annurev-genom-082908-150001</doi></citation><citation key="bib19"><journal_title>PLOS ONE</journal_title><author>Fledel-Alon</author><volume>6</volume><first_page>e20321</first_page><cYear>2011</cYear><article_title>Variation in human recombination rates and its genetic determinants</article_title><doi>10.1371/journal.pone.0020321</doi></citation><citation key="bib18"><journal_title>PLOS Genetics</journal_title><author>Fledel-Alon</author><volume>5</volume><first_page>e1000658</first_page><cYear>2009</cYear><article_title>Broad-scale recombination patterns underlying proper disjunction in humans</article_title><doi>10.1371/journal.pgen.1000658</doi></citation><citation key="bib20"><journal_title>American Journal of Human Genetics</journal_title><author>Frisse</author><volume>69</volume><first_page>831</first_page><cYear>2001</cYear><article_title>Gene conversion and different population histories may explain the contrast between polymorphism and linkage disequilibrium levels</article_title><doi>10.1086/323612</doi></citation><citation key="bib21"><journal_title>Genome Research</journal_title><author>Fungtammasan</author><volume>22</volume><first_page>993</first_page><cYear>2012</cYear><article_title>A genome-wide analysis of common fragile sites: what features determine chromosomal instability in the human genome?</article_title><doi>10.1101/gr.134395.111</doi></citation><citation key="bib22"><journal_title>Trends in Genetics</journal_title><author>Galtier</author><volume>23</volume><first_page>273</first_page><cYear>2007</cYear><article_title>Adaptation or biased gene conversion? Extending the null hypothesis of molecular evolution</article_title><doi>10.1016/j.tig.2007.03.011</doi></citation><citation key="bib23"><journal_title>Genetics</journal_title><author>Gay</author><volume>177</volume><first_page>881</first_page><cYear>2007</cYear><article_title>Estimating meiotic gene conversion rates from population genetic data</article_title><doi>10.1534/genetics.107.078907</doi></citation><citation key="bib24"><journal_title>American Journal of Human Genetics</journal_title><author>Genovese</author><volume>93</volume><first_page>411</first_page><cYear>2013</cYear><article_title>Mapping the human reference genome s missing sequence by three-way admixture in Latino genomes</article_title><doi>10.1016/j.ajhg.2013.07.002</doi></citation><citation key="bib25"><volume_title>From start to finish: Fine scale mapping of meiotic double strand breaks and gene conversion tracts reveals new insights into homologous recombination</volume_title><author>Globus</author><cYear>2013</cYear></citation><citation key="bib26"><journal_title>Nature</journal_title><author>Hinch</author><volume>476</volume><first_page>170</first_page><cYear>2011</cYear><article_title>The landscape of recombination in African Americans</article_title><doi>10.1038/nature10336</doi></citation><citation key="bib27"><journal_title>Diabetes</journal_title><author>Hunt</author><volume>54</volume><first_page>2655</first_page><cYear>2005</cYear><article_title>Genome-wide linkage analyses of type 2 diabetes in mexican americans: The san antonio family diabetes/gallbladder study</article_title><doi>10.2337/diabetes.54.9.2655</doi></citation><citation key="bib28"><journal_title>Nature Genetics</journal_title><author>Jeffreys</author><volume>36</volume><first_page>151</first_page><cYear>2004</cYear><article_title>Intense and highly localized gene conversion activity in human meiotic crossover hot spots</article_title><doi>10.1038/ng1287</doi></citation><citation key="bib29"><journal_title>Nature</journal_title><author>Kong</author><volume>467</volume><first_page>1099</first_page><cYear>2010</cYear><article_title>Fine-scale recombination rate differences between sexes, populations and individuals</article_title><doi>10.1038/nature09525</doi></citation><citation key="bib30"><journal_title>Molecular Biology and Evolution</journal_title><author>Lesecque</author><volume>30</volume><first_page>1409</first_page><cYear>2013</cYear><article_title>GC-biased gene conversion in yeast is specifically associated with crossovers: molecular mechanisms and evolutionary significance</article_title><doi>10.1093/molbev/mst056</doi></citation><citation key="bib31"><journal_title>PLOS Biology</journal_title><author>Levy</author><volume>5</volume><first_page>e254</first_page><cYear>2007</cYear><article_title>The diploid genome sequence of an individual human</article_title><doi>10.1371/journal.pbio.0050254</doi></citation><citation key="bib32"><journal_title>Bioinformatics</journal_title><author>Li</author><volume>25</volume><first_page>1754</first_page><cYear>2009</cYear><article_title>Fast and accurate short read alignment with Burrows–Wheeler transform</article_title><doi>10.1093/bioinformatics/btp324</doi></citation><citation key="bib33"><journal_title>Nature</journal_title><author>Mancera</author><volume>454</volume><first_page>479</first_page><cYear>2008</cYear><article_title>High-resolution mapping of meiotic crossovers and non-crossovers in yeast</article_title><doi>10.1038/nature07135</doi></citation><citation key="bib34"><journal_title>PLOS Genetics</journal_title><author>Martini</author><volume>7</volume><first_page>e1002305</first_page><cYear>2011</cYear><article_title>Genome-wide analysis of heteroduplex DNA in Mismatch Repair–Deficient yeast cells reveals Novel properties of meiotic recombination pathways</article_title><doi>10.1371/journal.pgen.1002305</doi></citation><citation key="bib35"><journal_title>Science</journal_title><author>McVean</author><volume>304</volume><first_page>581</first_page><cYear>2004</cYear><article_title>The Fine-Scale Structure of recombination rate variation in the human genome</article_title><doi>10.1126/science.1092500</doi></citation><citation key="bib36"><journal_title>Circulation</journal_title><author>Mitchell</author><volume>94</volume><first_page>2159</first_page><cYear>1996</cYear><article_title>Genetic and environmental contributions to cardiovascular risk factors in mexican americans: the san antonio family heart study</article_title><doi>10.1161/01.CIR.94.9.2159</doi></citation><citation key="bib37"><journal_title>Nature Genetics</journal_title><author>Myers</author><volume>40</volume><first_page>1124</first_page><cYear>2008</cYear><article_title>A common sequence motif associated with recombination hot spots and genome instability in humans</article_title><doi>10.1038/ng.213</doi></citation><citation key="bib38"><journal_title>PLOS Genetics</journal_title><author>Odenthal-Hesse</author><volume>10</volume><first_page>e1004106</first_page><cYear>2014</cYear><article_title>Transmission distortion affecting human noncrossover but not crossover recombination: a hidden source of meiotic drive</article_title><doi>10.1371/journal.pgen.1004106</doi></citation><citation key="bib39"><journal_title>Science</journal_title><author>Parvanov</author><volume>327</volume><first_page>835</first_page><cYear>2010</cYear><article_title>Prdm9 controls activation of mammalian recombination hotspots</article_title><doi>10.1126/science.1181495</doi></citation><citation key="bib40"><journal_title>PLOS Genetics</journal_title><author>Patterson</author><volume>2</volume><first_page>e190</first_page><cYear>2006</cYear><article_title>Population structure and eigenanalysis</article_title><doi>10.1371/journal.pgen.0020190</doi></citation><citation key="bib41"><journal_title>Science</journal_title><author>Pratto</author><volume>346</volume><first_page>1256442</first_page><cYear>2014</cYear><article_title>Recombination initiation maps of individual human genomes</article_title><doi>10.1126/science.1256442</doi></citation><citation key="bib41a"><journal_title>Genetical Research</journal_title><author>Przeworski</author><volume>77</volume><first_page>143</first_page><cYear>2001</cYear><article_title>Why is there so little intragenic linkage disequilibrium in humans?</article_title><doi>10.1017/S0016672301004967</doi></citation><citation key="bib42"><journal_title>Annual Review of Genomics and Human Genetics</journal_title><author>Ségurel</author><volume>15</volume><first_page>47</first_page><cYear>2014</cYear><article_title>Determinants of mutation rate variation in the human Germline</article_title><doi>10.1146/annurev-genom-031714-125740</doi></citation><citation key="bib43"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Song</author><volume>111</volume><first_page>E2210</first_page><cYear>2014</cYear><article_title>Genome-wide high-resolution mapping of chromosome fragile sites in Saccharomyces cerevisiae</article_title><doi>10.1073/pnas.1406847111</doi></citation><citation key="bib44"><journal_title>PLOS Genetics</journal_title><author>St Charles</author><volume>9</volume><first_page>e1003434</first_page><cYear>2013</cYear><article_title>High-resolution mapping of spontaneous mitotic recombination hotspots on the 1.1 Mb arm of yeast chromosome IV</article_title><doi>10.1371/journal.pgen.1003434</doi></citation><citation key="bib45"><journal_title>Nature</journal_title><author>The 1000 Genomes Project Consortium</author><volume>491</volume><first_page>56</first_page><cYear>2012</cYear><article_title>An integrated map of genetic variation from 1,092 human genomes</article_title><doi>10.1038/nature11632</doi></citation><citation key="bib46"><journal_title>Nature</journal_title><author>The International HapMap Consortium</author><volume>449</volume><first_page>851</first_page><cYear>2007</cYear><article_title>A second generation human haplotype map of over 3.1 million SNPs</article_title><doi>10.1038/nature06258</doi></citation><citation key="bib47"><journal_title>Molecular Cell</journal_title><author>Tsaponina</author><volume>55</volume><first_page>615</first_page><cYear>2014</cYear><article_title>Frequent Interchromosomal template switches during gene conversion in S. cerevisiae</article_title><doi>10.1016/j.molcel.2014.06.025</doi></citation><citation key="bib48"><journal_title>Proceedings of the National Academy of Sciences of USA</journal_title><author>Webb</author><volume>105</volume><first_page>10471</first_page><cYear>2008</cYear><article_title>Sperm cross-over activity in regions of the human genome showing extreme breakdown of marker association</article_title><doi>10.1073/pnas.0804933105</doi></citation><citation key="bib49"><journal_title>Genome Biology</journal_title><author>Williams</author><volume>11</volume><first_page>R108</first_page><cYear>2010</cYear><article_title>Rapid haplotype inference for nuclear families</article_title><doi>10.1186/gb-2010-11-10-r108</doi></citation><citation key="bib50"><journal_title>PLOS Genetics</journal_title><author>Yin</author><volume>9</volume><first_page>e1003894</first_page><cYear>2013</cYear><article_title>Genome-wide high-resolution mapping of UV-induced mitotic recombination events in Saccharomyces cerevisiae</article_title><doi>10.1371/journal.pgen.1003894</doi></citation><citation key="bib51"><journal_title>Journal of Cell Science</journal_title><author>Youds</author><volume>124</volume><first_page>501</first_page><cYear>2011</cYear><article_title>The choice in meiosis – defining the factors that influence crossover or non-crossover formation</article_title><doi>10.1242/jcs.074427</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.04637.001</doi><resource>https://elifesciences.org/articles/04637#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.04637.002</doi><resource>https://elifesciences.org/articles/04637#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Non-crossover detection.</title><subtitle>(A) Pictorial representation of a haplotype transmission including NCO events. A parent has two copies of each chromosome but transmits only one copy to his or her children. That copy is composed of DNA segments from the parent's two homologs; that is, it is formed by recombination between these two haplotypes. Here, the two haplotypes in the parent are colored in blue and red, and switches in color represent sites of recombination. The figure only depicts short NCO events and no COs. Overlaid on this haplotype are × symbols representing sites assayed by the SNP array. In this example, only one NCO has a SNP array site within it and only that NCO can be identified. (B) To avoid calling false positive NCO events driven by genotyping error, we required putative NCO events first to be detected in a second generation child (top red arrow) and also transmitted to a third generation grandchild (bottom red arrow). We also required that the allele from the opposite haplotype (i.e., the one not affected by the NCO) in the parent (first generation) be transmitted to at least one child in the second generation (blue arrow). This study design ensures that false positive NCOs will only occur if there are two or more genotyping errors at a site. All 34 pedigrees included in this study have genotype data for both parents, at least three children, one or more grandchild, and both parents of included grandchildren. (C) Genomic locations of the NCO sites that we detected are indicated by arrowheads, with red arrowheads representing NCO events from female meioses, and blue from male meioses. Many of the male NCO events localize to the telomeres. (D) Relative chromosomal positions of events, stratified by the sex of the transmitting parent.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.04637.003</doi><resource>https://elifesciences.org/articles/04637#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Proportion of non-crossover sites and rate of GC vs AT allele transmissions across recombination rate bins.</title><subtitle>(A) Histogram of proportions of sites that fall into six ranges of recombination rates from the HapMap2 LD-based map (The International HapMap Consortium, 2007) for the autosomal genome, all informative sites, and the identified NCO sites (see ‘Materials and methods’—‘Crossover and recombination rates’). (B) Rate of transmissions of G or C at AT/GC SNPs, across six recombination rate bins. Plot shows standard error bars.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.04637.004</doi><resource>https://elifesciences.org/articles/04637#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. Proportion of non-crossover sites across crossover rate bins.</title><subtitle>Histogram of proportions of sites that fall into six ranges of crossover rates from the deCODE pedigree map (Kong et al., 2010) for the autosomal genome, all informative sites, and the identified NCO sites (see ‘Materials and methods’—‘Crossover and recombination rates’).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.04637.005</doi><resource>https://elifesciences.org/articles/04637/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Tract lengths for identified non-crossovers.</title><subtitle>Tract lengths for the 22 NCO events that either have two or more SNPs in a tract or have maximum length of ≤5 kb. Each line corresponds to a NCO tract; lower bounds on length appear in color, with red corresponding to tract lengths informed by SNP array data and blue corresponding to tract lengths from sequence data. Gray dashed lines represent the region of uncertainty surrounding the tract length, with the end points being the upper bound on tract length. Tracts are sorted by the upper bound on tract length.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.04637.006</doi><resource>https://elifesciences.org/articles/04637#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Clustered non-crossover events evident in resequencing and SNP array data.</title><subtitle>(A) Recombination patterns in whole genome sequence data for the region surrounding 13 NCO events originally identified in the SNP array data. Each horizontal line represents a haplotype transmission from a single meiosis, and position 0 on the x-axis corresponds to NCO sites identified in the SNP array data. Blue lines depict haplotype segments that derive from the parental homolog transmitted in the wider surrounding region, with blue vertical bars depicting informative sites. Red lines depict segments from the opposite homolog and are putative NCO events, with red arrows indicating informative sites. Grey lines are regions that have ambiguous haplotypic origin. For haplotypes 1–9, only a single site exhibits NCO. For haplotypes 10–13, several NCO sites appear in a short interval near each other but separated by informative SNPs from the background haplotype. Boxes indicate regions for which we preformed Sanger sequencing (see text). (B) Clustered recombination events identified in the SNP array data; note the different scale on the x-axis compared with panel A. Here, haplotypes 14–16 are clustered NCO events while haplotypes 17–22 occur near but not contiguous with CO events (note the switch in haplotype color between the left and right side of the plot). It is uncertain whether the alleles descending from the blue or the red haplotype represent NCO events (‘Materials and methods’—‘Inclusion criteria’); thus the plot uses the same symbol for informative sites from both parental haplotypes. Haplotype 19 also appears to have resulted from a CO, but with informative sites more distant than the range of the plot. Haplotype 21 contains an informative marker that has ambiguous phase in the third generation and therefore was not detected initially, but it is plotted here with a * symbol. The ambiguous phase in the third generation is consistent with neighboring sites and not indicative of an incorrect genotype call.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.04637.007</doi><resource>https://elifesciences.org/articles/04637#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Long-range recombination events observed in sequence data.</title><subtitle>Shown are three contiguous recombination tracts with length ≥ 9 kb, ≥ 16.9 kb, and ≥ 79 kb as well as two sets of clustered long-range recombination events that span ∼200 kb and ∼76 kb.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.04637.008</doi><resource>https://elifesciences.org/articles/04637#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Source code 1.</title><subtitle>Non-crossover event details. TSV file containing information about each NCO site. Descriptions of each column are listed as comments at the beginning of the file.</subtitle></titles><doi_data><doi>10.7554/eLife.04637.009</doi><resource>https://elifesciences.org/articles/04637/figures#SD1-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Source code 2.</title><subtitle>R source code containing statistical analyses of NCO events.</subtitle></titles><doi_data><doi>10.7554/eLife.04637.010</doi><resource>https://elifesciences.org/articles/04637/figures#SD2-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.04637.011</doi><resource>https://elifesciences.org/articles/04637#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.04637.012</doi><resource>https://elifesciences.org/articles/04637#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-04637-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>03</month>
+					<day>25</day>
+					<year>2015</year>
+				</publication_date>
+				<journal_volume>
+					<volume>4</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Non-crossover gene conversions show strong GC bias and unexpected clustering in humans</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Amy L</given_name>
+						<surname>Williams</surname>
+						<affiliation>Department of Biological Sciences, Columbia University, New York, United States</affiliation>
+						<affiliation>Department of Systems Biology, Columbia University, New York, United States</affiliation>
+						<affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Giulio</given_name>
+						<surname>Genovese</surname>
+						<affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Thomas</given_name>
+						<surname>Dyer</surname>
+						<affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Nicolas</given_name>
+						<surname>Altemose</surname>
+						<affiliation>Wellcome Trust Centre for Human Genetics, Oxford University, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Katherine</given_name>
+						<surname>Truax</surname>
+						<affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Goo</given_name>
+						<surname>Jun</surname>
+						<affiliation>Department of Biostatistics, University of Michigan, Ann Arbor, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Nick</given_name>
+						<surname>Patterson</surname>
+						<affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Simon R</given_name>
+						<surname>Myers</surname>
+						<affiliation>Wellcome Trust Centre for Human Genetics, Oxford University, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Joanne E</given_name>
+						<surname>Curran</surname>
+						<affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Ravi</given_name>
+						<surname>Duggirala</surname>
+						<affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>John</given_name>
+						<surname>Blangero</surname>
+						<affiliation>Department of Genetics, Texas Biomedical Research Institute, San Antonio, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>David</given_name>
+						<surname>Reich</surname>
+						<affiliation>Program in Medical and Population Genetics, Broad Institute of Harvard and MIT, Cambridge, United States</affiliation>
+						<affiliation>Department of Genetics, Harvard Medical School, Boston, United States</affiliation>
+						<affiliation>Howard Hughes Medical Institute, Harvard Medical School, Boston, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Molly</given_name>
+						<surname>Przeworski</surname>
+						<affiliation>Department of Biological Sciences, Columbia University, New York, United States</affiliation>
+						<affiliation>Department of Systems Biology, Columbia University, New York, United States</affiliation>
+					</person_name>
+					<organization contributor_role="author" sequence="additional">on behalf of the T2D-GENES Consortium</organization>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Although the past decade has seen tremendous progress in our understanding of fine-scale recombination, little is known about non-crossover (NCO) gene conversion. We report the first genome-wide study of NCO events in humans. Using SNP array data from 98 meioses, we identified 103 sites affected by NCO, of which 50/52 were confirmed in sequence data. Overlap with double strand break (DSB) hotspots indicates that most of the events are likely of meiotic origin. We estimate that a site is involved in a NCO at a rate of 5.9 × 10−6/bp/generation, consistent with sperm-typing studies, and infer that tract lengths span at least an order of magnitude. Observed NCO events show strong allelic bias at heterozygous AT/GC SNPs, with 68% (58–78%) transmitting GC alleles (p = 5 × 10−4). Strikingly, in 4 of 15 regions with resequencing data, multiple disjoint NCO tracts cluster in close proximity (∼20–30 kb), a phenomenon not previously seen in mammals.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>The genetic information inside our cells is stored in the form of chromosomes, which are carefully packaged strands of DNA. Most human cells contain a pair of each chromosome: one inherited from the mother and another from the father. Typically, when a human cell divides, it duplicates all of its chromosomes and then places one copy of each into the two new cells.</jats:p>
+					<jats:p>However, a different process—known as ‘meiosis’—occurs when a human cell divides to make the cells involved in sexual reproduction (i.e., egg cells in females and sperm cells in males). First, the cell duplicates all of its chromosomes as before, but then it pairs the chromosomes originally from the mother with the equivalent chromosomes from the father. These paired chromosomes then swap sections of DNA. Next, the cell divides, and the resulting cells divide again; this produces four new cells that each contain a single, unique copy of every chromosome.</jats:p>
+					<jats:p>In the process of swapping sections of DNA between chromosomes, the DNA molecule inside the chromosome is broken and different sections of DNA are then joined together. This can occur by one of two methods: ‘crossover events’ that produce a final chromosome made up of long sequences from each of the contributing chromosomes; and ‘non-crossover events’, where only a small section of DNA is swapped between the chromosomes.</jats:p>
+					<jats:p>Research has tended to focus on DNA breaks and crossover events. Now, Williams et al. have looked at the genetic sequences transmitted by both parents to 49 humans—revealing information about a total of 98 meioses—and scoured them for evidence of non-crossover events. In addition to finding 103 sites where these events occurred, Williams et al. discovered that non-crossover events are more frequent around sites where crossover events also have a higher frequency. This suggests that the mechanism that initiates non-crossover events is shared with crossovers, and that non-crossover events primarily occur during meiosis. Unexpectedly, in some areas non-crossover events were found close to each other in ‘clusters’, which had not previously been seen in humans.</jats:p>
+					<jats:p>Non-crossover events will only produce an observable change if the chromosomes involved have differences in the sequence of the DNA section that is swapped between them. The number of such variable genetic positions that non-crossover events affect in a generation is roughly the same number as the number of newly generated random mutations to the DNA sequence in a generation. Examining the DNA sequences transferred during non-crossover events also shows that two different types of DNA bases (cytosine and guanine) are more likely to be transmitted by a non-crossover event than are the other two bases (adenine and thymine). This bias indicates that non-crossover events are an important factor in driving genome evolution. In the future, sequencing the entire genome—the total genetic material—of many different people could provide further insights into non-crossover events in humans.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>03</month>
+					<day>25</day>
+					<year>2015</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e04637</item_number>
+					<identifier id_type="doi">10.7554/eLife.04637</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institutes of Health (NIH)
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000002</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">T2D-GENES Consortium</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institutes of Health (NIH)
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000002</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">GM83098</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Howard Hughes Medical Institute (HHMI)
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000011</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Early Career Scientist</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Howard Hughes Medical Institute (HHMI)
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000011</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Investigator</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<rel:program>
+					<rel:related_item>
+						<rel:description>Family Investigation of Nephropathy and Diabetes (FIND) Study Genome-Wide Linkage Analyses of Type 2 Diabetes in Mexican Americans: The San Antonio Family Diabetes/Gallbladder Study</rel:description>
+						<rel:inter_work_relation identifier-type="uri" relationship-type="references">http://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000333.v1.p1</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>T2D-GENES Project 2: San Antonio Mexican American Family Studies</rel:description>
+						<rel:inter_work_relation identifier-type="uri" relationship-type="references">http://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000462.v1.p1</rel:inter_work_relation>
+					</rel:related_item>
+				</rel:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.04637</doi>
+					<resource>https://elifesciences.org/articles/04637</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/04637/elife-04637-v2.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/04637/elife-04637-v2.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib2">
+						<journal_title>Human Molecular Genetics</journal_title>
+						<author>Antonacci</author>
+						<volume>18</volume>
+						<first_page>2555</first_page>
+						<cYear>2009</cYear>
+						<article_title>Characterization of six human disease-associated inversion polymorphisms</article_title>
+						<doi>10.1093/hmg/ddp187</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Ardlie</author>
+						<volume>69</volume>
+						<first_page>582</first_page>
+						<cYear>2001</cYear>
+						<article_title>Lower-than-expected linkage disequilibrium between tightly linked markers in humans suggests a role for gene conversion</article_title>
+						<doi>10.1086/323251</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>Science</journal_title>
+						<author>Auton</author>
+						<volume>336</volume>
+						<first_page>193</first_page>
+						<cYear>2012</cYear>
+						<article_title>A Fine-Scale Chimpanzee genetic map from population sequencing</article_title>
+						<doi>10.1126/science.1216872</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>Science</journal_title>
+						<author>Bailey</author>
+						<volume>297</volume>
+						<first_page>1003</first_page>
+						<cYear>2002</cYear>
+						<article_title>Recent segmental duplications in the human genome</article_title>
+						<doi>10.1126/science.1072047</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>Science</journal_title>
+						<author>Baudat</author>
+						<volume>327</volume>
+						<first_page>836</first_page>
+						<cYear>2010</cYear>
+						<article_title>PRDM9 is a major Determinant of meiotic recombination hotspots in humans and Mice</article_title>
+						<doi>10.1126/science.1183439</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Chromosome Research</journal_title>
+						<author>Baudat</author>
+						<volume>15</volume>
+						<first_page>565</first_page>
+						<cYear>2007</cYear>
+						<article_title>Regulating double-stranded DNA break repair towards crossover or non-crossover during mammalian meiosis</article_title>
+						<doi>10.1007/s10577-007-1140-3</doi>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Nature Reviews Genetics</journal_title>
+						<author>Baudat</author>
+						<volume>14</volume>
+						<first_page>794</first_page>
+						<cYear>2013</cYear>
+						<article_title>Meiotic recombination in mammals: localization and regulation</article_title>
+						<doi>10.1038/nrg3573</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Benson</author>
+						<volume>42</volume>
+						<first_page>D32</first_page>
+						<cYear>2014</cYear>
+						<article_title>GenBank</article_title>
+						<doi>10.1093/nar/gkt1030</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Berg</author>
+						<volume>108</volume>
+						<first_page>12378</first_page>
+						<cYear>2011</cYear>
+						<article_title>Variants of the protein PRDM9 differentially regulate a set of human meiotic recombination hotspots highly active in African populations</article_title>
+						<doi>10.1073/pnas.1109531108</doi>
+					</citation>
+					<citation key="bib11">
+						<volume_title>Science and statistics: a festschrift for terry speed</volume_title>
+						<author>Broman</author>
+						<first_page>237</first_page>
+						<cYear>2003</cYear>
+						<article_title>Common long human inversion polymorphism on chromosome 8p</article_title>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Campbell</author>
+						<volume>44</volume>
+						<first_page>1277</first_page>
+						<cYear>2012</cYear>
+						<article_title>Estimating the human mutation rate using autozygosity in a founder population</article_title>
+						<doi>10.1038/ng.2418</doi>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Nature Cell Biology</journal_title>
+						<author>Cole</author>
+						<volume>14</volume>
+						<first_page>424</first_page>
+						<cYear>2012a</cYear>
+						<article_title>Homeostatic control of recombination is implemented progressively in mouse meiosis</article_title>
+						<doi>10.1038/ncb2451</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Annals of the New York Academy of Sciences</journal_title>
+						<author>Cole</author>
+						<volume>1267</volume>
+						<first_page>95</first_page>
+						<cYear>2012b</cYear>
+						<article_title>Preaching about the converted: how meiotic gene conversion influences genomic diversity</article_title>
+						<doi>10.1111/j.1749-6632.2012.06595.x</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Cole</author>
+						<volume>46</volume>
+						<first_page>1072</first_page>
+						<cYear>2014</cYear>
+						<article_title>Mouse tetrad analysis provides insights into recombination mechanisms and hotspot evolutionary dynamics</article_title>
+						<doi>10.1038/ng.3068</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>The American Journal of Human Genetics</journal_title>
+						<author>Duggirala</author>
+						<volume>64</volume>
+						<first_page>1127</first_page>
+						<cYear>1999</cYear>
+						<article_title>Linkage of type 2 diabetes mellitus and of age at onset to a genetic location on chromosome 10q in mexican americans</article_title>
+						<doi>10.1086/302316</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Annual Review of Genomics and Human Genetics</journal_title>
+						<author>Duret</author>
+						<volume>10</volume>
+						<first_page>285</first_page>
+						<cYear>2009</cYear>
+						<article_title>Biased gene conversion and the evolution of mammalian genomic Landscapes</article_title>
+						<doi>10.1146/annurev-genom-082908-150001</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>PLOS ONE</journal_title>
+						<author>Fledel-Alon</author>
+						<volume>6</volume>
+						<first_page>e20321</first_page>
+						<cYear>2011</cYear>
+						<article_title>Variation in human recombination rates and its genetic determinants</article_title>
+						<doi>10.1371/journal.pone.0020321</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>Fledel-Alon</author>
+						<volume>5</volume>
+						<first_page>e1000658</first_page>
+						<cYear>2009</cYear>
+						<article_title>Broad-scale recombination patterns underlying proper disjunction in humans</article_title>
+						<doi>10.1371/journal.pgen.1000658</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Frisse</author>
+						<volume>69</volume>
+						<first_page>831</first_page>
+						<cYear>2001</cYear>
+						<article_title>Gene conversion and different population histories may explain the contrast between polymorphism and linkage disequilibrium levels</article_title>
+						<doi>10.1086/323612</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Genome Research</journal_title>
+						<author>Fungtammasan</author>
+						<volume>22</volume>
+						<first_page>993</first_page>
+						<cYear>2012</cYear>
+						<article_title>A genome-wide analysis of common fragile sites: what features determine chromosomal instability in the human genome?</article_title>
+						<doi>10.1101/gr.134395.111</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>Trends in Genetics</journal_title>
+						<author>Galtier</author>
+						<volume>23</volume>
+						<first_page>273</first_page>
+						<cYear>2007</cYear>
+						<article_title>Adaptation or biased gene conversion? Extending the null hypothesis of molecular evolution</article_title>
+						<doi>10.1016/j.tig.2007.03.011</doi>
+					</citation>
+					<citation key="bib23">
+						<journal_title>Genetics</journal_title>
+						<author>Gay</author>
+						<volume>177</volume>
+						<first_page>881</first_page>
+						<cYear>2007</cYear>
+						<article_title>Estimating meiotic gene conversion rates from population genetic data</article_title>
+						<doi>10.1534/genetics.107.078907</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>American Journal of Human Genetics</journal_title>
+						<author>Genovese</author>
+						<volume>93</volume>
+						<first_page>411</first_page>
+						<cYear>2013</cYear>
+						<article_title>Mapping the human reference genome s missing sequence by three-way admixture in Latino genomes</article_title>
+						<doi>10.1016/j.ajhg.2013.07.002</doi>
+					</citation>
+					<citation key="bib25">
+						<volume_title>From start to finish: Fine scale mapping of meiotic double strand breaks and gene conversion tracts reveals new insights into homologous recombination</volume_title>
+						<author>Globus</author>
+						<cYear>2013</cYear>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Nature</journal_title>
+						<author>Hinch</author>
+						<volume>476</volume>
+						<first_page>170</first_page>
+						<cYear>2011</cYear>
+						<article_title>The landscape of recombination in African Americans</article_title>
+						<doi>10.1038/nature10336</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Diabetes</journal_title>
+						<author>Hunt</author>
+						<volume>54</volume>
+						<first_page>2655</first_page>
+						<cYear>2005</cYear>
+						<article_title>Genome-wide linkage analyses of type 2 diabetes in mexican americans: The san antonio family diabetes/gallbladder study</article_title>
+						<doi>10.2337/diabetes.54.9.2655</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Jeffreys</author>
+						<volume>36</volume>
+						<first_page>151</first_page>
+						<cYear>2004</cYear>
+						<article_title>Intense and highly localized gene conversion activity in human meiotic crossover hot spots</article_title>
+						<doi>10.1038/ng1287</doi>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Nature</journal_title>
+						<author>Kong</author>
+						<volume>467</volume>
+						<first_page>1099</first_page>
+						<cYear>2010</cYear>
+						<article_title>Fine-scale recombination rate differences between sexes, populations and individuals</article_title>
+						<doi>10.1038/nature09525</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Molecular Biology and Evolution</journal_title>
+						<author>Lesecque</author>
+						<volume>30</volume>
+						<first_page>1409</first_page>
+						<cYear>2013</cYear>
+						<article_title>GC-biased gene conversion in yeast is specifically associated with crossovers: molecular mechanisms and evolutionary significance</article_title>
+						<doi>10.1093/molbev/mst056</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>PLOS Biology</journal_title>
+						<author>Levy</author>
+						<volume>5</volume>
+						<first_page>e254</first_page>
+						<cYear>2007</cYear>
+						<article_title>The diploid genome sequence of an individual human</article_title>
+						<doi>10.1371/journal.pbio.0050254</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Bioinformatics</journal_title>
+						<author>Li</author>
+						<volume>25</volume>
+						<first_page>1754</first_page>
+						<cYear>2009</cYear>
+						<article_title>Fast and accurate short read alignment with Burrows–Wheeler transform</article_title>
+						<doi>10.1093/bioinformatics/btp324</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Nature</journal_title>
+						<author>Mancera</author>
+						<volume>454</volume>
+						<first_page>479</first_page>
+						<cYear>2008</cYear>
+						<article_title>High-resolution mapping of meiotic crossovers and non-crossovers in yeast</article_title>
+						<doi>10.1038/nature07135</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>Martini</author>
+						<volume>7</volume>
+						<first_page>e1002305</first_page>
+						<cYear>2011</cYear>
+						<article_title>Genome-wide analysis of heteroduplex DNA in Mismatch Repair–Deficient yeast cells reveals Novel properties of meiotic recombination pathways</article_title>
+						<doi>10.1371/journal.pgen.1002305</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>Science</journal_title>
+						<author>McVean</author>
+						<volume>304</volume>
+						<first_page>581</first_page>
+						<cYear>2004</cYear>
+						<article_title>The Fine-Scale Structure of recombination rate variation in the human genome</article_title>
+						<doi>10.1126/science.1092500</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>Circulation</journal_title>
+						<author>Mitchell</author>
+						<volume>94</volume>
+						<first_page>2159</first_page>
+						<cYear>1996</cYear>
+						<article_title>Genetic and environmental contributions to cardiovascular risk factors in mexican americans: the san antonio family heart study</article_title>
+						<doi>10.1161/01.CIR.94.9.2159</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Myers</author>
+						<volume>40</volume>
+						<first_page>1124</first_page>
+						<cYear>2008</cYear>
+						<article_title>A common sequence motif associated with recombination hot spots and genome instability in humans</article_title>
+						<doi>10.1038/ng.213</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>Odenthal-Hesse</author>
+						<volume>10</volume>
+						<first_page>e1004106</first_page>
+						<cYear>2014</cYear>
+						<article_title>Transmission distortion affecting human noncrossover but not crossover recombination: a hidden source of meiotic drive</article_title>
+						<doi>10.1371/journal.pgen.1004106</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>Science</journal_title>
+						<author>Parvanov</author>
+						<volume>327</volume>
+						<first_page>835</first_page>
+						<cYear>2010</cYear>
+						<article_title>Prdm9 controls activation of mammalian recombination hotspots</article_title>
+						<doi>10.1126/science.1181495</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>Patterson</author>
+						<volume>2</volume>
+						<first_page>e190</first_page>
+						<cYear>2006</cYear>
+						<article_title>Population structure and eigenanalysis</article_title>
+						<doi>10.1371/journal.pgen.0020190</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Science</journal_title>
+						<author>Pratto</author>
+						<volume>346</volume>
+						<first_page>1256442</first_page>
+						<cYear>2014</cYear>
+						<article_title>Recombination initiation maps of individual human genomes</article_title>
+						<doi>10.1126/science.1256442</doi>
+					</citation>
+					<citation key="bib41a">
+						<journal_title>Genetical Research</journal_title>
+						<author>Przeworski</author>
+						<volume>77</volume>
+						<first_page>143</first_page>
+						<cYear>2001</cYear>
+						<article_title>Why is there so little intragenic linkage disequilibrium in humans?</article_title>
+						<doi>10.1017/S0016672301004967</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Annual Review of Genomics and Human Genetics</journal_title>
+						<author>Ségurel</author>
+						<volume>15</volume>
+						<first_page>47</first_page>
+						<cYear>2014</cYear>
+						<article_title>Determinants of mutation rate variation in the human Germline</article_title>
+						<doi>10.1146/annurev-genom-031714-125740</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Song</author>
+						<volume>111</volume>
+						<first_page>E2210</first_page>
+						<cYear>2014</cYear>
+						<article_title>Genome-wide high-resolution mapping of chromosome fragile sites in Saccharomyces cerevisiae</article_title>
+						<doi>10.1073/pnas.1406847111</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>St Charles</author>
+						<volume>9</volume>
+						<first_page>e1003434</first_page>
+						<cYear>2013</cYear>
+						<article_title>High-resolution mapping of spontaneous mitotic recombination hotspots on the 1.1 Mb arm of yeast chromosome IV</article_title>
+						<doi>10.1371/journal.pgen.1003434</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>Nature</journal_title>
+						<author>The 1000 Genomes Project Consortium</author>
+						<volume>491</volume>
+						<first_page>56</first_page>
+						<cYear>2012</cYear>
+						<article_title>An integrated map of genetic variation from 1,092 human genomes</article_title>
+						<doi>10.1038/nature11632</doi>
+					</citation>
+					<citation key="bib46">
+						<journal_title>Nature</journal_title>
+						<author>The International HapMap Consortium</author>
+						<volume>449</volume>
+						<first_page>851</first_page>
+						<cYear>2007</cYear>
+						<article_title>A second generation human haplotype map of over 3.1 million SNPs</article_title>
+						<doi>10.1038/nature06258</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Molecular Cell</journal_title>
+						<author>Tsaponina</author>
+						<volume>55</volume>
+						<first_page>615</first_page>
+						<cYear>2014</cYear>
+						<article_title>Frequent Interchromosomal template switches during gene conversion in S. cerevisiae</article_title>
+						<doi>10.1016/j.molcel.2014.06.025</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Proceedings of the National Academy of Sciences of USA</journal_title>
+						<author>Webb</author>
+						<volume>105</volume>
+						<first_page>10471</first_page>
+						<cYear>2008</cYear>
+						<article_title>Sperm cross-over activity in regions of the human genome showing extreme breakdown of marker association</article_title>
+						<doi>10.1073/pnas.0804933105</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Genome Biology</journal_title>
+						<author>Williams</author>
+						<volume>11</volume>
+						<first_page>R108</first_page>
+						<cYear>2010</cYear>
+						<article_title>Rapid haplotype inference for nuclear families</article_title>
+						<doi>10.1186/gb-2010-11-10-r108</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>PLOS Genetics</journal_title>
+						<author>Yin</author>
+						<volume>9</volume>
+						<first_page>e1003894</first_page>
+						<cYear>2013</cYear>
+						<article_title>Genome-wide high-resolution mapping of UV-induced mitotic recombination events in Saccharomyces cerevisiae</article_title>
+						<doi>10.1371/journal.pgen.1003894</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Journal of Cell Science</journal_title>
+						<author>Youds</author>
+						<volume>124</volume>
+						<first_page>501</first_page>
+						<cYear>2011</cYear>
+						<article_title>The choice in meiosis – defining the factors that influence crossover or non-crossover formation</article_title>
+						<doi>10.1242/jcs.074427</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.001</doi>
+							<resource>https://elifesciences.org/articles/04637#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.002</doi>
+							<resource>https://elifesciences.org/articles/04637#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Non-crossover detection.</title>
+							<subtitle>(A) Pictorial representation of a haplotype transmission including NCO events. A parent has two copies of each chromosome but transmits only one copy to his or her children. That copy is composed of DNA segments from the parent's two homologs; that is, it is formed by recombination between these two haplotypes. Here, the two haplotypes in the parent are colored in blue and red, and switches in color represent sites of recombination. The figure only depicts short NCO events and no COs. Overlaid on this haplotype are × symbols representing sites assayed by the SNP array. In this example, only one NCO has a SNP array site within it and only that NCO can be identified. (B) To avoid calling false positive NCO events driven by genotyping error, we required putative NCO events first to be detected in a second generation child (top red arrow) and also transmitted to a third generation grandchild (bottom red arrow). We also required that the allele from the opposite haplotype (i.e., the one not affected by the NCO) in the parent (first generation) be transmitted to at least one child in the second generation (blue arrow). This study design ensures that false positive NCOs will only occur if there are two or more genotyping errors at a site. All 34 pedigrees included in this study have genotype data for both parents, at least three children, one or more grandchild, and both parents of included grandchildren. (C) Genomic locations of the NCO sites that we detected are indicated by arrowheads, with red arrowheads representing NCO events from female meioses, and blue from male meioses. Many of the male NCO events localize to the telomeres. (D) Relative chromosomal positions of events, stratified by the sex of the transmitting parent.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.003</doi>
+							<resource>https://elifesciences.org/articles/04637#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Proportion of non-crossover sites and rate of GC vs AT allele transmissions across recombination rate bins.</title>
+							<subtitle>(A) Histogram of proportions of sites that fall into six ranges of recombination rates from the HapMap2 LD-based map (The International HapMap Consortium, 2007) for the autosomal genome, all informative sites, and the identified NCO sites (see ‘Materials and methods’—‘Crossover and recombination rates’). (B) Rate of transmissions of G or C at AT/GC SNPs, across six recombination rate bins. Plot shows standard error bars.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.004</doi>
+							<resource>https://elifesciences.org/articles/04637#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. Proportion of non-crossover sites across crossover rate bins.</title>
+							<subtitle>Histogram of proportions of sites that fall into six ranges of crossover rates from the deCODE pedigree map (Kong et al., 2010) for the autosomal genome, all informative sites, and the identified NCO sites (see ‘Materials and methods’—‘Crossover and recombination rates’).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.005</doi>
+							<resource>https://elifesciences.org/articles/04637/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Tract lengths for identified non-crossovers.</title>
+							<subtitle>Tract lengths for the 22 NCO events that either have two or more SNPs in a tract or have maximum length of ≤5 kb. Each line corresponds to a NCO tract; lower bounds on length appear in color, with red corresponding to tract lengths informed by SNP array data and blue corresponding to tract lengths from sequence data. Gray dashed lines represent the region of uncertainty surrounding the tract length, with the end points being the upper bound on tract length. Tracts are sorted by the upper bound on tract length.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.006</doi>
+							<resource>https://elifesciences.org/articles/04637#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Clustered non-crossover events evident in resequencing and SNP array data.</title>
+							<subtitle>(A) Recombination patterns in whole genome sequence data for the region surrounding 13 NCO events originally identified in the SNP array data. Each horizontal line represents a haplotype transmission from a single meiosis, and position 0 on the x-axis corresponds to NCO sites identified in the SNP array data. Blue lines depict haplotype segments that derive from the parental homolog transmitted in the wider surrounding region, with blue vertical bars depicting informative sites. Red lines depict segments from the opposite homolog and are putative NCO events, with red arrows indicating informative sites. Grey lines are regions that have ambiguous haplotypic origin. For haplotypes 1–9, only a single site exhibits NCO. For haplotypes 10–13, several NCO sites appear in a short interval near each other but separated by informative SNPs from the background haplotype. Boxes indicate regions for which we preformed Sanger sequencing (see text). (B) Clustered recombination events identified in the SNP array data; note the different scale on the x-axis compared with panel A. Here, haplotypes 14–16 are clustered NCO events while haplotypes 17–22 occur near but not contiguous with CO events (note the switch in haplotype color between the left and right side of the plot). It is uncertain whether the alleles descending from the blue or the red haplotype represent NCO events (‘Materials and methods’—‘Inclusion criteria’); thus the plot uses the same symbol for informative sites from both parental haplotypes. Haplotype 19 also appears to have resulted from a CO, but with informative sites more distant than the range of the plot. Haplotype 21 contains an informative marker that has ambiguous phase in the third generation and therefore was not detected initially, but it is plotted here with a * symbol. The ambiguous phase in the third generation is consistent with neighboring sites and not indicative of an incorrect genotype call.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.007</doi>
+							<resource>https://elifesciences.org/articles/04637#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Long-range recombination events observed in sequence data.</title>
+							<subtitle>Shown are three contiguous recombination tracts with length ≥ 9 kb, ≥ 16.9 kb, and ≥ 79 kb as well as two sets of clustered long-range recombination events that span ∼200 kb and ∼76 kb.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.008</doi>
+							<resource>https://elifesciences.org/articles/04637#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Source code 1.</title>
+							<subtitle>Non-crossover event details. TSV file containing information about each NCO site. Descriptions of each column are listed as comments at the beginning of the file.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.04637.009</doi>
+							<resource>https://elifesciences.org/articles/04637/figures#SD1-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Source code 2.</title>
+							<subtitle>R source code containing statistical analyses of NCO events.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.04637.010</doi>
+							<resource>https://elifesciences.org/articles/04637/figures#SD2-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.011</doi>
+							<resource>https://elifesciences.org/articles/04637#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.04637.012</doi>
+							<resource>https://elifesciences.org/articles/04637#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-08206-20170717071707.xml
+++ b/tests/test_data/elife-crossref-08206-20170717071707.xml
@@ -799,26 +799,6 @@
 							<resource>https://elifesciences.org/articles/08206#fig5</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.08206.026</doi>
-							<resource>https://elifesciences.org/articles/08206#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.08206.027</doi>
-							<resource>https://elifesciences.org/articles/08206#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_data/elife-crossref-08206-20170717071707.xml
+++ b/tests/test_data/elife-crossref-08206-20170717071707.xml
@@ -1,1 +1,826 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-08206-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>12</month><day>09</day><year>2015</year></publication_date><journal_volume><volume>4</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Extracellular space preservation aids the connectomic analysis of neural circuits</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Marta</given_name><surname>Pallotto</surname><affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation><ORCID authenticated="true">http://orcid.org/0000-0001-7694-0398</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>Paul V</given_name><surname>Watkins</surname><affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Boma</given_name><surname>Fubara</surname><affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Joshua H</given_name><surname>Singer</surname><affiliation>Department of Biology, University of Maryland, College Park, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Kevin L</given_name><surname>Briggman</surname><affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation><affiliation>Department of Biomedical Optics, Max Planck Institute for Medical Research, Heidelberg, Germany</affiliation></person_name></contributors><jats:abstract><jats:p>Dense connectomic mapping of neuronal circuits is limited by the time and effort required to analyze 3D electron microscopy (EM) datasets. Algorithms designed to automate image segmentation suffer from substantial error rates and require significant manual error correction. Any improvement in segmentation error rates would therefore directly reduce the time required to analyze 3D EM data. We explored preserving extracellular space (ECS) during chemical tissue fixation to improve the ability to segment neurites and to identify synaptic contacts. ECS preserved tissue is easier to segment using machine learning algorithms, leading to significantly reduced error rates. In addition, we observed that electrical synapses are readily identified in ECS preserved tissue. Finally, we determined that antibodies penetrate deep into ECS preserved tissue with only minimal permeabilization, thereby enabling correlated light microscopy (LM) and EM studies. We conclude that preservation of ECS benefits multiple aspects of the connectomic analysis of neural circuits.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>The brain consists of billions of neurons that are connected into many different circuits. Mapping the connections between these neurons could help researchers to understand how the nervous system works. A method commonly used to do so is to preserve samples of brain tissue in chemical fixatives, and then image thin slices of this tissue using powerful microscopes.</jats:p><jats:p>As each tissue sample contains many neurons, computer algorithms have been developed to analyze the microscope images and automatically identify the neurons and the connections they make. However, these algorithms often make 'segmentation errors' that researchers need to manually correct: for example, overlapping neurons may be counted as a single neuron, or a neuron may be marked into several segments. Correcting these errors is a time-consuming and tedious task that limits how much of the brain can be currently mapped. Future algorithm improvements will hopefully reduce the number of errors; Pallotto, Watkins et al. explored an alternative approach by making the images themselves easier to analyze using existing algorithms.</jats:p><jats:p>The chemicals used to preserve brain tissue often suck out the fluids that fill the spaces between the neurons, causing these 'extracellular spaces' to shrink. Pallotto, Watkins et al. have now developed a method of preserving tissue that maintains more space between the neurons, and used this method to preserve samples of mouse brain with different amounts of extracellular space. Pallotto, Watkins et al. found that the algorithm used to analyze the images of these samples made far fewer segmentation errors on samples that contained more extracellular space. It was also easier to identify the connections between different neurons in these samples. The next challenge will be to extend these methods to preserving extracellular space across whole brains.</jats:p></jats:abstract><publication_date media_type="online"><month>12</month><day>09</day><year>2015</year></publication_date><publisher_item><item_number item_number_type="article_number">e08206</item_number><identifier id_type="doi">10.7554/eLife.08206</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Institute of Neurological Disorders and Stroke<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000065</fr:assertion></fr:assertion><fr:assertion name="award_number">Intramural Research Program (NS003133)</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">National Eye Institute<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000053</fr:assertion></fr:assertion><fr:assertion name="award_number">EY017836</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Pew Charitable Trusts<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000875</fr:assertion></fr:assertion><fr:assertion name="award_number">Pew Scholars Program in the Biomedical Sciences</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Max-Planck-Gesellschaft<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100004189</fr:assertion></fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref></ai:program><rel:program><rel:related_item><rel:description>Extracellular space preservation aids the connectomic analysis of neural circuits</rel:description><rel:inter_work_relation identifier-type="doi" relationship-type="isSupplementedBy">10.5061/dryad.36h28</rel:inter_work_relation></rel:related_item><rel:related_item><rel:description>Data from: extracellular space preservation aids the connectomic analysis of neural circuits</rel:description><rel:inter_work_relation identifier-type="doi" relationship-type="references">10.5061/dryad.36h28</rel:inter_work_relation></rel:related_item></rel:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.08206</doi><resource>https://elifesciences.org/articles/08206</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/08206/elife-08206-v3.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/08206/elife-08206-v3.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>Scientific American</journal_title><author>Appel</author><volume>237</volume><first_page>108</first_page><cYear>1977</cYear><article_title>The Solution of the Four-color-map Problem</article_title><doi>10.1038/scientificamerican1077-108</doi></citation><citation key="bib2"><journal_title>Neuron</journal_title><author>Berning</author><volume>87</volume><first_page>1193</first_page><cYear>2015</cYear><article_title>SegEM: efficient image analysis for high-resolution connectomics</article_title><doi>10.1016/j.neuron.2015.09.003</doi></citation><citation key="bib3"><journal_title>Nature Protocols</journal_title><author>Bischofberger</author><volume>1</volume><first_page>2075</first_page><cYear>2006</cYear><article_title>Patch-clamp recording from mossy fiber terminals in hippocampal slices</article_title><doi>10.1038/nprot.2006.312</doi></citation><citation key="bib4"><volume_title>Neural Networks for Pattern Recognition</volume_title><author>Bishop</author><cYear>1995</cYear></citation><citation key="bib5"><journal_title>The Histochemical Journal</journal_title><author>Bone</author><volume>4</volume><first_page>331</first_page><cYear>1972</cYear><article_title>Osmolarity of osmium tetroxide and glutaraldehyde fixatives</article_title><doi>10.1007/BF01005008</doi></citation><citation key="bib6"><journal_title>Neuropharmacology</journal_title><author>Bourne</author><volume>52</volume><first_page>55</first_page><cYear>2007</cYear><article_title>Warmer preparation of hippocampal slices prevents synapse proliferation that might obscure LTP-related structural plasticity</article_title><doi>10.1016/j.neuropharm.2006.06.020</doi></citation><citation key="bib7"><journal_title>Current Opinion in Neurobiology</journal_title><author>Briggman</author><volume>22</volume><first_page>154</first_page><cYear>2012</cYear><article_title>Volume electron microscopy for neuronal circuit reconstruction</article_title><doi>10.1016/j.conb.2011.10.022</doi></citation><citation key="bib8"><journal_title>Nature</journal_title><author>Briggman</author><volume>471</volume><first_page>183</first_page><cYear>2011</cYear><article_title>Wiring specificity in the direction-selectivity circuit of the retina</article_title><doi>10.1038/nature09818</doi></citation><citation key="bib9"><journal_title>Neutral Information Processing Systems(2012)</journal_title><author>Ciresan</author><cYear>2012</cYear><article_title>Deep neural networks segment neuronal membranes in electron microscopy images</article_title></citation><citation key="bib10"><journal_title>Neuroscience Letters</journal_title><author>Cragg</author><volume>15</volume><first_page>301</first_page><cYear>1979</cYear><article_title>Brain extracellular space fixed for electron microscopy</article_title><doi>10.1016/0304-3940(79)96130-5</doi></citation><citation key="bib11"><journal_title>Tissue and Cell</journal_title><author>Cragg</author><volume>12</volume><first_page>63</first_page><cYear>1980</cYear><article_title>Preservation of extracellular space during fixation of the brain for electron microscopy</article_title><doi>10.1016/0040-8166(80)90052-X</doi></citation><citation key="bib12"><journal_title>Visual Neuroscience</journal_title><author>Demb</author><volume>29</volume><first_page>51</first_page><cYear>2012</cYear><article_title>Intrinsic properties and functional circuitry of the AII amacrine cell</article_title><doi>10.1017/S0952523811000368</doi></citation><citation key="bib13"><journal_title>PLoS Biology</journal_title><author>Denk</author><volume>2</volume><cYear>2004</cYear><article_title>Serial block-face scanning electron microscopy to reconstruct three-dimensional tissue nanostructure</article_title><doi>10.1371/journal.pbio.0020329</doi><elocation_id>e329</elocation_id></citation><citation key="bib14"><journal_title>Brain Research</journal_title><author>Hartveit</author><volume>1487</volume><first_page>160</first_page><cYear>2012</cYear><article_title>Electrical synapses between AII amacrine cells in the retina: Function and modulation</article_title><doi>10.1016/j.brainres.2012.05.060</doi></citation><citation key="bib15"><journal_title>Nature Neuroscience</journal_title><author>Helmstaedter</author><volume>14</volume><first_page>1081</first_page><cYear>2011</cYear><article_title>High-accuracy neurite reconstruction for high-throughput neuroanatomy</article_title><doi>10.1038/nn.2868</doi></citation><citation key="bib16"><journal_title>Nature</journal_title><author>Helmstaedter</author><volume>500</volume><first_page>168</first_page><cYear>2013</cYear><article_title>Connectomic reconstruction of the inner plexiform layer in the mouse retina</article_title><doi>10.1038/nature12346</doi></citation><citation key="bib17"><journal_title>Neural and Evolutionary Computing</journal_title><author>Hinton</author><cYear>2012</cYear><article_title>Improving neural networks by preventing co-adaptation of feature detectors</article_title><elocation_id>arXiv:1207.0580v1</elocation_id></citation><citation key="bib18"><journal_title>Journal of Classification</journal_title><author>Hubert</author><volume>2</volume><first_page>193</first_page><cYear>1985</cYear><article_title>Comparing partitions</article_title></citation><citation key="bib19"><author>Jain</author><cYear>2010</cYear><article_title>Boundary learning by optimization with topological constraints</article_title><unstructured_citation>Jain BV, Bollman B, Richardson M, Berger DR, Helmstaedter MN, Briggman KL, Denk W, Bowden JB, Mendenhall JM, Abraham WC, Harris KM, Kasthuri N, Hayworth KJ, Schalek R, Tapia JC, Lichtman JW, Seung HS. 2010. Boundary learning by optimization with topological constraints. Computer Vision and Pattern Recognition (CVPR), 2010 IEEE Conference On, IEEE.</unstructured_citation></citation><citation key="bib20"><author>Jain</author><cYear>2007</cYear><article_title>Supervised learning of image restoration with convolutional networks</article_title><unstructured_citation>Jain V, Murray JF, Roth F, Turaga S, Zhigulin V, Briggman KL, Helmstaedter MN. 2007. Supervised learning of image restoration with convolutional networks. Computer Vision, 2007. ICCV 2007. IEEE 11th International Conference On.</unstructured_citation></citation><citation key="bib21"><journal_title>Current Opinion in Neurobiology</journal_title><author>Jain</author><volume>20</volume><first_page>653</first_page><cYear>2010</cYear><article_title>Machines that learn to segment images: a crucial technology for connectomics</article_title><doi>10.1016/j.conb.2010.07.004</doi></citation><citation key="bib22"><journal_title>Advances in Neural Information Processing Systems</journal_title><author>Jain</author><volume>24</volume><first_page>648</first_page><cYear>2011</cYear><article_title>Learning to agglomerate superpixel hierarchies</article_title></citation><citation key="bib23"><journal_title>The Journal of Neuroscience</journal_title><author>Johnson</author><volume>23</volume><first_page>518</first_page><cYear>2003</cYear><article_title>Vesicular neurotransmitter transporter expression in developing postnatal rodent retina: GABA and glycine precede glutamate</article_title></citation><citation key="bib24"><journal_title>Medical Image Analysis</journal_title><author>Jurrus</author><volume>14</volume><first_page>770</first_page><cYear>2010</cYear><article_title>Detection of neuron membranes in electron microscopy images using a serial neural network architecture</article_title><doi>10.1016/j.media.2010.06.002</doi></citation><citation key="bib25"><journal_title>Nature</journal_title><author>Kim</author><volume>509</volume><first_page>331</first_page><cYear>2014</cYear><article_title>Space–time wiring specificity supports direction selectivity in the retina</article_title><doi>10.1038/nature13240</doi></citation><citation key="bib26"><journal_title>Neuroscience</journal_title><author>Kirov</author><volume>127</volume><first_page>69</first_page><cYear>2004</cYear><article_title>Dendritic spines disappear with chilling but proliferate excessively upon rewarming of mature hippocampus</article_title><doi>10.1016/j.neuroscience.2004.04.053</doi></citation><citation key="bib27"><journal_title>Computer Vision, Graphics, and Image Processing</journal_title><author>Kong</author><volume>48</volume><first_page>357</first_page><cYear>1989</cYear><article_title>Digital topology: Introduction and survey</article_title><doi>10.1016/0734-189X(89)90147-3</doi></citation><citation key="bib28"><journal_title>eLife</journal_title><author>Korogod</author><volume>4</volume><cYear>2015</cYear><article_title>Ultrastructural analysis of adult mouse neocortex comparing aldehyde perfusion with cryo fixation</article_title><doi>10.7554/eLife.05793</doi><elocation_id>e05793</elocation_id></citation><citation key="bib29"><journal_title>NeuroReport</journal_title><author>Koulen</author><volume>8</volume><first_page>2845</first_page><cYear>1997</cYear><article_title>Vesicular acetylcholine transporter (VAChT)</article_title><doi>10.1097/00001756-199709080-00008</doi></citation><citation key="bib30"><author>Krizhevsky</author><cYear>2012</cYear><article_title>Imagenet classification with deep convolutional neural networks</article_title><unstructured_citation>Krizhevsky A, Sutskever I, Hinton GE. 2012. Imagenet classification with deep convolutional neural networks. Neutral Information Processing Systems(2012).</unstructured_citation></citation><citation key="bib31"><journal_title>Image Analysis &amp; Stereology</journal_title><author>Legland</author><volume>26</volume><first_page>83</first_page><cYear>2011</cYear><article_title>Computation of Minkowski measures on 2D and 3D binary images</article_title><doi>10.5566/ias.v26.p83-92</doi></citation><citation key="bib32"><journal_title>PLoS ONE</journal_title><author>Nunez-Iglesias</author><volume>8</volume><cYear>2013</cYear><article_title>Machine learning of hierarchical clustering to segment 2D and 3D images</article_title><doi>10.1371/journal.pone.0071715.s004</doi><elocation_id>e71715</elocation_id></citation><citation key="bib33"><journal_title>Frontiers in Neuroinformatics</journal_title><author>Nunez-Iglesias</author><volume>8</volume><first_page>2274</first_page><cYear>2014</cYear><article_title>Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages</article_title><doi>10.1109/TPAMI.2012.120</doi></citation><citation key="bib34"><volume_title>Dryad Digital Repository</volume_title><author>Pallotto</author><cYear>2015</cYear><article_title>Data from: extracellular space preservation aids the connectomic analysis of neural circuits</article_title><doi>10.5061/dryad.36h28</doi></citation><citation key="bib35"><volume_title>The Fine Structure of the Nervous System: Neurons and Their Supporting Cells</volume_title><author>Peters</author><cYear>1991</cYear></citation><citation key="bib36"><journal_title>Cell Biology International</journal_title><author>Rash</author><volume>22</volume><first_page>731</first_page><cYear>1998</cYear><article_title>Ultrastructure, histological distribution, and freeze-fracture immunocytochemistry of gap junctions in rat brain and spinal cord</article_title><doi>10.1006/cbir.1998.0392</doi></citation><citation key="bib37"><journal_title>Pattern Recognition, Springer Berlin Heidelberg</journal_title><author>Rigoll</author><volume>5096</volume><first_page>142</first_page><cYear>2008</cYear><article_title>Segmentation of SBFSEM volume data of neural tissue by hierarchical classification</article_title></citation><citation key="bib38"><journal_title>Journal of Histochemistry &amp; Cytochemistry</journal_title><author>Rostaing</author><volume>52</volume><first_page>1</first_page><cYear>2004</cYear><article_title>Preservation of Immunoreactivity and Fine Structure of Adult C. elegans Tissues Using High-pressure Freezing</article_title><doi>10.1177/002215540405200101</doi></citation><citation key="bib39"><journal_title>The Journal of Comparative Neurology</journal_title><author>Strettoi</author><volume>325</volume><first_page>152</first_page><cYear>1992</cYear><article_title>Synaptic connections of the narrow-field, bistratified rod amacrine cell (aII) in the rabbit retina</article_title><doi>10.1002/cne.903250203</doi></citation><citation key="bib40"><journal_title>Physiological Reviews</journal_title><author>Sykova</author><volume>88</volume><first_page>1277</first_page><cYear>2008</cYear><article_title>Diffusion in brain extracellular space</article_title><doi>10.1152/physrev.00027.2007</doi></citation><citation key="bib41"><journal_title>Nature</journal_title><author>Takemura</author><volume>500</volume><first_page>175</first_page><cYear>2013</cYear><article_title>A visual motion detection circuit suggested by Drosophila connectomics</article_title><doi>10.1038/nature12450</doi></citation><citation key="bib42"><journal_title>The Journal of Comparative Neurology</journal_title><author>Tao-Cheng</author><volume>501</volume><first_page>731</first_page><cYear>2007</cYear><article_title>Structural changes at synapses after delayed perfusion fixation in different regions of the mouse brain</article_title><doi>10.1002/cne.21276</doi></citation><citation key="bib43"><journal_title>Neural Computation</journal_title><author>Turaga</author><volume>22</volume><first_page>511</first_page><cYear>2010</cYear><article_title>Convolutional networks can learn to generate affinity graphs for image segmentation</article_title><doi>10.1098/rstb.1986.0056</doi></citation><citation key="bib44"><journal_title>The Anatomical Record</journal_title><author>van Harreveld</author><volume>182</volume><first_page>377</first_page><cYear>1975</cYear><article_title>Rapid freezing of deep cerebral structures for electron microscopy</article_title><doi>10.1002/ar.1091820311</doi></citation><citation key="bib45"><journal_title>Journal of Anatomy</journal_title><author>van Harreveld</author><volume>101</volume><first_page>197</first_page><cYear>1967</cYear><article_title>Extracellular space in the cerebral cortex of the mouse</article_title></citation><citation key="bib46"><journal_title>The Anatomical Record</journal_title><author>van Harreveld</author><volume>166</volume><first_page>117</first_page><cYear>1970</cYear><article_title>Extracellular space in frozen and ethanol substituted central nervous tissue</article_title><doi>10.1002/ar.1091660109</doi></citation><citation key="bib47"><journal_title>Journal of Cell Science</journal_title><author>Van Harreveld</author><volume>6</volume><first_page>793</first_page><cYear>1970</cYear><article_title>The magnitude of the extracellular space in electron micrographs of superficial and deep regions of the cerebral cortex</article_title></citation><citation key="bib48"><journal_title>Springer Berlin Heidelberg</journal_title><author>Vucetic</author><volume>2167</volume><first_page>527</first_page><cYear>2001</cYear><article_title>Classification on Data with Biased Class Distribution</article_title></citation><citation key="bib49"><journal_title>Nature</journal_title><author>Young</author><volume>135</volume><first_page>823</first_page><cYear>1935</cYear><article_title>Osmotic pressure of fixing solutions</article_title><doi>10.1038/135823b0</doi></citation><citation key="bib50"><journal_title>NeuroImage</journal_title><author>Yushkevich</author><volume>31</volume><first_page>1116</first_page><cYear>2006</cYear><article_title>User-guided 3D active contour segmentation of anatomical structures: significantly improved efficiency and reliability</article_title><doi>10.1016/j.neuroimage.2006.01.015</doi></citation><citation key="bib51"><journal_title>Computer Vision and Pattern Recognition</journal_title><author>Zeiler</author><cYear>2013</cYear><article_title>Visualizing and understanding convolutional neural networks</article_title><elocation_id>arXiv:1311.2901v3</elocation_id></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.08206.001</doi><resource>https://elifesciences.org/articles/08206#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.08206.002</doi><resource>https://elifesciences.org/articles/08206#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. ECS preservation in acutely isolated tissues.</title><subtitle>(A) A model of the changes brain tissue undergoes during chemical tissue fixation and possible interventions to preserve ECS. (B) ECS fraction of mouse olfactory bulb (x), retina (o), and cortex (□) correlates with increasing fixative vehicle concentration. Dashed line is the linear fit to olfactory bulb data, solid line is the linear fit to cortex data (olfactory bulb: R = 0.80, p = 0.0006; cortex: R = 0.79, p = 0.0113). (C–F) EM images from the external plexiform layer of the mouse olfactory bulb from a perfused brain (C) or from acute sections fixed with increasing buffer concentrations (D–F). ECS fractions are 0.6% (C), 5.8% (D), 11.3% (E), and 23.9% (F). Scale bars: 1 µm (C–F). ECS: Extracellular space; EM: Electron microscopy.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.003</doi><resource>https://elifesciences.org/articles/08206#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 1. Change of tissue dimensions and uniformity of ECS preserved sections.</title><subtitle>(A) Vibratome sections were cut from the cerebral cortex of acutely isolated brains (for ECS preservation) or from perfused animals. Section thickness was nominally 500 µm as determined by the slice thickness setting of the vibratome. Sections were stained for EM and the cross-sectional thickness measured from EM images (mean +/- SEM; n = 20 slices from 6 animals, one-way ANOVA: p = 0.46). (B) Sample images from the edges (Bi, Biii) and center (Bii) of a 500-µm-thick section of the mouse olfactory bulb. ECS is evenly preserved across the section. ECS: Extracellular space; EM: Electron microscopy.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.004</doi><resource>https://elifesciences.org/articles/08206/figures#fig1s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 2. Effect of temperature on the preservation of ECS.</title><subtitle>(A,B) Vibratome sections were cut from the olfactory bulbs of acutely isolated brains at either 4°C or 25°C and then fixed at 25°C in 0.1 M CB + 2% GA. (C,D) Vibratome sections were cut from the olfactory bulbs of acutely isolated brains at either 4°C or 25°C and then fixed at 25°C in 0.2 M CB + 2% GA. ECS preservation was similar under both conditions indicating the temperature of solutions during tissue dissection is not a major determinant for ECS preservation. Scale bars: 1 μm. ECS: Extracellular space; EM: Electron microscopy.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.005</doi><resource>https://elifesciences.org/articles/08206/figures#fig1s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Automated 2D segmentation of extracellular space preserved data.</title><subtitle>(A) Four raw EM images (first column) of varying ECS fractions (0.6, 5.8, 11.3, and 23.9%) were analyzed. The lowest ECS fraction (0.6%) is the perfused preparation while the others are the acute slice preparations. Pixels in each image were annotated (second column) as either intracellular (white), extracellular (gray), or plasma membrane (black). Representative test image pixel classifications (third column) yielded network classification errors of 9.3, 8.1, 6.7, and 7.2% for the four examples shown. Intracellular pixel probabilities were thresholded and segmented (fourth column) to yield minimum Rand errors of 0.11, 0.06, 0.06, and 0.07 for the four examples shown. (B) Pixel classification errors plotted versus ECS fraction from an ninefold cross-validation, median values in red, shows no significant difference between perfused and acute preparations (K-W test: p=0.05). (C) Rand error plotted versus ECS fraction for the ninefold cross-validation, median values in red, shows a significant difference between perfused and acute preparations (K-W test: p&lt;0.01; Wilcoxon rank-sum test: p=0.0017 [5.8%], p=0.0091 [11.3%], p=0.031 [23.9%]). (D) Total number of splits and merger per object in each test image plotted versus ECS fraction for the ninefold cross-validation, median values in red, shows a significant difference between perfused and acute preparations (K-W test: p&lt;0.001; Wilcoxon rank-sum test: p=0.00049 [5.8%], p=0.00035 [11.3%], p=0.00035 [23.9%]). Scale bars: 2 μm. p-Values: *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001. ECS: Extracellular space; EM: Electron microscopy.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.006</doi><resource>https://elifesciences.org/articles/08206#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—source data 1. Raw image and expert labels of 0.6% ECS data.</title><subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.007</doi><resource>https://elifesciences.org/articles/08206/figures#SD1-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—source data 2. Raw image and expert labels of 5.8% ECS data.</title><subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.008</doi><resource>https://elifesciences.org/articles/08206/figures#SD2-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—source data 3. Raw image and expert labels of 11.3% ECS data.</title><subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.009</doi><resource>https://elifesciences.org/articles/08206/figures#SD3-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—source data 4. Raw image and expert labels of 23.9% ECS data.</title><subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.010</doi><resource>https://elifesciences.org/articles/08206/figures#SD4-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. Warping error of automated segmentations.</title><subtitle>(A) Split/merger curves parameterized by threshold of the network output. Shaded area is the standard error of the mean, lines are the mean number of splits/mergers per object, and the circles are the mean of the minimum total splits + mergers per object. (B) Network segmentations at the minimum warping error threshold, same regions as in Figure 2A. Warping errors were 0.68 (0.6% ECS), 0.32 (5.8% ECS), 0.52 (11.3% ECS), and 0.56 (23.9% ECS) for the four examples shown. (C) Cumulative distributions of the number of ground truth intracellular pixels per object for the four datasets. The difference in these distributions motivated the use of a Bernoulli sampling procedure for calculating the adapted Rand Error metrics in Figure 2C. Scale bars: 2 μm. ECS: Extracellular space.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.011</doi><resource>https://elifesciences.org/articles/08206/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Automated 3D segmentation of extracellular space preserved data.</title><subtitle>(A) A 10 x 10 x 12 μm3 3D SBEM cube (left) of perfused tissue (LowECS), a dense skeletonization of all neurites in the volume (middle), and an automated segmentation of the volume (right). (B) A 10 x 10 x 12 μm3 3D SBEM cube (left) of ECS-preserved tissue (HighECS), a dense skeletonization of all neurites in the volume (middle), and an automated segmentation of the volume (right). (C) Adapted Rand error of automated segmentations compared to dense skeletonizations as a function of the segmentation threshold for the HighECS (brown) and LowECS (blue) data volumes. (D) The fraction of merged skeleton nodes versus split skeleton edges as a function of network threshold. Solid points indicate the minimum sum of the error fractions. (E) The total error-free skeleton path length recovered as a function of network threshold. Shaded regions in C–E are the 99% confidence intervals based on a Bernoulli sampling of the data. Scale bars in A, B = 1 μm. SBEM: Serial block-face scanning electron microscopy.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.012</doi><resource>https://elifesciences.org/articles/08206#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—source data 1. M0027_11 dense skeletonization, Knossos NML file.</title></titles><doi_data><doi>10.7554/eLife.08206.013</doi><resource>https://elifesciences.org/articles/08206/figures#SD5-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—source data 2. M0007_33 dense skeletonization, Knossos NML file.</title></titles><doi_data><doi>10.7554/eLife.08206.014</doi><resource>https://elifesciences.org/articles/08206/figures#SD6-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—source data 3. M0007_33 training data cubes.</title></titles><doi_data><doi>10.7554/eLife.08206.015</doi><resource>https://elifesciences.org/articles/08206/figures#SD7-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—source data 4. M0027_11 training data cubes.</title></titles><doi_data><doi>10.7554/eLife.08206.016</doi><resource>https://elifesciences.org/articles/08206/figures#SD8-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. Cumulative distributions for 3D hand-labeled volumes and skeletonizations of the LowECS (blue) and HighECS (brown) data volumes.</title><subtitle>(A) Cumulative distribution frequency (CDF) of number of intracellular ground truth voxels per object. The distribution medians are significantly different (Wilcoxon rank-sum test, p &lt;0.0001). (B) CDF of path length per skeleton, medians 10.2 (LowECS) and 10.1 (HighECS) μm. The distributions are not significantly different (two-sample Kolmogorov–Smirnov (KS) test, p = 0.91). (C) CDF of the number of nodes annotated per skeleton, medians 16 (LowECS) and 17 (HighECS) nodes. The distributions not significantly different (two-sample KS test, p = 0.77).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.017</doi><resource>https://elifesciences.org/articles/08206/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Extracellular space aids the identification of gap junctions.</title><subtitle>(A) Reconstructed dendrites of an AII amacrine cell (gray) and surface renderings of tight (yellow) and cleft (black) contacts. (B-D) Example EM images and volumetric reconstructions of (B) an AII (gray) to AII (blue) tight contact, (C) an AII (gray) to cone bipolar cell (green) tight contact (C), and (D) a cleft contact identified as a chemical synapse between a presynaptic amacrine cell (cyan) and the AII cell (gray). (E) Tight contact surface renderings color-coded by the identity of the synaptic partner: AII amacrine cell (blue), cone bipolar cell (green), presynaptic amacrine cell (cyan). (F) Summary of the number of contacts color-coded by the cell type of the contacting cell: AII (blue), cone bipolar (green), presynaptic amacrine cell (cyan), other (black). Scale bars: 2 µm (A,E), 1 µm (B–D). EM: Electron microscopy.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.018</doi><resource>https://elifesciences.org/articles/08206#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—source data 1. Example image stack of an A2 to A2 tight contact.</title><subtitle>TIFF stack viewable using ImageJ. Slice #128 in the stack indicates the location of the tight contact.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.019</doi><resource>https://elifesciences.org/articles/08206/figures#SD9-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—source data 2. Example image stack of a cone bipolar to A2 tight contact.</title><subtitle>TIFF stack viewable using ImageJ. Slice #128 in the stack indicates the location of the tight contact.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.020</doi><resource>https://elifesciences.org/articles/08206/figures#SD10-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—source data 3. Example image stack of a chemical synapse to A2 cleft contact.</title><subtitle>TIFF stack viewable using ImageJ. Slice #128 in the stack indicates the location of the cleft contact.</subtitle></titles><doi_data><doi>10.7554/eLife.08206.021</doi><resource>https://elifesciences.org/articles/08206/figures#SD11-data</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 1. Simple measures of contact geometry do not predict gap junctions.</title><subtitle>(A) Surface area and the volume of the convex hull bounding each contact are plotted for cleft contacts (gray), AII amacrine cell tight contacts (blue) and cone bipolar cell tight contacts (green).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.022</doi><resource>https://elifesciences.org/articles/08206/figures#fig4s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Extracellular space preservation increases access to antibodies.</title><subtitle>(A) Flat-mounted retinas were immunolabeled for vACHT with and without ECS preservation. Retinas were then cross-sectioned and confocal images were taken to directly visualize penetration depth. (B) Same as A, but immunolabeled for vGAT. (C) Fullwidth half-maximal penetration distances (mean +/- SEM) for retinas with and without ECS preservation (n = 20 retina slices from two animals, unpaired Student’s t-test, vACHT: ***p&lt;0.0001, vGAT: ***p&lt;0.0001). (D) EM images collected from the regions of interest in panel B indicated by dotted rectangles. Scale bars: 50 μm (A,B), 1 μm (D).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.08206.023</doi><resource>https://elifesciences.org/articles/08206#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.08206.026</doi><resource>https://elifesciences.org/articles/08206#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.08206.027</doi><resource>https://elifesciences.org/articles/08206#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-08206-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>12</month>
+					<day>09</day>
+					<year>2015</year>
+				</publication_date>
+				<journal_volume>
+					<volume>4</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Extracellular space preservation aids the connectomic analysis of neural circuits</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Marta</given_name>
+						<surname>Pallotto</surname>
+						<affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0001-7694-0398</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Paul V</given_name>
+						<surname>Watkins</surname>
+						<affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Boma</given_name>
+						<surname>Fubara</surname>
+						<affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Joshua H</given_name>
+						<surname>Singer</surname>
+						<affiliation>Department of Biology, University of Maryland, College Park, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Kevin L</given_name>
+						<surname>Briggman</surname>
+						<affiliation>Circuit Dynamics and Connectivity Unit, National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, United States</affiliation>
+						<affiliation>Department of Biomedical Optics, Max Planck Institute for Medical Research, Heidelberg, Germany</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>Dense connectomic mapping of neuronal circuits is limited by the time and effort required to analyze 3D electron microscopy (EM) datasets. Algorithms designed to automate image segmentation suffer from substantial error rates and require significant manual error correction. Any improvement in segmentation error rates would therefore directly reduce the time required to analyze 3D EM data. We explored preserving extracellular space (ECS) during chemical tissue fixation to improve the ability to segment neurites and to identify synaptic contacts. ECS preserved tissue is easier to segment using machine learning algorithms, leading to significantly reduced error rates. In addition, we observed that electrical synapses are readily identified in ECS preserved tissue. Finally, we determined that antibodies penetrate deep into ECS preserved tissue with only minimal permeabilization, thereby enabling correlated light microscopy (LM) and EM studies. We conclude that preservation of ECS benefits multiple aspects of the connectomic analysis of neural circuits.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>The brain consists of billions of neurons that are connected into many different circuits. Mapping the connections between these neurons could help researchers to understand how the nervous system works. A method commonly used to do so is to preserve samples of brain tissue in chemical fixatives, and then image thin slices of this tissue using powerful microscopes.</jats:p>
+					<jats:p>As each tissue sample contains many neurons, computer algorithms have been developed to analyze the microscope images and automatically identify the neurons and the connections they make. However, these algorithms often make 'segmentation errors' that researchers need to manually correct: for example, overlapping neurons may be counted as a single neuron, or a neuron may be marked into several segments. Correcting these errors is a time-consuming and tedious task that limits how much of the brain can be currently mapped. Future algorithm improvements will hopefully reduce the number of errors; Pallotto, Watkins et al. explored an alternative approach by making the images themselves easier to analyze using existing algorithms.</jats:p>
+					<jats:p>The chemicals used to preserve brain tissue often suck out the fluids that fill the spaces between the neurons, causing these 'extracellular spaces' to shrink. Pallotto, Watkins et al. have now developed a method of preserving tissue that maintains more space between the neurons, and used this method to preserve samples of mouse brain with different amounts of extracellular space. Pallotto, Watkins et al. found that the algorithm used to analyze the images of these samples made far fewer segmentation errors on samples that contained more extracellular space. It was also easier to identify the connections between different neurons in these samples. The next challenge will be to extend these methods to preserving extracellular space across whole brains.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>12</month>
+					<day>09</day>
+					<year>2015</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e08206</item_number>
+					<identifier id_type="doi">10.7554/eLife.08206</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Institute of Neurological Disorders and Stroke
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000065</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Intramural Research Program (NS003133)</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							National Eye Institute
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000053</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">EY017836</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Pew Charitable Trusts
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100000875</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Pew Scholars Program in the Biomedical Sciences</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Max-Planck-Gesellschaft
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100004189</fr:assertion>
+						</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+				</ai:program>
+				<rel:program>
+					<rel:related_item>
+						<rel:description>Extracellular space preservation aids the connectomic analysis of neural circuits</rel:description>
+						<rel:inter_work_relation identifier-type="doi" relationship-type="isSupplementedBy">10.5061/dryad.36h28</rel:inter_work_relation>
+					</rel:related_item>
+					<rel:related_item>
+						<rel:description>Data from: extracellular space preservation aids the connectomic analysis of neural circuits</rel:description>
+						<rel:inter_work_relation identifier-type="doi" relationship-type="references">10.5061/dryad.36h28</rel:inter_work_relation>
+					</rel:related_item>
+				</rel:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.08206</doi>
+					<resource>https://elifesciences.org/articles/08206</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/08206/elife-08206-v3.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/08206/elife-08206-v3.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>Scientific American</journal_title>
+						<author>Appel</author>
+						<volume>237</volume>
+						<first_page>108</first_page>
+						<cYear>1977</cYear>
+						<article_title>The Solution of the Four-color-map Problem</article_title>
+						<doi>10.1038/scientificamerican1077-108</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Neuron</journal_title>
+						<author>Berning</author>
+						<volume>87</volume>
+						<first_page>1193</first_page>
+						<cYear>2015</cYear>
+						<article_title>SegEM: efficient image analysis for high-resolution connectomics</article_title>
+						<doi>10.1016/j.neuron.2015.09.003</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Nature Protocols</journal_title>
+						<author>Bischofberger</author>
+						<volume>1</volume>
+						<first_page>2075</first_page>
+						<cYear>2006</cYear>
+						<article_title>Patch-clamp recording from mossy fiber terminals in hippocampal slices</article_title>
+						<doi>10.1038/nprot.2006.312</doi>
+					</citation>
+					<citation key="bib4">
+						<volume_title>Neural Networks for Pattern Recognition</volume_title>
+						<author>Bishop</author>
+						<cYear>1995</cYear>
+					</citation>
+					<citation key="bib5">
+						<journal_title>The Histochemical Journal</journal_title>
+						<author>Bone</author>
+						<volume>4</volume>
+						<first_page>331</first_page>
+						<cYear>1972</cYear>
+						<article_title>Osmolarity of osmium tetroxide and glutaraldehyde fixatives</article_title>
+						<doi>10.1007/BF01005008</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Neuropharmacology</journal_title>
+						<author>Bourne</author>
+						<volume>52</volume>
+						<first_page>55</first_page>
+						<cYear>2007</cYear>
+						<article_title>Warmer preparation of hippocampal slices prevents synapse proliferation that might obscure LTP-related structural plasticity</article_title>
+						<doi>10.1016/j.neuropharm.2006.06.020</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>Current Opinion in Neurobiology</journal_title>
+						<author>Briggman</author>
+						<volume>22</volume>
+						<first_page>154</first_page>
+						<cYear>2012</cYear>
+						<article_title>Volume electron microscopy for neuronal circuit reconstruction</article_title>
+						<doi>10.1016/j.conb.2011.10.022</doi>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Nature</journal_title>
+						<author>Briggman</author>
+						<volume>471</volume>
+						<first_page>183</first_page>
+						<cYear>2011</cYear>
+						<article_title>Wiring specificity in the direction-selectivity circuit of the retina</article_title>
+						<doi>10.1038/nature09818</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Neutral Information Processing Systems(2012)</journal_title>
+						<author>Ciresan</author>
+						<cYear>2012</cYear>
+						<article_title>Deep neural networks segment neuronal membranes in electron microscopy images</article_title>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Neuroscience Letters</journal_title>
+						<author>Cragg</author>
+						<volume>15</volume>
+						<first_page>301</first_page>
+						<cYear>1979</cYear>
+						<article_title>Brain extracellular space fixed for electron microscopy</article_title>
+						<doi>10.1016/0304-3940(79)96130-5</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>Tissue and Cell</journal_title>
+						<author>Cragg</author>
+						<volume>12</volume>
+						<first_page>63</first_page>
+						<cYear>1980</cYear>
+						<article_title>Preservation of extracellular space during fixation of the brain for electron microscopy</article_title>
+						<doi>10.1016/0040-8166(80)90052-X</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Visual Neuroscience</journal_title>
+						<author>Demb</author>
+						<volume>29</volume>
+						<first_page>51</first_page>
+						<cYear>2012</cYear>
+						<article_title>Intrinsic properties and functional circuitry of the AII amacrine cell</article_title>
+						<doi>10.1017/S0952523811000368</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>PLoS Biology</journal_title>
+						<author>Denk</author>
+						<volume>2</volume>
+						<cYear>2004</cYear>
+						<article_title>Serial block-face scanning electron microscopy to reconstruct three-dimensional tissue nanostructure</article_title>
+						<doi>10.1371/journal.pbio.0020329</doi>
+						<elocation_id>e329</elocation_id>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Brain Research</journal_title>
+						<author>Hartveit</author>
+						<volume>1487</volume>
+						<first_page>160</first_page>
+						<cYear>2012</cYear>
+						<article_title>Electrical synapses between AII amacrine cells in the retina: Function and modulation</article_title>
+						<doi>10.1016/j.brainres.2012.05.060</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>Nature Neuroscience</journal_title>
+						<author>Helmstaedter</author>
+						<volume>14</volume>
+						<first_page>1081</first_page>
+						<cYear>2011</cYear>
+						<article_title>High-accuracy neurite reconstruction for high-throughput neuroanatomy</article_title>
+						<doi>10.1038/nn.2868</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>Nature</journal_title>
+						<author>Helmstaedter</author>
+						<volume>500</volume>
+						<first_page>168</first_page>
+						<cYear>2013</cYear>
+						<article_title>Connectomic reconstruction of the inner plexiform layer in the mouse retina</article_title>
+						<doi>10.1038/nature12346</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Neural and Evolutionary Computing</journal_title>
+						<author>Hinton</author>
+						<cYear>2012</cYear>
+						<article_title>Improving neural networks by preventing co-adaptation of feature detectors</article_title>
+						<elocation_id>arXiv:1207.0580v1</elocation_id>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Journal of Classification</journal_title>
+						<author>Hubert</author>
+						<volume>2</volume>
+						<first_page>193</first_page>
+						<cYear>1985</cYear>
+						<article_title>Comparing partitions</article_title>
+					</citation>
+					<citation key="bib19">
+						<author>Jain</author>
+						<cYear>2010</cYear>
+						<article_title>Boundary learning by optimization with topological constraints</article_title>
+						<unstructured_citation>Jain BV, Bollman B, Richardson M, Berger DR, Helmstaedter MN, Briggman KL, Denk W, Bowden JB, Mendenhall JM, Abraham WC, Harris KM, Kasthuri N, Hayworth KJ, Schalek R, Tapia JC, Lichtman JW, Seung HS. 2010. Boundary learning by optimization with topological constraints. Computer Vision and Pattern Recognition (CVPR), 2010 IEEE Conference On, IEEE.</unstructured_citation>
+					</citation>
+					<citation key="bib20">
+						<author>Jain</author>
+						<cYear>2007</cYear>
+						<article_title>Supervised learning of image restoration with convolutional networks</article_title>
+						<unstructured_citation>Jain V, Murray JF, Roth F, Turaga S, Zhigulin V, Briggman KL, Helmstaedter MN. 2007. Supervised learning of image restoration with convolutional networks. Computer Vision, 2007. ICCV 2007. IEEE 11th International Conference On.</unstructured_citation>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Current Opinion in Neurobiology</journal_title>
+						<author>Jain</author>
+						<volume>20</volume>
+						<first_page>653</first_page>
+						<cYear>2010</cYear>
+						<article_title>Machines that learn to segment images: a crucial technology for connectomics</article_title>
+						<doi>10.1016/j.conb.2010.07.004</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>Advances in Neural Information Processing Systems</journal_title>
+						<author>Jain</author>
+						<volume>24</volume>
+						<first_page>648</first_page>
+						<cYear>2011</cYear>
+						<article_title>Learning to agglomerate superpixel hierarchies</article_title>
+					</citation>
+					<citation key="bib23">
+						<journal_title>The Journal of Neuroscience</journal_title>
+						<author>Johnson</author>
+						<volume>23</volume>
+						<first_page>518</first_page>
+						<cYear>2003</cYear>
+						<article_title>Vesicular neurotransmitter transporter expression in developing postnatal rodent retina: GABA and glycine precede glutamate</article_title>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Medical Image Analysis</journal_title>
+						<author>Jurrus</author>
+						<volume>14</volume>
+						<first_page>770</first_page>
+						<cYear>2010</cYear>
+						<article_title>Detection of neuron membranes in electron microscopy images using a serial neural network architecture</article_title>
+						<doi>10.1016/j.media.2010.06.002</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>Nature</journal_title>
+						<author>Kim</author>
+						<volume>509</volume>
+						<first_page>331</first_page>
+						<cYear>2014</cYear>
+						<article_title>Space–time wiring specificity supports direction selectivity in the retina</article_title>
+						<doi>10.1038/nature13240</doi>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Neuroscience</journal_title>
+						<author>Kirov</author>
+						<volume>127</volume>
+						<first_page>69</first_page>
+						<cYear>2004</cYear>
+						<article_title>Dendritic spines disappear with chilling but proliferate excessively upon rewarming of mature hippocampus</article_title>
+						<doi>10.1016/j.neuroscience.2004.04.053</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Computer Vision, Graphics, and Image Processing</journal_title>
+						<author>Kong</author>
+						<volume>48</volume>
+						<first_page>357</first_page>
+						<cYear>1989</cYear>
+						<article_title>Digital topology: Introduction and survey</article_title>
+						<doi>10.1016/0734-189X(89)90147-3</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>eLife</journal_title>
+						<author>Korogod</author>
+						<volume>4</volume>
+						<cYear>2015</cYear>
+						<article_title>Ultrastructural analysis of adult mouse neocortex comparing aldehyde perfusion with cryo fixation</article_title>
+						<doi>10.7554/eLife.05793</doi>
+						<elocation_id>e05793</elocation_id>
+					</citation>
+					<citation key="bib29">
+						<journal_title>NeuroReport</journal_title>
+						<author>Koulen</author>
+						<volume>8</volume>
+						<first_page>2845</first_page>
+						<cYear>1997</cYear>
+						<article_title>Vesicular acetylcholine transporter (VAChT)</article_title>
+						<doi>10.1097/00001756-199709080-00008</doi>
+					</citation>
+					<citation key="bib30">
+						<author>Krizhevsky</author>
+						<cYear>2012</cYear>
+						<article_title>Imagenet classification with deep convolutional neural networks</article_title>
+						<unstructured_citation>Krizhevsky A, Sutskever I, Hinton GE. 2012. Imagenet classification with deep convolutional neural networks. Neutral Information Processing Systems(2012).</unstructured_citation>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Image Analysis &amp; Stereology</journal_title>
+						<author>Legland</author>
+						<volume>26</volume>
+						<first_page>83</first_page>
+						<cYear>2011</cYear>
+						<article_title>Computation of Minkowski measures on 2D and 3D binary images</article_title>
+						<doi>10.5566/ias.v26.p83-92</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>PLoS ONE</journal_title>
+						<author>Nunez-Iglesias</author>
+						<volume>8</volume>
+						<cYear>2013</cYear>
+						<article_title>Machine learning of hierarchical clustering to segment 2D and 3D images</article_title>
+						<doi>10.1371/journal.pone.0071715.s004</doi>
+						<elocation_id>e71715</elocation_id>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Frontiers in Neuroinformatics</journal_title>
+						<author>Nunez-Iglesias</author>
+						<volume>8</volume>
+						<first_page>2274</first_page>
+						<cYear>2014</cYear>
+						<article_title>Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages</article_title>
+						<doi>10.1109/TPAMI.2012.120</doi>
+					</citation>
+					<citation key="bib34">
+						<volume_title>Dryad Digital Repository</volume_title>
+						<author>Pallotto</author>
+						<cYear>2015</cYear>
+						<article_title>Data from: extracellular space preservation aids the connectomic analysis of neural circuits</article_title>
+						<doi>10.5061/dryad.36h28</doi>
+					</citation>
+					<citation key="bib35">
+						<volume_title>The Fine Structure of the Nervous System: Neurons and Their Supporting Cells</volume_title>
+						<author>Peters</author>
+						<cYear>1991</cYear>
+					</citation>
+					<citation key="bib36">
+						<journal_title>Cell Biology International</journal_title>
+						<author>Rash</author>
+						<volume>22</volume>
+						<first_page>731</first_page>
+						<cYear>1998</cYear>
+						<article_title>Ultrastructure, histological distribution, and freeze-fracture immunocytochemistry of gap junctions in rat brain and spinal cord</article_title>
+						<doi>10.1006/cbir.1998.0392</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Pattern Recognition, Springer Berlin Heidelberg</journal_title>
+						<author>Rigoll</author>
+						<volume>5096</volume>
+						<first_page>142</first_page>
+						<cYear>2008</cYear>
+						<article_title>Segmentation of SBFSEM volume data of neural tissue by hierarchical classification</article_title>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Journal of Histochemistry &amp; Cytochemistry</journal_title>
+						<author>Rostaing</author>
+						<volume>52</volume>
+						<first_page>1</first_page>
+						<cYear>2004</cYear>
+						<article_title>Preservation of Immunoreactivity and Fine Structure of Adult C. elegans Tissues Using High-pressure Freezing</article_title>
+						<doi>10.1177/002215540405200101</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>The Journal of Comparative Neurology</journal_title>
+						<author>Strettoi</author>
+						<volume>325</volume>
+						<first_page>152</first_page>
+						<cYear>1992</cYear>
+						<article_title>Synaptic connections of the narrow-field, bistratified rod amacrine cell (aII) in the rabbit retina</article_title>
+						<doi>10.1002/cne.903250203</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Physiological Reviews</journal_title>
+						<author>Sykova</author>
+						<volume>88</volume>
+						<first_page>1277</first_page>
+						<cYear>2008</cYear>
+						<article_title>Diffusion in brain extracellular space</article_title>
+						<doi>10.1152/physrev.00027.2007</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Nature</journal_title>
+						<author>Takemura</author>
+						<volume>500</volume>
+						<first_page>175</first_page>
+						<cYear>2013</cYear>
+						<article_title>A visual motion detection circuit suggested by Drosophila connectomics</article_title>
+						<doi>10.1038/nature12450</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>The Journal of Comparative Neurology</journal_title>
+						<author>Tao-Cheng</author>
+						<volume>501</volume>
+						<first_page>731</first_page>
+						<cYear>2007</cYear>
+						<article_title>Structural changes at synapses after delayed perfusion fixation in different regions of the mouse brain</article_title>
+						<doi>10.1002/cne.21276</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Neural Computation</journal_title>
+						<author>Turaga</author>
+						<volume>22</volume>
+						<first_page>511</first_page>
+						<cYear>2010</cYear>
+						<article_title>Convolutional networks can learn to generate affinity graphs for image segmentation</article_title>
+						<doi>10.1098/rstb.1986.0056</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>The Anatomical Record</journal_title>
+						<author>van Harreveld</author>
+						<volume>182</volume>
+						<first_page>377</first_page>
+						<cYear>1975</cYear>
+						<article_title>Rapid freezing of deep cerebral structures for electron microscopy</article_title>
+						<doi>10.1002/ar.1091820311</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>Journal of Anatomy</journal_title>
+						<author>van Harreveld</author>
+						<volume>101</volume>
+						<first_page>197</first_page>
+						<cYear>1967</cYear>
+						<article_title>Extracellular space in the cerebral cortex of the mouse</article_title>
+					</citation>
+					<citation key="bib46">
+						<journal_title>The Anatomical Record</journal_title>
+						<author>van Harreveld</author>
+						<volume>166</volume>
+						<first_page>117</first_page>
+						<cYear>1970</cYear>
+						<article_title>Extracellular space in frozen and ethanol substituted central nervous tissue</article_title>
+						<doi>10.1002/ar.1091660109</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Journal of Cell Science</journal_title>
+						<author>Van Harreveld</author>
+						<volume>6</volume>
+						<first_page>793</first_page>
+						<cYear>1970</cYear>
+						<article_title>The magnitude of the extracellular space in electron micrographs of superficial and deep regions of the cerebral cortex</article_title>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Springer Berlin Heidelberg</journal_title>
+						<author>Vucetic</author>
+						<volume>2167</volume>
+						<first_page>527</first_page>
+						<cYear>2001</cYear>
+						<article_title>Classification on Data with Biased Class Distribution</article_title>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Nature</journal_title>
+						<author>Young</author>
+						<volume>135</volume>
+						<first_page>823</first_page>
+						<cYear>1935</cYear>
+						<article_title>Osmotic pressure of fixing solutions</article_title>
+						<doi>10.1038/135823b0</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>NeuroImage</journal_title>
+						<author>Yushkevich</author>
+						<volume>31</volume>
+						<first_page>1116</first_page>
+						<cYear>2006</cYear>
+						<article_title>User-guided 3D active contour segmentation of anatomical structures: significantly improved efficiency and reliability</article_title>
+						<doi>10.1016/j.neuroimage.2006.01.015</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Computer Vision and Pattern Recognition</journal_title>
+						<author>Zeiler</author>
+						<cYear>2013</cYear>
+						<article_title>Visualizing and understanding convolutional neural networks</article_title>
+						<elocation_id>arXiv:1311.2901v3</elocation_id>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.001</doi>
+							<resource>https://elifesciences.org/articles/08206#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.002</doi>
+							<resource>https://elifesciences.org/articles/08206#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. ECS preservation in acutely isolated tissues.</title>
+							<subtitle>(A) A model of the changes brain tissue undergoes during chemical tissue fixation and possible interventions to preserve ECS. (B) ECS fraction of mouse olfactory bulb (x), retina (o), and cortex (□) correlates with increasing fixative vehicle concentration. Dashed line is the linear fit to olfactory bulb data, solid line is the linear fit to cortex data (olfactory bulb: R = 0.80, p = 0.0006; cortex: R = 0.79, p = 0.0113). (C–F) EM images from the external plexiform layer of the mouse olfactory bulb from a perfused brain (C) or from acute sections fixed with increasing buffer concentrations (D–F). ECS fractions are 0.6% (C), 5.8% (D), 11.3% (E), and 23.9% (F). Scale bars: 1 µm (C–F). ECS: Extracellular space; EM: Electron microscopy.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.003</doi>
+							<resource>https://elifesciences.org/articles/08206#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 1. Change of tissue dimensions and uniformity of ECS preserved sections.</title>
+							<subtitle>(A) Vibratome sections were cut from the cerebral cortex of acutely isolated brains (for ECS preservation) or from perfused animals. Section thickness was nominally 500 µm as determined by the slice thickness setting of the vibratome. Sections were stained for EM and the cross-sectional thickness measured from EM images (mean +/- SEM; n = 20 slices from 6 animals, one-way ANOVA: p = 0.46). (B) Sample images from the edges (Bi, Biii) and center (Bii) of a 500-µm-thick section of the mouse olfactory bulb. ECS is evenly preserved across the section. ECS: Extracellular space; EM: Electron microscopy.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.004</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#fig1s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 2. Effect of temperature on the preservation of ECS.</title>
+							<subtitle>(A,B) Vibratome sections were cut from the olfactory bulbs of acutely isolated brains at either 4°C or 25°C and then fixed at 25°C in 0.1 M CB + 2% GA. (C,D) Vibratome sections were cut from the olfactory bulbs of acutely isolated brains at either 4°C or 25°C and then fixed at 25°C in 0.2 M CB + 2% GA. ECS preservation was similar under both conditions indicating the temperature of solutions during tissue dissection is not a major determinant for ECS preservation. Scale bars: 1 μm. ECS: Extracellular space; EM: Electron microscopy.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.005</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#fig1s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Automated 2D segmentation of extracellular space preserved data.</title>
+							<subtitle>(A) Four raw EM images (first column) of varying ECS fractions (0.6, 5.8, 11.3, and 23.9%) were analyzed. The lowest ECS fraction (0.6%) is the perfused preparation while the others are the acute slice preparations. Pixels in each image were annotated (second column) as either intracellular (white), extracellular (gray), or plasma membrane (black). Representative test image pixel classifications (third column) yielded network classification errors of 9.3, 8.1, 6.7, and 7.2% for the four examples shown. Intracellular pixel probabilities were thresholded and segmented (fourth column) to yield minimum Rand errors of 0.11, 0.06, 0.06, and 0.07 for the four examples shown. (B) Pixel classification errors plotted versus ECS fraction from an ninefold cross-validation, median values in red, shows no significant difference between perfused and acute preparations (K-W test: p=0.05). (C) Rand error plotted versus ECS fraction for the ninefold cross-validation, median values in red, shows a significant difference between perfused and acute preparations (K-W test: p&lt;0.01; Wilcoxon rank-sum test: p=0.0017 [5.8%], p=0.0091 [11.3%], p=0.031 [23.9%]). (D) Total number of splits and merger per object in each test image plotted versus ECS fraction for the ninefold cross-validation, median values in red, shows a significant difference between perfused and acute preparations (K-W test: p&lt;0.001; Wilcoxon rank-sum test: p=0.00049 [5.8%], p=0.00035 [11.3%], p=0.00035 [23.9%]). Scale bars: 2 μm. p-Values: *p&lt;0.05, **p&lt;0.01, ***p&lt;0.001. ECS: Extracellular space; EM: Electron microscopy.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.006</doi>
+							<resource>https://elifesciences.org/articles/08206#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—source data 1. Raw image and expert labels of 0.6% ECS data.</title>
+							<subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.007</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD1-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—source data 2. Raw image and expert labels of 5.8% ECS data.</title>
+							<subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.008</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD2-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—source data 3. Raw image and expert labels of 11.3% ECS data.</title>
+							<subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.009</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD3-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—source data 4. Raw image and expert labels of 23.9% ECS data.</title>
+							<subtitle>TIFF stack viewable using ImageJ. ECS: Extracellular space.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.010</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD4-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. Warping error of automated segmentations.</title>
+							<subtitle>(A) Split/merger curves parameterized by threshold of the network output. Shaded area is the standard error of the mean, lines are the mean number of splits/mergers per object, and the circles are the mean of the minimum total splits + mergers per object. (B) Network segmentations at the minimum warping error threshold, same regions as in Figure 2A. Warping errors were 0.68 (0.6% ECS), 0.32 (5.8% ECS), 0.52 (11.3% ECS), and 0.56 (23.9% ECS) for the four examples shown. (C) Cumulative distributions of the number of ground truth intracellular pixels per object for the four datasets. The difference in these distributions motivated the use of a Bernoulli sampling procedure for calculating the adapted Rand Error metrics in Figure 2C. Scale bars: 2 μm. ECS: Extracellular space.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.011</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Automated 3D segmentation of extracellular space preserved data.</title>
+							<subtitle>(A) A 10 x 10 x 12 μm3 3D SBEM cube (left) of perfused tissue (LowECS), a dense skeletonization of all neurites in the volume (middle), and an automated segmentation of the volume (right). (B) A 10 x 10 x 12 μm3 3D SBEM cube (left) of ECS-preserved tissue (HighECS), a dense skeletonization of all neurites in the volume (middle), and an automated segmentation of the volume (right). (C) Adapted Rand error of automated segmentations compared to dense skeletonizations as a function of the segmentation threshold for the HighECS (brown) and LowECS (blue) data volumes. (D) The fraction of merged skeleton nodes versus split skeleton edges as a function of network threshold. Solid points indicate the minimum sum of the error fractions. (E) The total error-free skeleton path length recovered as a function of network threshold. Shaded regions in C–E are the 99% confidence intervals based on a Bernoulli sampling of the data. Scale bars in A, B = 1 μm. SBEM: Serial block-face scanning electron microscopy.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.012</doi>
+							<resource>https://elifesciences.org/articles/08206#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—source data 1. M0027_11 dense skeletonization, Knossos NML file.</title>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.013</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD5-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—source data 2. M0007_33 dense skeletonization, Knossos NML file.</title>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.014</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD6-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—source data 3. M0007_33 training data cubes.</title>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.015</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD7-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—source data 4. M0027_11 training data cubes.</title>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.016</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD8-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. Cumulative distributions for 3D hand-labeled volumes and skeletonizations of the LowECS (blue) and HighECS (brown) data volumes.</title>
+							<subtitle>(A) Cumulative distribution frequency (CDF) of number of intracellular ground truth voxels per object. The distribution medians are significantly different (Wilcoxon rank-sum test, p &lt;0.0001). (B) CDF of path length per skeleton, medians 10.2 (LowECS) and 10.1 (HighECS) μm. The distributions are not significantly different (two-sample Kolmogorov–Smirnov (KS) test, p = 0.91). (C) CDF of the number of nodes annotated per skeleton, medians 16 (LowECS) and 17 (HighECS) nodes. The distributions not significantly different (two-sample KS test, p = 0.77).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.017</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Extracellular space aids the identification of gap junctions.</title>
+							<subtitle>(A) Reconstructed dendrites of an AII amacrine cell (gray) and surface renderings of tight (yellow) and cleft (black) contacts. (B-D) Example EM images and volumetric reconstructions of (B) an AII (gray) to AII (blue) tight contact, (C) an AII (gray) to cone bipolar cell (green) tight contact (C), and (D) a cleft contact identified as a chemical synapse between a presynaptic amacrine cell (cyan) and the AII cell (gray). (E) Tight contact surface renderings color-coded by the identity of the synaptic partner: AII amacrine cell (blue), cone bipolar cell (green), presynaptic amacrine cell (cyan). (F) Summary of the number of contacts color-coded by the cell type of the contacting cell: AII (blue), cone bipolar (green), presynaptic amacrine cell (cyan), other (black). Scale bars: 2 µm (A,E), 1 µm (B–D). EM: Electron microscopy.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.018</doi>
+							<resource>https://elifesciences.org/articles/08206#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—source data 1. Example image stack of an A2 to A2 tight contact.</title>
+							<subtitle>TIFF stack viewable using ImageJ. Slice #128 in the stack indicates the location of the tight contact.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.019</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD9-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—source data 2. Example image stack of a cone bipolar to A2 tight contact.</title>
+							<subtitle>TIFF stack viewable using ImageJ. Slice #128 in the stack indicates the location of the tight contact.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.020</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD10-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—source data 3. Example image stack of a chemical synapse to A2 cleft contact.</title>
+							<subtitle>TIFF stack viewable using ImageJ. Slice #128 in the stack indicates the location of the cleft contact.</subtitle>
+						</titles>
+						<doi_data>
+							<doi>10.7554/eLife.08206.021</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#SD11-data</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 1. Simple measures of contact geometry do not predict gap junctions.</title>
+							<subtitle>(A) Surface area and the volume of the convex hull bounding each contact are plotted for cleft contacts (gray), AII amacrine cell tight contacts (blue) and cone bipolar cell tight contacts (green).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.022</doi>
+							<resource>https://elifesciences.org/articles/08206/figures#fig4s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Extracellular space preservation increases access to antibodies.</title>
+							<subtitle>(A) Flat-mounted retinas were immunolabeled for vACHT with and without ECS preservation. Retinas were then cross-sectioned and confocal images were taken to directly visualize penetration depth. (B) Same as A, but immunolabeled for vGAT. (C) Fullwidth half-maximal penetration distances (mean +/- SEM) for retinas with and without ECS preservation (n = 20 retina slices from two animals, unpaired Student’s t-test, vACHT: ***p&lt;0.0001, vGAT: ***p&lt;0.0001). (D) EM images collected from the regions of interest in panel B indicated by dotted rectangles. Scale bars: 50 μm (A,B), 1 μm (D).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.023</doi>
+							<resource>https://elifesciences.org/articles/08206#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.026</doi>
+							<resource>https://elifesciences.org/articles/08206#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.08206.027</doi>
+							<resource>https://elifesciences.org/articles/08206#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-11134-20170717071707.xml
+++ b/tests/test_data/elife-crossref-11134-20170717071707.xml
@@ -792,26 +792,6 @@
 							<resource>https://elifesciences.org/articles/11134#fig5</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.11134.019</doi>
-							<resource>https://elifesciences.org/articles/11134#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.11134.020</doi>
-							<resource>https://elifesciences.org/articles/11134#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_data/elife-crossref-11134-20170717071707.xml
+++ b/tests/test_data/elife-crossref-11134-20170717071707.xml
@@ -1,1 +1,819 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-11134-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>10</month><day>24</day><year>2015</year></publication_date><journal_volume><volume>4</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>cryo-EM structures of the E. coli replicative DNA polymerase reveal its dynamic interactions with the DNA sliding clamp, exonuclease and τ</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Rafael</given_name><surname>Fernandez-Leiro</surname><affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation><ORCID authenticated="true">http://orcid.org/0000-0002-7941-0357</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>Julian</given_name><surname>Conrad</surname><affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Sjors HW</given_name><surname>Scheres</surname><affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation><ORCID authenticated="true">http://orcid.org/0000-0002-0462-6540</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>Meindert H</given_name><surname>Lamers</surname><affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation></person_name></contributors><jats:abstract><jats:p>The replicative DNA polymerase PolIIIα from Escherichia coli is a uniquely fast and processive enzyme. For its activity it relies on the DNA sliding clamp β, the proofreading exonuclease ε and the C-terminal domain of the clamp loader subunit τ. Due to the dynamic nature of the four-protein complex it has long been refractory to structural characterization. Here we present the 8 Å resolution cryo-electron microscopy structures of DNA-bound and DNA-free states of the PolIII-clamp-exonuclease-τc complex. The structures show how the polymerase is tethered to the DNA through multiple contacts with the clamp and exonuclease. A novel contact between the polymerase and clamp is made in the DNA bound state, facilitated by a large movement of the polymerase tail domain and τc. These structures provide crucial insights into the organization of the catalytic core of the replisome and form an important step towards determining the structure of the complete holoenzyme.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>DNA replication is complicated because the two strands that form its “double helix” structure run in opposite directions and need to be replicated at the same time. One of the new strands, the leading strand, is built continuously. While the other strand, called the lagging strand, is made in stretches that are about 1000-times shorter and run in the opposite direction from the leading strand. This means that the enzyme that builds the new strands of DNA (called DNA polymerase) must be repeatedly released and repositioned when it builds the lagging strand, however it is not fully understood how this achieved.</jats:p><jats:p>Fernandez-Leiro, Conrad et al. have now used a technique called cryo-electron microscopy to reveal the three-dimensional structure of a DNA polymerase from a bacterium called Escherichia coli complete with other associated factors and a DNA molecule. These factors include: the “sliding clamp” that allows the polymerase to slide along the DNA; the “proofreading exonuclease” that removes mistakes in the newly built DNA strand, and the “processivity switch Tau” that is needed for the repeated release and repositioning of the polymerase at the lagging strand. These structures show how the polymerase is bound to the DNA by multiple interactions with the sliding clamp and exonuclease.</jats:p><jats:p>Fernandez-Leiro, Conrad et al. also solved the structure of the same proteins but without the DNA molecule. This revealed a large structural change between the DNA-bound and DNA-free states, which provides some clues as to how the polymerase can be quickly released from the DNA during the repeated cycles of DNA synthesis at the lagging strand. Further research is now needed to uncover what signals trigger this release of the DNA polymerase.</jats:p></jats:abstract><publication_date media_type="online"><month>10</month><day>24</day><year>2015</year></publication_date><publisher_item><item_number item_number_type="article_number">e11134</item_number><identifier id_type="doi">10.7554/eLife.11134</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Medical Research Counc</fr:assertion><fr:assertion name="award_number">U105197143</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Medical Research Council<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion></fr:assertion><fr:assertion name="award_number">MC_UP_A025_1013</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.11134</doi><resource>https://elifesciences.org/articles/11134</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/11134/elife-11134-v2.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/11134/elife-11134-v2.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>Science</journal_title><author>Bailey</author><volume>318</volume><first_page>459</first_page><cYear>2007</cYear><article_title>Structure of hexameric DnaB helicase and its complex with a domain of DnaG primase</article_title><doi>10.1126/science.1147353</doi></citation><citation key="bib2"><journal_title>Cell</journal_title><author>Bailey</author><volume>126</volume><first_page>893</first_page><cYear>2006</cYear><article_title>The structure of T. aquaticus DNA polymerase III is distinct from eukaryotic replicative DNA polymerases</article_title><doi>10.1016/j.cell.2006.07.027</doi></citation><citation key="bib3"><journal_title>Journal of Biological Chemistry</journal_title><author>Bloom</author><volume>272</volume><first_page>27919</first_page><cYear>1997</cYear><article_title>Fidelity of Escherichia coli DNA polymerase III holoenzyme: The effects of beta, gamma complex processivity proteins and epsilon proofreadingexonuclease on nucleotide misincorporation efficiencies</article_title><doi>10.1074/jbc.272.44.27919</doi></citation><citation key="bib4"><journal_title>The EMBO Journal</journal_title><author>Bunting</author><volume>22</volume><first_page>5883</first_page><cYear>2003</cYear><article_title>Structural basis for recruitment of translesion DNA polymerase Pol IV/DinB to the beta-clamp</article_title><doi>10.1093/emboj/cdg568</doi></citation><citation key="bib5"><journal_title>Ultramicroscopy</journal_title><author>Chen</author><volume>135</volume><first_page>24</first_page><cYear>2013</cYear><article_title>High-resolution noise substitution to measure overfitting and validate resolution in 3D structure determination by single particle electron cryomicroscopy</article_title><doi>10.1016/j.ultramic.2013.06.004</doi></citation><citation key="bib6"><journal_title>Journal of Molecular Biology</journal_title><author>Dohrmann</author><volume>414</volume><first_page>15</first_page><cYear>2011</cYear><article_title>The rate of polymerase release upon filling the gap between okazaki fragments is inadequate to support cycling during lagging strand synthesis</article_title><doi>10.1016/j.jmb.2011.09.039</doi></citation><citation key="bib7"><journal_title>Journal of Molecular Biology</journal_title><author>Dohrmann</author><volume>350</volume><first_page>228</first_page><cYear>2005</cYear><article_title>A bipartite polymerase–processivity factor interaction: only the internal β binding site of the α subunit is required for processive replication by the DNA polymerase III holoenzyme</article_title><doi>10.1016/j.jmb.2005.04.065</doi></citation><citation key="bib8"><journal_title>Acta Crystallographica Section D. Biological Crystallography</journal_title><author>Emsley</author><volume>66</volume><first_page>486</first_page><cYear>2010</cYear><article_title>Features and development of coot</article_title><doi>10.1107/S0907444910007493</doi></citation><citation key="bib9"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Evans</author><volume>105</volume><first_page>20695</first_page><cYear>2008</cYear><article_title>Structure of PolC reveals unique DNA binding and fidelity determinants</article_title><doi>10.1073/pnas.0809989106</doi></citation><citation key="bib10"><journal_title>Cell</journal_title><author>Georgescu</author><volume>132</volume><first_page>43</first_page><cYear>2008</cYear><article_title>Structure of a sliding clamp on DNA</article_title><doi>10.1016/j.cell.2007.11.045</doi></citation><citation key="bib11"><journal_title>The EMBO Journal</journal_title><author>Georgescu</author><volume>28</volume><first_page>2981</first_page><cYear>2009</cYear><article_title>Mechanism of polymerase collision release from sliding clamps on the lagging strand</article_title><doi>10.1038/emboj.2009.233</doi></citation><citation key="bib12"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Georgescu</author><volume>105</volume><first_page>11116</first_page><cYear>2008</cYear><article_title>Structure of a small-molecule inhibitor of a DNA polymerase sliding clamp</article_title><doi>10.1073/pnas.0804754105</doi></citation><citation key="bib13"><journal_title>Structure</journal_title><author>Hamdan</author><volume>10</volume><first_page>535</first_page><cYear>2002</cYear><article_title>Structural basis for proofreading during replication of the escherichia coli chromosome</article_title><doi>10.1016/S0969-2126(02)00738-4</doi></citation><citation key="bib14"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Hwang</author><volume>108</volume><first_page>7414</first_page><cYear>2011</cYear><article_title>Protein induced fluorescence enhancement as a single molecule assay with short distance sensitivity</article_title><doi>10.1073/pnas.1017672108</doi></citation><citation key="bib15"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Indiani</author><volume>106</volume><first_page>6031</first_page><cYear>2009</cYear><article_title>Translesion DNA polymerases remodel the replisome and alter the speed of the replicative helicase</article_title><doi>10.1073/pnas.0901403106</doi></citation><citation key="bib16"><journal_title>The EMBO Journal</journal_title><author>Jergic</author><volume>32</volume><first_page>1322</first_page><cYear>2013</cYear><article_title>A direct proofreader–clamp interaction stabilizes the Pol III replicase in the polymerization mode</article_title><doi>10.1038/emboj.2012.347</doi></citation><citation key="bib17"><journal_title>Nucleic Acids Research</journal_title><author>Jergic</author><volume>35</volume><first_page>2813</first_page><cYear>2007</cYear><article_title>The unstructured C-terminus of the tau subunit of Escherichia coli DNA polymerase III holoenzyme is the site of interaction with the alpha subunit</article_title><doi>10.1093/nar/gkm079</doi></citation><citation key="bib18"><journal_title>Cell</journal_title><author>Jeruzalmi</author><volume>106</volume><first_page>429</first_page><cYear>2001</cYear><article_title>Crystal structure of the processivity clamp loader gamma (γ) complex of E. coli DNA polymerase III</article_title><doi>10.1016/S0092-8674(01)00463-9</doi></citation><citation key="bib19"><journal_title>Cell</journal_title><author>Jeruzalmi</author><volume>106</volume><first_page>417</first_page><cYear>2001</cYear><article_title>Mechanism of processivity clamp opening by the delta subunit wrench of the clamp loader complex of E. coli DNA polymerase III</article_title><doi>10.1016/S0092-8674(01)00462-7</doi></citation><citation key="bib20"><journal_title>Cell</journal_title><author>Kong</author><volume>69</volume><first_page>425</first_page><cYear>1992</cYear><article_title>Three-dimensional structure of the beta subunit of E. coli DNA polymerase III holoenzyme: a sliding DNA clamp</article_title><doi>10.1016/0092-8674(92)90445-I</doi></citation><citation key="bib21"><journal_title>Cell</journal_title><author>Lamers</author><volume>126</volume><first_page>881</first_page><cYear>2006</cYear><article_title>Crystal structure of the catalytic alpha subunit of E. coli replicative DNA polymerase III</article_title><doi>10.1016/j.cell.2006.07.028</doi></citation><citation key="bib22"><journal_title>Journal of Bacteriology</journal_title><author>Lancy</author><volume>171</volume><first_page>5572</first_page><cYear>1989</cYear><article_title>Isolation and characterization of mutants with deletions in dnaQ, the gene for the editing subunit of DNA polymerase III in Salmonella typhimurium</article_title></citation><citation key="bib23"><journal_title>Molecular Cell</journal_title><author>Leu</author><volume>11</volume><first_page>315</first_page><cYear>2003</cYear><article_title>Mechanism of the E. coli tau processivity switch during lagging-strand synthesis</article_title><doi>10.1016/S1097-2765(03)00042-X</doi></citation><citation key="bib24"><journal_title>Journal of Biological Chemistry</journal_title><author>Li</author><volume>275</volume><first_page>34757</first_page><cYear>2000</cYear><article_title>Two distinct triggers for cycling of the lagging strand polymerase at the replication fork</article_title><doi>10.1074/jbc.M006556200</doi></citation><citation key="bib25"><journal_title>Nature Methods</journal_title><author>Li</author><volume>10</volume><first_page>584</first_page><cYear>2013</cYear><article_title>Electron counting and beam-induced motion correction enable near-atomic-resolution single-particle cryo-EM</article_title><doi>10.1038/nmeth.2472</doi></citation><citation key="bib26"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Li</author><volume>96</volume><first_page>9491</first_page><cYear>1999</cYear><article_title>Structure-based design of taq DNA polymerases with improved properties of dideoxynucleotide incorporation</article_title><doi>10.1073/pnas.96.17.9491</doi></citation><citation key="bib27"><journal_title>Structure</journal_title><author>Liu</author><volume>21</volume><first_page>658</first_page><cYear>2013</cYear><article_title>Structure of the PolIIIα-τc-DNA complex suggests an atomic model of the replisome</article_title><doi>10.1016/j.str.2013.02.002</doi></citation><citation key="bib28"><journal_title>The Journal of Biological Chemistry</journal_title><author>Maki</author><volume>260</volume><first_page>12987</first_page><cYear>1985</cYear><article_title>The polymerase subunit of DNA polymerase III of Escherichia coli. II. Purification of the alpha subunit, devoid of nuclease activities</article_title></citation><citation key="bib29"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Mayanagi</author><volume>108</volume><first_page>1845</first_page><cYear>2011</cYear><article_title>Architecture of the DNA polymerase b-proliferating cell nuclear antigen (pCNA)-DNA ternary complex</article_title><doi>10.1073/pnas.1010933108</doi></citation><citation key="bib30"><journal_title>The Journal of Biological Chemistry</journal_title><author>McHenry</author><volume>257</volume><first_page>2657</first_page><cYear>1982</cYear><article_title>Purification and characterization of DNA polymerase III'. Identification of tau as a subunit of the DNA polymerase III holoenzyme</article_title></citation><citation key="bib31"><journal_title>Molecular Cell</journal_title><author>McInerney</author><volume>27</volume><first_page>527</first_page><cYear>2007</cYear><article_title>Characterization of a triple DNA polymerase replisome</article_title><doi>10.1016/j.molcel.2007.06.019</doi></citation><citation key="bib32"><journal_title>Journal of Structural Biology</journal_title><author>Mindell</author><volume>142</volume><first_page>334</first_page><cYear>2003</cYear><article_title>Accurate determination of local defocus and specimen tilt in electron microscopy</article_title><doi>10.1016/S1047-8477(03)00069-8</doi></citation><citation key="bib33"><journal_title>The Journal of Biological Chemistry</journal_title><author>Mok</author><volume>262</volume><first_page>16644</first_page><cYear>1987</cYear><article_title>The Escherichia coli preprimosome and DNA B helicase can form replication forks that move at the same rate</article_title></citation><citation key="bib34"><journal_title>Journal of Biological Chemistry</journal_title><author>Onrust</author><volume>270</volume><first_page>13366</first_page><cYear>1995</cYear><article_title>Assembly of a chromosomal replication machine: two DNA polymerases, a clamp loader, and sliding clamps in one holoenzyme particle: III. Interface between two polymerases and the clamp loader</article_title><doi>10.1074/jbc.270.22.13366</doi></citation><citation key="bib35"><journal_title>Nucleic Acids Research</journal_title><author>Ozawa</author><volume>41</volume><first_page>5354</first_page><cYear>2013</cYear><article_title>Proofreading exonuclease on a tether: the complex between the E. coli DNA polymerase III subunits and alpha, epsilon, theta and beta reveals a highly flexible arrangement of the proofreading domain</article_title><doi>10.1093/nar/gkt162</doi></citation><citation key="bib36"><journal_title>Journal of Molecular Biology</journal_title><author>Rosenthal</author><volume>333</volume><first_page>721</first_page><cYear>2003</cYear><article_title>Optimal determination of particle orientation, absolute hand, and contrast loss in single-particle electron cryomicroscopy</article_title><doi>10.1016/j.jmb.2003.07.013</doi></citation><citation key="bib37"><journal_title>Nature Methods</journal_title><author>Scheres</author><volume>9</volume><first_page>853</first_page><cYear>2012</cYear><article_title>Prevention of overfitting in cryo-EM structure determination</article_title><doi>10.1038/nmeth.2115</doi></citation><citation key="bib38"><journal_title>Journal of Structural Biology</journal_title><author>Scheres</author><volume>180</volume><first_page>519</first_page><cYear>2012</cYear><article_title>RELION: implementation of a Bayesian approach to cryo-EM structure determination</article_title><doi>10.1016/j.jsb.2012.09.006</doi></citation><citation key="bib39"><journal_title>eLife</journal_title><author>Scheres</author><volume>3</volume><first_page>p.e03665.</first_page><cYear>2014</cYear><article_title>Beam-induced motion correction for sub-megadalton cryo-EM particles</article_title><doi>10.7554/eLife.03665.009</doi></citation><citation key="bib40"><journal_title>Proceedings of the National Academy of Sciences of the United States of America </journal_title><author>Scheuermann</author><volume>80</volume><first_page>7085</first_page><cYear>1983</cYear><article_title>Identification of the epsilon-subunit of escherichia coli DNA polymerase III holoenzyme as the dnaQ gene product: a fidelity subunit for DNA replication</article_title><doi>10.1073/pnas.80.23.7085</doi></citation><citation key="bib41"><author>Schrödinger</author><cYear>2010</cYear><article_title>The PyMOL molecular graphics system</article_title></citation><citation key="bib42"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Schwartz</author><volume>106</volume><first_page>20294</first_page><cYear>2009</cYear><article_title>Single molecule measurement of the &quot;speed limit&quot; of DNA polymerase</article_title><doi>10.1073/pnas.0907404106</doi></citation><citation key="bib43"><journal_title>Nucleic Acids Research</journal_title><author>Sharma</author><volume>41</volume><first_page>5104</first_page><cYear>2013</cYear><article_title>A strategically located serine residue is critical for the mutator activity of DNA polymerase IV from Escherichia coli</article_title><doi>10.1093/nar/gkt146</doi></citation><citation key="bib44"><journal_title>Cell</journal_title><author>Simonetta</author><volume>137</volume><first_page>659</first_page><cYear>2009</cYear><article_title>The mechanism of ATP-dependent primer-template recognition by a clamp loader complex</article_title><doi>10.1016/j.cell.2009.03.044</doi></citation><citation key="bib45"><journal_title>The Journal of Biological Chemistry</journal_title><author>Stukenberg</author><volume>266</volume><first_page>11328</first_page><cYear>1991</cYear><article_title>Mechanism of the sliding beta-clamp of DNA polymerase III holoenzyme</article_title></citation><citation key="bib46"><journal_title>Nucleic Acids Research</journal_title><author>Su</author><volume>35</volume><first_page>2825</first_page><cYear>2007</cYear><article_title>Solution structure of domains IVa and V of the tau subunit of Escherichia coli DNA polymerase III and interaction with the alpha subunit</article_title><doi>10.1093/nar/gkm080</doi></citation><citation key="bib47"><journal_title>Journal of Structural Biology</journal_title><author>Tang</author><volume>157</volume><first_page>38</first_page><cYear>2007</cYear><article_title>EMAN2: an extensible image processing suite for electron microscopy</article_title><doi>10.1016/j.jsb.2006.05.009</doi></citation><citation key="bib48"><journal_title>The EMBO Journal</journal_title><author>Toste Rêgo</author><volume>32</volume><first_page>1334</first_page><cYear>2013</cYear><article_title>Architecture of the Pol III–clamp–exonuclease complex reveals key roles of the exonuclease subunit in processive DNA synthesis and repair</article_title><doi>10.1038/emboj.2013.68</doi></citation><citation key="bib49"><journal_title>Cell</journal_title><author>Wang</author><volume>139</volume><first_page>1279</first_page><cYear>2009</cYear><article_title>Structural insight into translesion synthesis by DNA Pol II</article_title><doi>10.1016/j.cell.2009.11.043</doi></citation><citation key="bib50"><journal_title>Nature Structural Molecular Biology</journal_title><author>Wang</author><volume>15</volume><first_page>94</first_page><cYear>2008</cYear><article_title>The structure of a DnaB-family replicative helicase and its interactions with primase</article_title><doi>10.1038/nsmb1356</doi></citation><citation key="bib51"><journal_title>Biochemistry</journal_title><author>Wijffels</author><volume>43</volume><first_page>5661</first_page><cYear>2004</cYear><article_title>Inhibition of protein interactions with the beta 2 sliding clamp of Escherichia coli DNA polymerase III by peptides from beta 2 -binding proteins</article_title><doi>10.1021/bi036229j</doi></citation><citation key="bib52"><journal_title>Journal of Molecular Biology</journal_title><author>Wing</author><volume>382</volume><first_page>859</first_page><cYear>2008</cYear><article_title>Insights into the replisome from the structure of a ternary complex of the DNA polymerase III α-subunit</article_title><doi>10.1016/j.jmb.2008.07.058</doi></citation><citation key="bib53"><journal_title>The Journal of Biological Chemistry</journal_title><author>Wu</author><volume>267</volume><first_page>4030</first_page><cYear>1992</cYear><article_title>Coordinated leading- and lagging-strand synthesis at the Escherichia coli DNA replication fork. I. Multiple effectors act to modulate Okazaki fragment size</article_title></citation><citation key="bib54"><journal_title>The Journal of Biological Chemistry</journal_title><author>Wu</author><volume>267</volume><first_page>4074</first_page><cYear>1992</cYear><article_title>Coordinated leading- and lagging-strand synthesis at the Escherichia coli DNA replication fork. V. primase action regulates the cycle of okazaki fragment synthesis</article_title></citation><citation key="bib55"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Yao</author><volume>106</volume><first_page>13236</first_page><cYear>2009</cYear><article_title>Single-molecule analysis reveals that the lagging strand increases replisome processivity but slows replication fork progression</article_title><doi>10.1073/pnas.0906157106</doi></citation><citation key="bib56"><journal_title>Nucleic Acids Research</journal_title><author>Yuan</author><volume>42</volume><first_page>1747</first_page><cYear>2014</cYear><article_title>Cycling of the E. coli lagging strand polymerase is triggered exclusively by the availability of a new primer at the replication fork</article_title><doi>10.1093/nar/gkt1098</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.11134.001</doi><resource>https://elifesciences.org/articles/11134#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.11134.002</doi><resource>https://elifesciences.org/articles/11134#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Cryo-EM structures of the E. coli PolIIIα-clamp-exonuclease-τ500 complex.</title><subtitle>(A) Surface representation of the three structures, shown at 5 σ. Left to right: DNA-free, DNA-bound, and DNA-bound without tail. Colors indicate the position of the different proteins (B) Individual structures of PolIIIα, clamp, exonuclease, and τ500 fitted into the cryo-EM map (shown in grey at 5 σ) (C) Detailed views of the cryo-EM map (shown in grey mesh at 6 σ). Left panel: exit channel of the clamp in the DNA-free structure showing the ‘DNA-free’ map. Middle panel: bottom view of the polymerase showing the ‘DNA-free’ map. Right panel: detail of the DNA showing the ‘DNA-bound, no tail’ map. See also Videos 1 and 2.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.003</doi><resource>https://elifesciences.org/articles/11134#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 1. Characterization of improved clamp binding mutants.</title><subtitle>(A) Gel filtration analysis of the wild-type PolIIIα-clamp-exonuclease complex (top panel) and the PolIIIαQLDLF-clamp-exonucleaseQLSLPL complex (lower panel). The wild-type complex dissociates at lower protein concentrations, while the stabilized complex remains intact even at 0.1 μM.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.004</doi><resource>https://elifesciences.org/articles/11134/figures#fig1s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 2. Microscopy data analysis and validation.</title><subtitle>(A) Typical micrograph of the PolIIIα-clamp-exonuclease-τ500-DNA complex. (B) 2D class averages derived from the final 63,215 particle dataset (C) Fourier shell correlation for the DNA-free and DNA-bound models. In solid lines, the correlation between two independently refined halves of the data is indicated (gold-standard FSC). Estimated resolution at a correlation of 0.143 is 8.3 Å and 8.0 Å for the DNA-free and DNA-bound complex, respectively. In dashed lines, the correlation between the rigid-body docked models and their respective maps is indicated. (D) 3D model reconstruction. An initial model was obtained using Eman2 and subsequently classified into six 3D classes. Two of the 3D classes were merged into the ‘DNA-free’ map (16,970 particles) and one of these (5663 particles) was used for the ‘DNA-bound’ map. The remaining three classes were merged into the ‘DNA-bound, no tail’ map (40,582 particles) and further refined in Relion, resulting in three structurally distinct models. (E) Orientational distribution for particles of the DNA-free complex. The circle represents a flattened sphere plotted using Lambert equal area projection with the pole at the center and the equator at the outer rim of the circle. The radius indicates the tilt angle and the azimuth indicates the rotation or direction of the tilt. (F) Same for the DNA-bound complex (G) Tilt pair validation using 267 particle pairs that were selected from 20 image pairs collected at 0 and 20° tilt angle of the sample stage. The angular difference between the same particle collected from the two images is displayed. The black cross indicates the expected angular difference between pairs.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.005</doi><resource>https://elifesciences.org/articles/11134/figures#fig1s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 3. Rigid body movements in PolIIIα.</title><subtitle>(A) Domain definitions used for the rigid body fitting of the PolIIIα structure into the cryo-EM maps. Domain boundaries are: PHP (residues 1–280), palm-fingers (residues 281–432 + 510–810), thumb (residues 433–509), tip-of-fingers (residues 811–928) and C-terminal tail (residues 929–1160). (B and C) Comparison of crystal structure of E. coli PolIIIα (shown in grey) and PolIIIα as fitted into the cryo-EM maps (the tail of the polymerase is omitted for clarity).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.006</doi><resource>https://elifesciences.org/articles/11134/figures#fig1s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 1. Structure of the DNA-free complex of PolIIα-clamp-exonuclease-τ500, Related to Figure 1.</title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.11134.007</doi><resource>https://elifesciences.org/articles/11134#media1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 2. Structure of the DNA-bound complex of PolIIα-clamp-exonuclease-τ500, Related to Figure 1.</title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.11134.008</doi><resource>https://elifesciences.org/articles/11134#media2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Multiple contacts between the subunits hold the complex together.</title><subtitle>(A) Three different views of the DNA-free complex of PolIIIα-clamp-exonuclease-τ500 showing extensive contacts between the polymerase and other subunits. Missing loops in PolIIIα (residues 927–936) and exonuclease (residues 190–207) are shown in dots. Dashed boxes indicate views shown in panels B-D. (B) Modified clamp binding motif of PolIIIα (QLDLF: shown in sticks) modeled into the binding pocket of the clamp. (C) Modified clamp binding motif of the exonuclease (QLSLPL: shown in sticks) modeled into the second binding pocket of the dimeric clamp. (D) τ500 simultaneously binds the fingers and tail domain of the polymerase. The C-terminal residues of τ500 (residues 622–643: not modeled) bind to the tail of the polymerase, while the globular domain of τ500 binds to the polymerase fingers domain (see Figure 2—figure supplement 2 for more details).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.009</doi><resource>https://elifesciences.org/articles/11134#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. Previously determined cross-links fit accurately with the cryo-EM model.</title><subtitle>(A) Model of the polymerase-clamp-exonuclease complex based on chemical cross-links reported in (Toste Rêgo et al., 2013). Magenta dashed lines: polymerase-clamp cross-links. Cyan dashed lines: polymerase-exonuclease cross-links. Black dashed lines: clamp-exonuclease cross-links. (B) Same cross-links mapped onto the DNA-free cryo-EM model.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.010</doi><resource>https://elifesciences.org/articles/11134/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 2. Details of the interactions between τ500 and the PolIIIα fingers domain.</title><subtitle>(A) Three orthogonal views of the fit of τ500 into the cryo-EM density. Dashed box in left panel indicates view shown in panel B. (B) Detailed view of the τ500 - PolIIIα fingers domain interaction. Contact regions at the interface are indicated with thick coil in red (τ500: residues 530–535 and residues 562–566) and blue (PolIIIα: residues 657–667)</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.011</doi><resource>https://elifesciences.org/articles/11134/figures#fig2s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 3. Comparison of τ binding in E. coli and Taq PolIIIα.</title><subtitle>(A,B) DNA-free and DNA-bound E. coli PolIIIα-τ500. The clamp and exonuclease are omitted for clarity. (C) Taq PolIIIα-τc (Liu et al., 2013).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.012</doi><resource>https://elifesciences.org/articles/11134/figures#fig2s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. The DNA has extensive contacts with PolIIIα and clamp.</title><subtitle>(A) Overview of the DNA-bound complex. The N-termini of the two helices that point at the DNA backbone are colored in blue. Potential DNA interacting side chains are shown in sticks. The tail of PolIIIα, the exonuclease and τ500 are omitted for clarity. Arrow indicates viewpoint in panel B (B) Polymerase active site, with the DNA held between thumb, palm and fingers domain. Polymerase active site residues are indicated with magenta spheres. Arrow indicates viewpoint in panel C (C) DNA interactions downstream of the active site. The OB domain is positioned on top of the DNA but does not make any contacts with it. (D) DNA exit channel in the clamp with positively charged residues within 10 Å of the DNA indicated in magenta sticks. Note that the positions of the side chains have not been refined and should be seen as approximate positions. (E) In the DNA-bound complex, the clamp is at a ∼80° angle from the DNA. A dashed line indicates the position of the clamp alone bound to a DNA substrate. (Georgescu et al., 2008a). The other subunits (PolIIIα, exonuclease, τ500) are shown in light grey for clarity.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.013</doi><resource>https://elifesciences.org/articles/11134#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. Comparison of DNA binding by C family DNA polymerases.</title><subtitle>(A) E. coli PolIIIα, (B) T. aquaticus PolIIIα (Wing et al., 2008), (C) G. kaustophilus PolC (Evans et al., 2008).</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.014</doi><resource>https://elifesciences.org/articles/11134/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 2. Pol IIIα has more extensive DNA interactions than other DNA polymerases.</title><subtitle>(A) Left panel: Electro-mobility shift assay with the E. coli DNA polymerases Pol I (Klenow fragment), Pol II, Pol IIIα, and Pol IV. At 2.5 μM Pol I, Pol II, and Pol IV retain DNA, whereas Pol IIIα does not. The more intense bands for Pol I and Pol II are caused by protein induced fluoresence enhancement (PIFE) (Hwang et al., 2011). Right panel: SDS-page analysis of the same samples used for the electro-mobility shift assay (proteins stained with coomassie blue). Molecular weights: Pol I (Klenow fragment) 70 kDa, Pol II 90 kDa, Pol IIIα 130 kDa, Pol IV 40 kDa. (B) Structural comparison of Pol I (PDB code: 1QTM [Li et al., 1999]), Pol II (PDB code: 3K57 [Wang and Yang, 2009]), PolIIIα (this work), and Pol IV (PDB code: 4IRD [Sharma et al., 2013]). Polymerases were aligned on the 3’ end of the primer, indicated by the solid line. For Pol I, Pol II, and Pol IV, the clamp was modeled based on predicted clamp interacting motifs in the respective polymerases. The distance measured in base pairs between the 3’ end of the primer and the opening of the clamp is indicated on top of the structures, together with the rate of DNA synthesis of each polymerase. (C) Detailed view of the interaction of the polymerase thumb domains and the DNA. All polymerase thumb domains interact with the backbone of the minor groove. Only Pol IIIα inserts a loop into the major groove of the DNA.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.015</doi><resource>https://elifesciences.org/articles/11134/figures#fig3s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. DNA binding induces large conformational changes in the polymerase.</title><subtitle>(A) Clamp binding by PolIIIα in the DNA-free complex. Arrows indicate movement of the PolIIIα tail (see also Video 3). (B) Clamp binding by PolIIIα in the DNA-bound complex. Dashed boxes indicate views shown in panel D and E (C) Comparison of the PolIIIα-tail - τ500 interaction in the DNA-free (in grey) and DNA-bound structure. (D and E) Detailed view of the clamp - PolIIIα OB domain interaction. Interacting regions at the interface are indicated in thick coil in magenta (clamp: residues 24–24 and residues 275–278) and red (PolIIIα-OB domain: residues 1035–1043 and residues 1003–1013). Residues mutated in Georgescu et al (Georgescu et al., 2009) are shown in sticks and labeled with outlined boxes. Note that the positions of the side chains have not been refined and should be seen as approximate positions.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.016</doi><resource>https://elifesciences.org/articles/11134#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Video 3. DNA binding induces large conformational changes in the complex, Related to Figure 4.</title></titles><format mime_type="video/mp4"/><doi_data><doi>10.7554/eLife.11134.017</doi><resource>https://elifesciences.org/articles/11134#media3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Schematic representation for a possible role of the conformational changes in the polymerase.</title><subtitle>During processive DNA synthesis, the tail of the polymerase is attached to the clamp (indicated with ‘1’) and pulls τ500 away from the polymerase fingers domain. This conformation may be further stabilized by the presence of a DNA binding region immediately upstream of τ500 (indicated with ‘2’; see text for more details).Upon encounter of a release trigger, the contact between τ500 and the polymerase fingers domain is restored (indicated with ‘3’), and the contact between the clamp and polymerase tail is broken (indicated with ‘4’). The release trigger may either come from a collision with the previous Okazaki fragment (indicated with ‘Collision’), or a signal from other replisome components via the flexible linker of τ (indicated with ‘Signaling’). Once the polymerase-tail clamp contact has been broken, the two remaining contacts between the clamp and polymerase-exonuclease are not enough to keep the polymerase bound to the clamp. The polymerase is released from clamp and DNA and can be repositioned to a newly primed site to reinitiate DNA synthesis.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.11134.018</doi><resource>https://elifesciences.org/articles/11134#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.11134.019</doi><resource>https://elifesciences.org/articles/11134#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.11134.020</doi><resource>https://elifesciences.org/articles/11134#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-11134-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>10</month>
+					<day>24</day>
+					<year>2015</year>
+				</publication_date>
+				<journal_volume>
+					<volume>4</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>cryo-EM structures of the E. coli replicative DNA polymerase reveal its dynamic interactions with the DNA sliding clamp, exonuclease and τ</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Rafael</given_name>
+						<surname>Fernandez-Leiro</surname>
+						<affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0002-7941-0357</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Julian</given_name>
+						<surname>Conrad</surname>
+						<affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Sjors HW</given_name>
+						<surname>Scheres</surname>
+						<affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0002-0462-6540</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Meindert H</given_name>
+						<surname>Lamers</surname>
+						<affiliation>MRC Laboratory of Molecular Biology, Cambridge, United Kingdom</affiliation>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>The replicative DNA polymerase PolIIIα from Escherichia coli is a uniquely fast and processive enzyme. For its activity it relies on the DNA sliding clamp β, the proofreading exonuclease ε and the C-terminal domain of the clamp loader subunit τ. Due to the dynamic nature of the four-protein complex it has long been refractory to structural characterization. Here we present the 8 Å resolution cryo-electron microscopy structures of DNA-bound and DNA-free states of the PolIII-clamp-exonuclease-τc complex. The structures show how the polymerase is tethered to the DNA through multiple contacts with the clamp and exonuclease. A novel contact between the polymerase and clamp is made in the DNA bound state, facilitated by a large movement of the polymerase tail domain and τc. These structures provide crucial insights into the organization of the catalytic core of the replisome and form an important step towards determining the structure of the complete holoenzyme.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>DNA replication is complicated because the two strands that form its “double helix” structure run in opposite directions and need to be replicated at the same time. One of the new strands, the leading strand, is built continuously. While the other strand, called the lagging strand, is made in stretches that are about 1000-times shorter and run in the opposite direction from the leading strand. This means that the enzyme that builds the new strands of DNA (called DNA polymerase) must be repeatedly released and repositioned when it builds the lagging strand, however it is not fully understood how this achieved.</jats:p>
+					<jats:p>Fernandez-Leiro, Conrad et al. have now used a technique called cryo-electron microscopy to reveal the three-dimensional structure of a DNA polymerase from a bacterium called Escherichia coli complete with other associated factors and a DNA molecule. These factors include: the “sliding clamp” that allows the polymerase to slide along the DNA; the “proofreading exonuclease” that removes mistakes in the newly built DNA strand, and the “processivity switch Tau” that is needed for the repeated release and repositioning of the polymerase at the lagging strand. These structures show how the polymerase is bound to the DNA by multiple interactions with the sliding clamp and exonuclease.</jats:p>
+					<jats:p>Fernandez-Leiro, Conrad et al. also solved the structure of the same proteins but without the DNA molecule. This revealed a large structural change between the DNA-bound and DNA-free states, which provides some clues as to how the polymerase can be quickly released from the DNA during the repeated cycles of DNA synthesis at the lagging strand. Further research is now needed to uncover what signals trigger this release of the DNA polymerase.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>10</month>
+					<day>24</day>
+					<year>2015</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e11134</item_number>
+					<identifier id_type="doi">10.7554/eLife.11134</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Medical Research Counc</fr:assertion>
+						<fr:assertion name="award_number">U105197143</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Medical Research Council
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">MC_UP_A025_1013</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.11134</doi>
+					<resource>https://elifesciences.org/articles/11134</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/11134/elife-11134-v2.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/11134/elife-11134-v2.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>Science</journal_title>
+						<author>Bailey</author>
+						<volume>318</volume>
+						<first_page>459</first_page>
+						<cYear>2007</cYear>
+						<article_title>Structure of hexameric DnaB helicase and its complex with a domain of DnaG primase</article_title>
+						<doi>10.1126/science.1147353</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Cell</journal_title>
+						<author>Bailey</author>
+						<volume>126</volume>
+						<first_page>893</first_page>
+						<cYear>2006</cYear>
+						<article_title>The structure of T. aquaticus DNA polymerase III is distinct from eukaryotic replicative DNA polymerases</article_title>
+						<doi>10.1016/j.cell.2006.07.027</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Journal of Biological Chemistry</journal_title>
+						<author>Bloom</author>
+						<volume>272</volume>
+						<first_page>27919</first_page>
+						<cYear>1997</cYear>
+						<article_title>Fidelity of Escherichia coli DNA polymerase III holoenzyme: The effects of beta, gamma complex processivity proteins and epsilon proofreadingexonuclease on nucleotide misincorporation efficiencies</article_title>
+						<doi>10.1074/jbc.272.44.27919</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Bunting</author>
+						<volume>22</volume>
+						<first_page>5883</first_page>
+						<cYear>2003</cYear>
+						<article_title>Structural basis for recruitment of translesion DNA polymerase Pol IV/DinB to the beta-clamp</article_title>
+						<doi>10.1093/emboj/cdg568</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>Ultramicroscopy</journal_title>
+						<author>Chen</author>
+						<volume>135</volume>
+						<first_page>24</first_page>
+						<cYear>2013</cYear>
+						<article_title>High-resolution noise substitution to measure overfitting and validate resolution in 3D structure determination by single particle electron cryomicroscopy</article_title>
+						<doi>10.1016/j.ultramic.2013.06.004</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Journal of Molecular Biology</journal_title>
+						<author>Dohrmann</author>
+						<volume>414</volume>
+						<first_page>15</first_page>
+						<cYear>2011</cYear>
+						<article_title>The rate of polymerase release upon filling the gap between okazaki fragments is inadequate to support cycling during lagging strand synthesis</article_title>
+						<doi>10.1016/j.jmb.2011.09.039</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>Journal of Molecular Biology</journal_title>
+						<author>Dohrmann</author>
+						<volume>350</volume>
+						<first_page>228</first_page>
+						<cYear>2005</cYear>
+						<article_title>A bipartite polymerase–processivity factor interaction: only the internal β binding site of the α subunit is required for processive replication by the DNA polymerase III holoenzyme</article_title>
+						<doi>10.1016/j.jmb.2005.04.065</doi>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Acta Crystallographica Section D. Biological Crystallography</journal_title>
+						<author>Emsley</author>
+						<volume>66</volume>
+						<first_page>486</first_page>
+						<cYear>2010</cYear>
+						<article_title>Features and development of coot</article_title>
+						<doi>10.1107/S0907444910007493</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Evans</author>
+						<volume>105</volume>
+						<first_page>20695</first_page>
+						<cYear>2008</cYear>
+						<article_title>Structure of PolC reveals unique DNA binding and fidelity determinants</article_title>
+						<doi>10.1073/pnas.0809989106</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Cell</journal_title>
+						<author>Georgescu</author>
+						<volume>132</volume>
+						<first_page>43</first_page>
+						<cYear>2008</cYear>
+						<article_title>Structure of a sliding clamp on DNA</article_title>
+						<doi>10.1016/j.cell.2007.11.045</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Georgescu</author>
+						<volume>28</volume>
+						<first_page>2981</first_page>
+						<cYear>2009</cYear>
+						<article_title>Mechanism of polymerase collision release from sliding clamps on the lagging strand</article_title>
+						<doi>10.1038/emboj.2009.233</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Georgescu</author>
+						<volume>105</volume>
+						<first_page>11116</first_page>
+						<cYear>2008</cYear>
+						<article_title>Structure of a small-molecule inhibitor of a DNA polymerase sliding clamp</article_title>
+						<doi>10.1073/pnas.0804754105</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Structure</journal_title>
+						<author>Hamdan</author>
+						<volume>10</volume>
+						<first_page>535</first_page>
+						<cYear>2002</cYear>
+						<article_title>Structural basis for proofreading during replication of the escherichia coli chromosome</article_title>
+						<doi>10.1016/S0969-2126(02)00738-4</doi>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Hwang</author>
+						<volume>108</volume>
+						<first_page>7414</first_page>
+						<cYear>2011</cYear>
+						<article_title>Protein induced fluorescence enhancement as a single molecule assay with short distance sensitivity</article_title>
+						<doi>10.1073/pnas.1017672108</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Indiani</author>
+						<volume>106</volume>
+						<first_page>6031</first_page>
+						<cYear>2009</cYear>
+						<article_title>Translesion DNA polymerases remodel the replisome and alter the speed of the replicative helicase</article_title>
+						<doi>10.1073/pnas.0901403106</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Jergic</author>
+						<volume>32</volume>
+						<first_page>1322</first_page>
+						<cYear>2013</cYear>
+						<article_title>A direct proofreader–clamp interaction stabilizes the Pol III replicase in the polymerization mode</article_title>
+						<doi>10.1038/emboj.2012.347</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Jergic</author>
+						<volume>35</volume>
+						<first_page>2813</first_page>
+						<cYear>2007</cYear>
+						<article_title>The unstructured C-terminus of the tau subunit of Escherichia coli DNA polymerase III holoenzyme is the site of interaction with the alpha subunit</article_title>
+						<doi>10.1093/nar/gkm079</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Cell</journal_title>
+						<author>Jeruzalmi</author>
+						<volume>106</volume>
+						<first_page>429</first_page>
+						<cYear>2001</cYear>
+						<article_title>Crystal structure of the processivity clamp loader gamma (γ) complex of E. coli DNA polymerase III</article_title>
+						<doi>10.1016/S0092-8674(01)00463-9</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>Cell</journal_title>
+						<author>Jeruzalmi</author>
+						<volume>106</volume>
+						<first_page>417</first_page>
+						<cYear>2001</cYear>
+						<article_title>Mechanism of processivity clamp opening by the delta subunit wrench of the clamp loader complex of E. coli DNA polymerase III</article_title>
+						<doi>10.1016/S0092-8674(01)00462-7</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Cell</journal_title>
+						<author>Kong</author>
+						<volume>69</volume>
+						<first_page>425</first_page>
+						<cYear>1992</cYear>
+						<article_title>Three-dimensional structure of the beta subunit of E. coli DNA polymerase III holoenzyme: a sliding DNA clamp</article_title>
+						<doi>10.1016/0092-8674(92)90445-I</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Cell</journal_title>
+						<author>Lamers</author>
+						<volume>126</volume>
+						<first_page>881</first_page>
+						<cYear>2006</cYear>
+						<article_title>Crystal structure of the catalytic alpha subunit of E. coli replicative DNA polymerase III</article_title>
+						<doi>10.1016/j.cell.2006.07.028</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>Journal of Bacteriology</journal_title>
+						<author>Lancy</author>
+						<volume>171</volume>
+						<first_page>5572</first_page>
+						<cYear>1989</cYear>
+						<article_title>Isolation and characterization of mutants with deletions in dnaQ, the gene for the editing subunit of DNA polymerase III in Salmonella typhimurium</article_title>
+					</citation>
+					<citation key="bib23">
+						<journal_title>Molecular Cell</journal_title>
+						<author>Leu</author>
+						<volume>11</volume>
+						<first_page>315</first_page>
+						<cYear>2003</cYear>
+						<article_title>Mechanism of the E. coli tau processivity switch during lagging-strand synthesis</article_title>
+						<doi>10.1016/S1097-2765(03)00042-X</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Journal of Biological Chemistry</journal_title>
+						<author>Li</author>
+						<volume>275</volume>
+						<first_page>34757</first_page>
+						<cYear>2000</cYear>
+						<article_title>Two distinct triggers for cycling of the lagging strand polymerase at the replication fork</article_title>
+						<doi>10.1074/jbc.M006556200</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>Nature Methods</journal_title>
+						<author>Li</author>
+						<volume>10</volume>
+						<first_page>584</first_page>
+						<cYear>2013</cYear>
+						<article_title>Electron counting and beam-induced motion correction enable near-atomic-resolution single-particle cryo-EM</article_title>
+						<doi>10.1038/nmeth.2472</doi>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Li</author>
+						<volume>96</volume>
+						<first_page>9491</first_page>
+						<cYear>1999</cYear>
+						<article_title>Structure-based design of taq DNA polymerases with improved properties of dideoxynucleotide incorporation</article_title>
+						<doi>10.1073/pnas.96.17.9491</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Structure</journal_title>
+						<author>Liu</author>
+						<volume>21</volume>
+						<first_page>658</first_page>
+						<cYear>2013</cYear>
+						<article_title>Structure of the PolIIIα-τc-DNA complex suggests an atomic model of the replisome</article_title>
+						<doi>10.1016/j.str.2013.02.002</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Maki</author>
+						<volume>260</volume>
+						<first_page>12987</first_page>
+						<cYear>1985</cYear>
+						<article_title>The polymerase subunit of DNA polymerase III of Escherichia coli. II. Purification of the alpha subunit, devoid of nuclease activities</article_title>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Mayanagi</author>
+						<volume>108</volume>
+						<first_page>1845</first_page>
+						<cYear>2011</cYear>
+						<article_title>Architecture of the DNA polymerase b-proliferating cell nuclear antigen (pCNA)-DNA ternary complex</article_title>
+						<doi>10.1073/pnas.1010933108</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>McHenry</author>
+						<volume>257</volume>
+						<first_page>2657</first_page>
+						<cYear>1982</cYear>
+						<article_title>Purification and characterization of DNA polymerase III'. Identification of tau as a subunit of the DNA polymerase III holoenzyme</article_title>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Molecular Cell</journal_title>
+						<author>McInerney</author>
+						<volume>27</volume>
+						<first_page>527</first_page>
+						<cYear>2007</cYear>
+						<article_title>Characterization of a triple DNA polymerase replisome</article_title>
+						<doi>10.1016/j.molcel.2007.06.019</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Journal of Structural Biology</journal_title>
+						<author>Mindell</author>
+						<volume>142</volume>
+						<first_page>334</first_page>
+						<cYear>2003</cYear>
+						<article_title>Accurate determination of local defocus and specimen tilt in electron microscopy</article_title>
+						<doi>10.1016/S1047-8477(03)00069-8</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Mok</author>
+						<volume>262</volume>
+						<first_page>16644</first_page>
+						<cYear>1987</cYear>
+						<article_title>The Escherichia coli preprimosome and DNA B helicase can form replication forks that move at the same rate</article_title>
+					</citation>
+					<citation key="bib34">
+						<journal_title>Journal of Biological Chemistry</journal_title>
+						<author>Onrust</author>
+						<volume>270</volume>
+						<first_page>13366</first_page>
+						<cYear>1995</cYear>
+						<article_title>Assembly of a chromosomal replication machine: two DNA polymerases, a clamp loader, and sliding clamps in one holoenzyme particle: III. Interface between two polymerases and the clamp loader</article_title>
+						<doi>10.1074/jbc.270.22.13366</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Ozawa</author>
+						<volume>41</volume>
+						<first_page>5354</first_page>
+						<cYear>2013</cYear>
+						<article_title>Proofreading exonuclease on a tether: the complex between the E. coli DNA polymerase III subunits and alpha, epsilon, theta and beta reveals a highly flexible arrangement of the proofreading domain</article_title>
+						<doi>10.1093/nar/gkt162</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>Journal of Molecular Biology</journal_title>
+						<author>Rosenthal</author>
+						<volume>333</volume>
+						<first_page>721</first_page>
+						<cYear>2003</cYear>
+						<article_title>Optimal determination of particle orientation, absolute hand, and contrast loss in single-particle electron cryomicroscopy</article_title>
+						<doi>10.1016/j.jmb.2003.07.013</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Nature Methods</journal_title>
+						<author>Scheres</author>
+						<volume>9</volume>
+						<first_page>853</first_page>
+						<cYear>2012</cYear>
+						<article_title>Prevention of overfitting in cryo-EM structure determination</article_title>
+						<doi>10.1038/nmeth.2115</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Journal of Structural Biology</journal_title>
+						<author>Scheres</author>
+						<volume>180</volume>
+						<first_page>519</first_page>
+						<cYear>2012</cYear>
+						<article_title>RELION: implementation of a Bayesian approach to cryo-EM structure determination</article_title>
+						<doi>10.1016/j.jsb.2012.09.006</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>eLife</journal_title>
+						<author>Scheres</author>
+						<volume>3</volume>
+						<first_page>p.e03665.</first_page>
+						<cYear>2014</cYear>
+						<article_title>Beam-induced motion correction for sub-megadalton cryo-EM particles</article_title>
+						<doi>10.7554/eLife.03665.009</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America </journal_title>
+						<author>Scheuermann</author>
+						<volume>80</volume>
+						<first_page>7085</first_page>
+						<cYear>1983</cYear>
+						<article_title>Identification of the epsilon-subunit of escherichia coli DNA polymerase III holoenzyme as the dnaQ gene product: a fidelity subunit for DNA replication</article_title>
+						<doi>10.1073/pnas.80.23.7085</doi>
+					</citation>
+					<citation key="bib41">
+						<author>Schrödinger</author>
+						<cYear>2010</cYear>
+						<article_title>The PyMOL molecular graphics system</article_title>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Schwartz</author>
+						<volume>106</volume>
+						<first_page>20294</first_page>
+						<cYear>2009</cYear>
+						<article_title>Single molecule measurement of the &quot;speed limit&quot; of DNA polymerase</article_title>
+						<doi>10.1073/pnas.0907404106</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Sharma</author>
+						<volume>41</volume>
+						<first_page>5104</first_page>
+						<cYear>2013</cYear>
+						<article_title>A strategically located serine residue is critical for the mutator activity of DNA polymerase IV from Escherichia coli</article_title>
+						<doi>10.1093/nar/gkt146</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>Cell</journal_title>
+						<author>Simonetta</author>
+						<volume>137</volume>
+						<first_page>659</first_page>
+						<cYear>2009</cYear>
+						<article_title>The mechanism of ATP-dependent primer-template recognition by a clamp loader complex</article_title>
+						<doi>10.1016/j.cell.2009.03.044</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Stukenberg</author>
+						<volume>266</volume>
+						<first_page>11328</first_page>
+						<cYear>1991</cYear>
+						<article_title>Mechanism of the sliding beta-clamp of DNA polymerase III holoenzyme</article_title>
+					</citation>
+					<citation key="bib46">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Su</author>
+						<volume>35</volume>
+						<first_page>2825</first_page>
+						<cYear>2007</cYear>
+						<article_title>Solution structure of domains IVa and V of the tau subunit of Escherichia coli DNA polymerase III and interaction with the alpha subunit</article_title>
+						<doi>10.1093/nar/gkm080</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Journal of Structural Biology</journal_title>
+						<author>Tang</author>
+						<volume>157</volume>
+						<first_page>38</first_page>
+						<cYear>2007</cYear>
+						<article_title>EMAN2: an extensible image processing suite for electron microscopy</article_title>
+						<doi>10.1016/j.jsb.2006.05.009</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Toste Rêgo</author>
+						<volume>32</volume>
+						<first_page>1334</first_page>
+						<cYear>2013</cYear>
+						<article_title>Architecture of the Pol III–clamp–exonuclease complex reveals key roles of the exonuclease subunit in processive DNA synthesis and repair</article_title>
+						<doi>10.1038/emboj.2013.68</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Cell</journal_title>
+						<author>Wang</author>
+						<volume>139</volume>
+						<first_page>1279</first_page>
+						<cYear>2009</cYear>
+						<article_title>Structural insight into translesion synthesis by DNA Pol II</article_title>
+						<doi>10.1016/j.cell.2009.11.043</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>Nature Structural Molecular Biology</journal_title>
+						<author>Wang</author>
+						<volume>15</volume>
+						<first_page>94</first_page>
+						<cYear>2008</cYear>
+						<article_title>The structure of a DnaB-family replicative helicase and its interactions with primase</article_title>
+						<doi>10.1038/nsmb1356</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Biochemistry</journal_title>
+						<author>Wijffels</author>
+						<volume>43</volume>
+						<first_page>5661</first_page>
+						<cYear>2004</cYear>
+						<article_title>Inhibition of protein interactions with the beta 2 sliding clamp of Escherichia coli DNA polymerase III by peptides from beta 2 -binding proteins</article_title>
+						<doi>10.1021/bi036229j</doi>
+					</citation>
+					<citation key="bib52">
+						<journal_title>Journal of Molecular Biology</journal_title>
+						<author>Wing</author>
+						<volume>382</volume>
+						<first_page>859</first_page>
+						<cYear>2008</cYear>
+						<article_title>Insights into the replisome from the structure of a ternary complex of the DNA polymerase III α-subunit</article_title>
+						<doi>10.1016/j.jmb.2008.07.058</doi>
+					</citation>
+					<citation key="bib53">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Wu</author>
+						<volume>267</volume>
+						<first_page>4030</first_page>
+						<cYear>1992</cYear>
+						<article_title>Coordinated leading- and lagging-strand synthesis at the Escherichia coli DNA replication fork. I. Multiple effectors act to modulate Okazaki fragment size</article_title>
+					</citation>
+					<citation key="bib54">
+						<journal_title>The Journal of Biological Chemistry</journal_title>
+						<author>Wu</author>
+						<volume>267</volume>
+						<first_page>4074</first_page>
+						<cYear>1992</cYear>
+						<article_title>Coordinated leading- and lagging-strand synthesis at the Escherichia coli DNA replication fork. V. primase action regulates the cycle of okazaki fragment synthesis</article_title>
+					</citation>
+					<citation key="bib55">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Yao</author>
+						<volume>106</volume>
+						<first_page>13236</first_page>
+						<cYear>2009</cYear>
+						<article_title>Single-molecule analysis reveals that the lagging strand increases replisome processivity but slows replication fork progression</article_title>
+						<doi>10.1073/pnas.0906157106</doi>
+					</citation>
+					<citation key="bib56">
+						<journal_title>Nucleic Acids Research</journal_title>
+						<author>Yuan</author>
+						<volume>42</volume>
+						<first_page>1747</first_page>
+						<cYear>2014</cYear>
+						<article_title>Cycling of the E. coli lagging strand polymerase is triggered exclusively by the availability of a new primer at the replication fork</article_title>
+						<doi>10.1093/nar/gkt1098</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.001</doi>
+							<resource>https://elifesciences.org/articles/11134#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.002</doi>
+							<resource>https://elifesciences.org/articles/11134#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Cryo-EM structures of the E. coli PolIIIα-clamp-exonuclease-τ500 complex.</title>
+							<subtitle>(A) Surface representation of the three structures, shown at 5 σ. Left to right: DNA-free, DNA-bound, and DNA-bound without tail. Colors indicate the position of the different proteins (B) Individual structures of PolIIIα, clamp, exonuclease, and τ500 fitted into the cryo-EM map (shown in grey at 5 σ) (C) Detailed views of the cryo-EM map (shown in grey mesh at 6 σ). Left panel: exit channel of the clamp in the DNA-free structure showing the ‘DNA-free’ map. Middle panel: bottom view of the polymerase showing the ‘DNA-free’ map. Right panel: detail of the DNA showing the ‘DNA-bound, no tail’ map. See also Videos 1 and 2.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.003</doi>
+							<resource>https://elifesciences.org/articles/11134#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 1. Characterization of improved clamp binding mutants.</title>
+							<subtitle>(A) Gel filtration analysis of the wild-type PolIIIα-clamp-exonuclease complex (top panel) and the PolIIIαQLDLF-clamp-exonucleaseQLSLPL complex (lower panel). The wild-type complex dissociates at lower protein concentrations, while the stabilized complex remains intact even at 0.1 μM.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.004</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig1s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 2. Microscopy data analysis and validation.</title>
+							<subtitle>(A) Typical micrograph of the PolIIIα-clamp-exonuclease-τ500-DNA complex. (B) 2D class averages derived from the final 63,215 particle dataset (C) Fourier shell correlation for the DNA-free and DNA-bound models. In solid lines, the correlation between two independently refined halves of the data is indicated (gold-standard FSC). Estimated resolution at a correlation of 0.143 is 8.3 Å and 8.0 Å for the DNA-free and DNA-bound complex, respectively. In dashed lines, the correlation between the rigid-body docked models and their respective maps is indicated. (D) 3D model reconstruction. An initial model was obtained using Eman2 and subsequently classified into six 3D classes. Two of the 3D classes were merged into the ‘DNA-free’ map (16,970 particles) and one of these (5663 particles) was used for the ‘DNA-bound’ map. The remaining three classes were merged into the ‘DNA-bound, no tail’ map (40,582 particles) and further refined in Relion, resulting in three structurally distinct models. (E) Orientational distribution for particles of the DNA-free complex. The circle represents a flattened sphere plotted using Lambert equal area projection with the pole at the center and the equator at the outer rim of the circle. The radius indicates the tilt angle and the azimuth indicates the rotation or direction of the tilt. (F) Same for the DNA-bound complex (G) Tilt pair validation using 267 particle pairs that were selected from 20 image pairs collected at 0 and 20° tilt angle of the sample stage. The angular difference between the same particle collected from the two images is displayed. The black cross indicates the expected angular difference between pairs.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.005</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig1s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 3. Rigid body movements in PolIIIα.</title>
+							<subtitle>(A) Domain definitions used for the rigid body fitting of the PolIIIα structure into the cryo-EM maps. Domain boundaries are: PHP (residues 1–280), palm-fingers (residues 281–432 + 510–810), thumb (residues 433–509), tip-of-fingers (residues 811–928) and C-terminal tail (residues 929–1160). (B and C) Comparison of crystal structure of E. coli PolIIIα (shown in grey) and PolIIIα as fitted into the cryo-EM maps (the tail of the polymerase is omitted for clarity).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.006</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig1s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 1. Structure of the DNA-free complex of PolIIα-clamp-exonuclease-τ500, Related to Figure 1.</title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.007</doi>
+							<resource>https://elifesciences.org/articles/11134#media1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 2. Structure of the DNA-bound complex of PolIIα-clamp-exonuclease-τ500, Related to Figure 1.</title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.008</doi>
+							<resource>https://elifesciences.org/articles/11134#media2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Multiple contacts between the subunits hold the complex together.</title>
+							<subtitle>(A) Three different views of the DNA-free complex of PolIIIα-clamp-exonuclease-τ500 showing extensive contacts between the polymerase and other subunits. Missing loops in PolIIIα (residues 927–936) and exonuclease (residues 190–207) are shown in dots. Dashed boxes indicate views shown in panels B-D. (B) Modified clamp binding motif of PolIIIα (QLDLF: shown in sticks) modeled into the binding pocket of the clamp. (C) Modified clamp binding motif of the exonuclease (QLSLPL: shown in sticks) modeled into the second binding pocket of the dimeric clamp. (D) τ500 simultaneously binds the fingers and tail domain of the polymerase. The C-terminal residues of τ500 (residues 622–643: not modeled) bind to the tail of the polymerase, while the globular domain of τ500 binds to the polymerase fingers domain (see Figure 2—figure supplement 2 for more details).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.009</doi>
+							<resource>https://elifesciences.org/articles/11134#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. Previously determined cross-links fit accurately with the cryo-EM model.</title>
+							<subtitle>(A) Model of the polymerase-clamp-exonuclease complex based on chemical cross-links reported in (Toste Rêgo et al., 2013). Magenta dashed lines: polymerase-clamp cross-links. Cyan dashed lines: polymerase-exonuclease cross-links. Black dashed lines: clamp-exonuclease cross-links. (B) Same cross-links mapped onto the DNA-free cryo-EM model.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.010</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 2. Details of the interactions between τ500 and the PolIIIα fingers domain.</title>
+							<subtitle>(A) Three orthogonal views of the fit of τ500 into the cryo-EM density. Dashed box in left panel indicates view shown in panel B. (B) Detailed view of the τ500 - PolIIIα fingers domain interaction. Contact regions at the interface are indicated with thick coil in red (τ500: residues 530–535 and residues 562–566) and blue (PolIIIα: residues 657–667)</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.011</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig2s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 3. Comparison of τ binding in E. coli and Taq PolIIIα.</title>
+							<subtitle>(A,B) DNA-free and DNA-bound E. coli PolIIIα-τ500. The clamp and exonuclease are omitted for clarity. (C) Taq PolIIIα-τc (Liu et al., 2013).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.012</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig2s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. The DNA has extensive contacts with PolIIIα and clamp.</title>
+							<subtitle>(A) Overview of the DNA-bound complex. The N-termini of the two helices that point at the DNA backbone are colored in blue. Potential DNA interacting side chains are shown in sticks. The tail of PolIIIα, the exonuclease and τ500 are omitted for clarity. Arrow indicates viewpoint in panel B (B) Polymerase active site, with the DNA held between thumb, palm and fingers domain. Polymerase active site residues are indicated with magenta spheres. Arrow indicates viewpoint in panel C (C) DNA interactions downstream of the active site. The OB domain is positioned on top of the DNA but does not make any contacts with it. (D) DNA exit channel in the clamp with positively charged residues within 10 Å of the DNA indicated in magenta sticks. Note that the positions of the side chains have not been refined and should be seen as approximate positions. (E) In the DNA-bound complex, the clamp is at a ∼80° angle from the DNA. A dashed line indicates the position of the clamp alone bound to a DNA substrate. (Georgescu et al., 2008a). The other subunits (PolIIIα, exonuclease, τ500) are shown in light grey for clarity.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.013</doi>
+							<resource>https://elifesciences.org/articles/11134#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. Comparison of DNA binding by C family DNA polymerases.</title>
+							<subtitle>(A) E. coli PolIIIα, (B) T. aquaticus PolIIIα (Wing et al., 2008), (C) G. kaustophilus PolC (Evans et al., 2008).</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.014</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 2. Pol IIIα has more extensive DNA interactions than other DNA polymerases.</title>
+							<subtitle>(A) Left panel: Electro-mobility shift assay with the E. coli DNA polymerases Pol I (Klenow fragment), Pol II, Pol IIIα, and Pol IV. At 2.5 μM Pol I, Pol II, and Pol IV retain DNA, whereas Pol IIIα does not. The more intense bands for Pol I and Pol II are caused by protein induced fluoresence enhancement (PIFE) (Hwang et al., 2011). Right panel: SDS-page analysis of the same samples used for the electro-mobility shift assay (proteins stained with coomassie blue). Molecular weights: Pol I (Klenow fragment) 70 kDa, Pol II 90 kDa, Pol IIIα 130 kDa, Pol IV 40 kDa. (B) Structural comparison of Pol I (PDB code: 1QTM [Li et al., 1999]), Pol II (PDB code: 3K57 [Wang and Yang, 2009]), PolIIIα (this work), and Pol IV (PDB code: 4IRD [Sharma et al., 2013]). Polymerases were aligned on the 3’ end of the primer, indicated by the solid line. For Pol I, Pol II, and Pol IV, the clamp was modeled based on predicted clamp interacting motifs in the respective polymerases. The distance measured in base pairs between the 3’ end of the primer and the opening of the clamp is indicated on top of the structures, together with the rate of DNA synthesis of each polymerase. (C) Detailed view of the interaction of the polymerase thumb domains and the DNA. All polymerase thumb domains interact with the backbone of the minor groove. Only Pol IIIα inserts a loop into the major groove of the DNA.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.015</doi>
+							<resource>https://elifesciences.org/articles/11134/figures#fig3s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. DNA binding induces large conformational changes in the polymerase.</title>
+							<subtitle>(A) Clamp binding by PolIIIα in the DNA-free complex. Arrows indicate movement of the PolIIIα tail (see also Video 3). (B) Clamp binding by PolIIIα in the DNA-bound complex. Dashed boxes indicate views shown in panel D and E (C) Comparison of the PolIIIα-tail - τ500 interaction in the DNA-free (in grey) and DNA-bound structure. (D and E) Detailed view of the clamp - PolIIIα OB domain interaction. Interacting regions at the interface are indicated in thick coil in magenta (clamp: residues 24–24 and residues 275–278) and red (PolIIIα-OB domain: residues 1035–1043 and residues 1003–1013). Residues mutated in Georgescu et al (Georgescu et al., 2009) are shown in sticks and labeled with outlined boxes. Note that the positions of the side chains have not been refined and should be seen as approximate positions.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.016</doi>
+							<resource>https://elifesciences.org/articles/11134#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Video 3. DNA binding induces large conformational changes in the complex, Related to Figure 4.</title>
+						</titles>
+						<format mime_type="video/mp4"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.017</doi>
+							<resource>https://elifesciences.org/articles/11134#media3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Schematic representation for a possible role of the conformational changes in the polymerase.</title>
+							<subtitle>During processive DNA synthesis, the tail of the polymerase is attached to the clamp (indicated with ‘1’) and pulls τ500 away from the polymerase fingers domain. This conformation may be further stabilized by the presence of a DNA binding region immediately upstream of τ500 (indicated with ‘2’; see text for more details).Upon encounter of a release trigger, the contact between τ500 and the polymerase fingers domain is restored (indicated with ‘3’), and the contact between the clamp and polymerase tail is broken (indicated with ‘4’). The release trigger may either come from a collision with the previous Okazaki fragment (indicated with ‘Collision’), or a signal from other replisome components via the flexible linker of τ (indicated with ‘Signaling’). Once the polymerase-tail clamp contact has been broken, the two remaining contacts between the clamp and polymerase-exonuclease are not enough to keep the polymerase bound to the clamp. The polymerase is released from clamp and DNA and can be repositioned to a newly primed site to reinitiate DNA synthesis.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.018</doi>
+							<resource>https://elifesciences.org/articles/11134#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.019</doi>
+							<resource>https://elifesciences.org/articles/11134#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.11134.020</doi>
+							<resource>https://elifesciences.org/articles/11134#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-12444-20170717071707.xml
+++ b/tests/test_data/elife-crossref-12444-20170717071707.xml
@@ -1,1 +1,1120 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-12444-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>02</month><day>24</day><year>2016</year></publication_date><journal_volume><volume>5</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>The autophagy gene Atg16l1 differentially regulates Treg and TH2 cells to control intestinal inflammation</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Agnieszka M</given_name><surname>Kabat</surname><affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Oliver J</given_name><surname>Harrison</surname><affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation><affiliation>Immunity at Barrier Sites Initiative, National Institute of Allergy and Infectious Diseases, National Institutes of Health, Bethesda, United States</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Thomas</given_name><surname>Riffelmacher</surname><affiliation>MRC Human Immunology Unit, Weatherall Institute of Molecular Medicine, University of Oxford, Oxford, United Kingdom</affiliation><affiliation>John Radcliffe Hospital, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Amin E</given_name><surname>Moghaddam</surname><affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Claire F</given_name><surname>Pearson</surname><affiliation>Kennedy Institute of Rheumatology, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Adam</given_name><surname>Laing</surname><affiliation>Peter Gorer Department of Immunobiology, King's College London, London, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Lucie</given_name><surname>Abeler-Dörner</surname><affiliation>Peter Gorer Department of Immunobiology, King's College London, London, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Simon P</given_name><surname>Forman</surname><affiliation>Faculty of Life Sciences, The University of Manchester, Manchester, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Richard K</given_name><surname>Grencis</surname><affiliation>Faculty of Life Sciences, The University of Manchester, Manchester, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Quentin</given_name><surname>Sattentau</surname><affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Anna Katharina</given_name><surname>Simon</surname><affiliation>MRC Human Immunology Unit, Weatherall Institute of Molecular Medicine, University of Oxford, Oxford, United Kingdom</affiliation><affiliation>John Radcliffe Hospital, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Johanna</given_name><surname>Pott</surname><affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Kevin J</given_name><surname>Maloy</surname><affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation><ORCID authenticated="true">http://orcid.org/0000-0001-5795-7688</ORCID></person_name></contributors><jats:abstract><jats:p>A polymorphism in the autophagy gene Atg16l1 is associated with susceptibility to inflammatory bowel disease (IBD); however, it remains unclear how autophagy contributes to intestinal immune homeostasis. Here, we demonstrate that autophagy is essential for maintenance of balanced CD4+ T cell responses in the intestine. Selective deletion of Atg16l1 in T cells in mice resulted in spontaneous intestinal inflammation that was characterized by aberrant type 2 responses to dietary and microbiota antigens, and by a loss of Foxp3+ Treg cells. Specific ablation of Atg16l1 in Foxp3+ Treg cells in mice demonstrated that autophagy directly promotes their survival and metabolic adaptation in the intestine. Moreover, we also identify an unexpected role for autophagy in directly limiting mucosal TH2 cell expansion. These findings provide new insights into the reciprocal control of distinct intestinal TH cell responses by autophagy, with important implications for understanding and treatment of chronic inflammatory disorders.</jats:p></jats:abstract><jats:abstract abstract-type="executive-summary"><jats:p>The gut presents a puzzle to our immune system. Immune cells must rapidly respond to antigens produced by harmful bacteria, but food and the beneficial bacteria that inhabit the gut also produce antigens that our immune system must tolerate. Inappropriate immune responses in the gut can lead to inflammatory bowel disease, a debilitating disease with no current cure. We do not fully understand why these harmful inflammatory responses arise, but we know that genetic factors are important. Mutations in genes that affect a process known as autophagy – a pathway that breaks down and recycles unwanted material inside cells – make inflammatory bowel disease more likely to develop, but exactly how they do so remains unclear.</jats:p><jats:p>T helper cells are crucial controllers of intestinal immune responses and changes in their numbers and behaviour occur during inflammatory bowel disease. Kabat et al. explored how the autophagy pathway affects these key immune cells in mice. Blocking autophagy in T cells altered the balance of different types of T helper cells in the gut. A crucial population of regulatory T cells, which keep inflammatory responses in check, was lost. At the same time, another population of T cells expanded: the T helper 2 (TH2) cells that are responsible for driving allergies. As a result, the mice developed intestinal inflammation and produced antibodies against gut bacteria and food.</jats:p><jats:p>Overall, Kabat et al.’s results show that autophagy defects can alter the balance of different types of T cells in the gut, leading to inflammation in the intestine. These observations contribute to our understanding of how genetic changes may influence susceptibility to inflammatory bowel disease. They also suggest that drugs that activate autophagy could help to treat diseases associated with changes in regulatory T cells or TH2 cells, including inflammatory bowel disease and allergies. It will now be important to test this and to confirm whether similar changes in T cells are present in humans that have mutations in autophagy genes.</jats:p></jats:abstract><publication_date media_type="online"><month>02</month><day>24</day><year>2016</year></publication_date><publisher_item><item_number item_number_type="article_number">e12444</item_number><identifier id_type="doi">10.7554/eLife.12444</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion><fr:assertion name="award_number">Graduate Student Scholarship 097112</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion><fr:assertion name="award_number">100290</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion><fr:assertion name="award_number">100156</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Medical Research Council<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion></fr:assertion><fr:assertion name="award_number">MR/K011898/1</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Wellcome Trust<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion></fr:assertion><fr:assertion name="award_number">102972</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.12444</doi><resource>https://elifesciences.org/articles/12444</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/12444/elife-12444-v2.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/12444/elife-12444-v2.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>New England Journal of Medicine</journal_title><author>Abraham</author><volume>361</volume><first_page>2066</first_page><cYear>2009</cYear><article_title>Inflammatory Bowel Disease</article_title><doi>10.1056/NEJMra0804647</doi></citation><citation key="bib2"><journal_title>Biochemical Journal</journal_title><author>Backer</author><volume>410</volume><first_page>1</first_page><cYear>2008</cYear><article_title>The regulation and function of Class III PI3Ks: novel roles for Vps34</article_title><doi>10.1042/BJ20071427</doi></citation><citation key="bib3"><journal_title>Trends in Immunology</journal_title><author>Berin</author><volume>34</volume><first_page>390</first_page><cYear>2013</cYear><article_title>Food allergy: an enigmatic epidemic</article_title><doi>10.1016/j.it.2013.04.003</doi></citation><citation key="bib4"><journal_title>Nature Medicine</journal_title><author>Berod</author><volume>20</volume><first_page>1327</first_page><cYear>2014</cYear><article_title>De novo fatty acid synthesis controls the fate between regulatory T and T helper 17 cells</article_title><doi>10.1038/nm.3704</doi></citation><citation key="bib5"><journal_title>Nature Immunology</journal_title><author>Burzyn</author><volume>14</volume><first_page>1007</first_page><cYear>2013</cYear><article_title>Regulatory T cells in nonlymphoid tissues</article_title><doi>10.1038/ni.2683</doi></citation><citation key="bib6"><journal_title>Nature</journal_title><author>Cadwell</author><volume>456</volume><first_page>259</first_page><cYear>2008</cYear><article_title>A key role for autophagy and the autophagy gene Atg16l1 in mouse and human intestinal Paneth cells</article_title><doi>10.1038/nature07416</doi></citation><citation key="bib7"><journal_title>PLoS ONE</journal_title><author>Cai</author><volume>9</volume><cYear>2014</cYear><article_title>Serological Investigation of Food Specific Immunoglobulin G Antibodies in Patients with Inflammatory Bowel Diseases</article_title><doi>10.1371/journal.pone.0112154</doi><elocation_id>e112154</elocation_id></citation><citation key="bib8"><journal_title>The Journal of Immunology</journal_title><author>Cheng</author><volume>189</volume><first_page>1780</first_page><cYear>2012</cYear><article_title>IL-2 Receptor Signaling Is Essential for the Development of Klrg1+ Terminally Differentiated T Regulatory Cells</article_title><doi>10.4049/jimmunol.1103768</doi></citation><citation key="bib9"><journal_title>The Journal of Experimental Medicine</journal_title><author>Coccia</author><volume>209</volume><first_page>1595</first_page><cYear>2012</cYear><article_title>IL-1β mediates chronic intestinal inflammation by promoting the accumulation of IL-17A secreting innate lymphoid cells and CD4(+) Th17 cells</article_title><doi>10.1084/jem.20111453</doi></citation><citation key="bib10"><journal_title>Immunity</journal_title><author>Curotto de Lafaille</author><volume>29</volume><first_page>114</first_page><cYear>2008</cYear><article_title>Adaptive Foxp3+ Regulatory T Cell-Dependent and -Independent Control of Allergic Inflammation</article_title><doi>10.1016/j.immuni.2008.05.010</doi></citation><citation key="bib11"><journal_title>Nature Immunology</journal_title><author>Dardalhon</author><volume>9</volume><first_page>1347</first_page><cYear>2008</cYear><article_title>IL-4 inhibits TGF-β-induced Foxp3+ T cells and, together with TGF-β, generates IL-9+ IL-10+ Foxp3− effector T cells</article_title><doi>10.1038/ni.1677</doi></citation><citation key="bib12"><journal_title>Cell</journal_title><author>Feng</author><volume>158</volume><first_page>749</first_page><cYear>2014</cYear><article_title>Control of the Inheritance of Regulatory T Cell Identity by a cis Element in the Foxp3 Locus</article_title><doi>10.1016/j.cell.2014.07.031</doi></citation><citation key="bib13"><journal_title>Cell</journal_title><author>Galluzzi</author><volume>159</volume><first_page>1263</first_page><cYear>2014</cYear><article_title>Metabolic Control of Autophagy</article_title><doi>10.1016/j.cell.2014.11.006</doi></citation><citation key="bib14"><journal_title>Nature Genetics</journal_title><author>Hampe</author><volume>39</volume><first_page>207</first_page><cYear>2007</cYear><article_title>A genome-wide association scan of nonsynonymous SNPs identifies a susceptibility variant for Crohn disease in ATG16L1</article_title><doi>10.1038/ng1954</doi></citation><citation key="bib15"><journal_title>Cell Host &amp; Microbe</journal_title><author>Hwang</author><volume>11</volume><first_page>397</first_page><cYear>2012</cYear><article_title>Nondegradative Role of Atg5-Atg12/ Atg16L1 Autophagy Protein Complex in Antiviral Activity of Interferon Gamma</article_title><doi>10.1016/j.chom.2012.03.002</doi></citation><citation key="bib16"><journal_title>Blood</journal_title><author>Isakson</author><volume>116</volume><first_page>2324</first_page><cYear>2010</cYear><article_title>Autophagy contributes to therapy-induced degradation of the PML/RARA oncoprotein</article_title><doi>10.1182/blood-2010-01-261040</doi></citation><citation key="bib17"><journal_title>Annual Review of Immunology</journal_title><author>Izcue</author><volume>27</volume><first_page>313</first_page><cYear>2009</cYear><article_title>Regulatory Lymphocytes and Intestinal Inflammation</article_title><doi>10.1146/annurev.immunol.021908.132657</doi></citation><citation key="bib18"><journal_title>The Journal of Immunology</journal_title><author>Jia</author><volume>186</volume><first_page>5313</first_page><cYear>2011</cYear><article_title>Temporal Regulation of Intracellular Organelle Homeostasis in T Lymphocytes by Autophagy</article_title><doi>10.4049/jimmunol.1002404</doi></citation><citation key="bib19"><journal_title>Cell Research</journal_title><author>Jiang</author><volume>24</volume><first_page>69</first_page><cYear>2014</cYear><article_title>Autophagy and human diseases</article_title><doi>10.1038/cr.2013.161</doi></citation><citation key="bib20"><journal_title>Nature</journal_title><author>Josefowicz</author><volume>482</volume><first_page>395</first_page><cYear>2012</cYear><article_title>Extrathymically generated regulatory T cells control mucosal TH2 inflammation</article_title><doi>10.1038/nature10772</doi></citation><citation key="bib21"><journal_title>Nature Reviews Molecular Cell Biology</journal_title><author>Kaur</author><volume>16</volume><first_page>461</first_page><cYear>2015</cYear><article_title>Autophagy at the crossroads of catabolism and anabolism</article_title><doi>10.1038/nrm4024</doi></citation><citation key="bib22"><journal_title>Autophagy</journal_title><author>Klionsky</author><volume>8</volume><first_page>445</first_page><cYear>2012</cYear><article_title>Guidelines for the use and interpretation of assays for monitoring autophagy</article_title><doi>10.4161/auto.19496</doi></citation><citation key="bib23"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Komatsu</author><volume>106</volume><first_page>1903</first_page><cYear>2009</cYear><article_title>Heterogeneity of natural Foxp3+ T cells: a committed regulatory T-cell lineage and an uncommitted minor population retaining plasticity</article_title><doi>10.1073/pnas.0811556106</doi></citation><citation key="bib24"><journal_title>Cell Death and Differentiation</journal_title><author>Kovacs</author><volume>19</volume><first_page>144</first_page><cYear>2012</cYear><article_title>Autophagy promotes T-cell survival through degradation of proteins of the cell death machinery</article_title><doi>10.1038/cdd.2011.78</doi></citation><citation key="bib25"><journal_title>PLoS ONE</journal_title><author>Kuballa</author><volume>3</volume><cYear>2008</cYear><article_title>Impaired Autophagy of an Intracellular Pathogen Induced by a Crohn's Disease Associated ATG16L1 Variant</article_title><doi>10.1371/journal.pone.0003391</doi><elocation_id>e3391</elocation_id></citation><citation key="bib26"><journal_title>Infection and Immunity</journal_title><author>Kullberg</author><volume>66</volume><first_page>5157</first_page><cYear>1998</cYear><article_title>Helicobacter hepaticus triggers colitis in specific-pathogen-free interleukin-10 (IL-10)-deficient mice through an IL-12- and gamma interferon-dependent mechanism</article_title></citation><citation key="bib27"><journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title><author>Lassen</author><volume>111</volume><first_page>7741</first_page><cYear>2014</cYear><article_title>Atg16L1 T300A variant decreases selective autophagy resulting in altered cytokine signaling and decreased antibacterial defense</article_title><doi>10.1073/pnas.1407001111</doi></citation><citation key="bib28"><journal_title>Gut</journal_title><author>Lees</author><volume>60</volume><first_page>1739</first_page><cYear>2011</cYear><article_title>New IBD genetics: common pathways with other diseases</article_title><doi>10.1136/gut.2009.199679</doi></citation><citation key="bib29"><journal_title>The Journal of Immunology</journal_title><author>Li</author><volume>177</volume><first_page>5163</first_page><cYear>2006</cYear><article_title>Autophagy Is Induced in CD4+ T Cells and Important for the Growth Factor-Withdrawal Cell Death</article_title><doi>10.4049/jimmunol.177.8.5163</doi></citation><citation key="bib30"><journal_title>Nature Reviews Immunology</journal_title><author>Liston</author><volume>14</volume><first_page>154</first_page><cYear>2014</cYear><article_title>Homeostatic control of regulatory T cell diversity</article_title><doi>10.1038/nri3605</doi></citation><citation key="bib31"><journal_title>Autophagy</journal_title><author>Lizaso</author><volume>9</volume><first_page>1228</first_page><cYear>2013</cYear><article_title>β-adrenergic receptor-stimulated lipolysis requires the RAB7-mediated autolysosomal lipid degradation</article_title><doi>10.4161/auto.24893</doi></citation><citation key="bib32"><journal_title>Trends in Immunology</journal_title><author>Lochner</author><volume>36</volume><first_page>81</first_page><cYear>2015</cYear><article_title>Fatty acid metabolism in the regulation of T cell function</article_title><doi>10.1016/j.it.2014.12.005</doi></citation><citation key="bib33"><journal_title>Journal of Clinical Investigation</journal_title><author>Lodes</author><volume>113</volume><first_page>1296</first_page><cYear>2004</cYear><article_title>Bacterial flagellin is a dominant antigen in Crohn disease</article_title><doi>10.1172/JCI200420295</doi></citation><citation key="bib34"><journal_title>Immunity</journal_title><author>Ma</author><volume>39</volume><first_page>211</first_page><cYear>2013</cYear><article_title>Autophagy and Cellular Immune Responses</article_title><doi>10.1016/j.immuni.2013.07.017</doi></citation><citation key="bib35"><journal_title>Annual Review of Immunology</journal_title><author>MacIver</author><volume>31</volume><first_page>259</first_page><cYear>2013</cYear><article_title>Metabolic Regulation of T Lymphocytes</article_title><doi>10.1146/annurev-immunol-032712-095956</doi></citation><citation key="bib36"><journal_title>Nature</journal_title><author>Maloy</author><volume>474</volume><first_page>298</first_page><cYear>2011</cYear><article_title>Intestinal homeostasis and its breakdown in inflammatory bowel disease</article_title><doi>10.1038/nature10208</doi></citation><citation key="bib37"><journal_title>PLoS ONE</journal_title><author>Martin</author><volume>7</volume><cYear>2012</cYear><article_title>Functional Variant in the Autophagy-Related 5 Gene Promotor is Associated with Childhood Asthma</article_title><doi>10.1371/journal.pone.0033454</doi><elocation_id>e33454</elocation_id></citation><citation key="bib38"><journal_title>The Journal of Immunology</journal_title><author>Michalek</author><volume>186</volume><first_page>3299</first_page><cYear>2011</cYear><article_title>Cutting Edge: Distinct Glycolytic and Lipid Oxidative Metabolic Programs Are Essential for Effector and Regulatory CD4+ T Cell Subsets</article_title><doi>10.4049/jimmunol.1003613</doi></citation><citation key="bib39"><journal_title>Journal of Cell Science</journal_title><author>Mizushima</author><volume>116</volume><first_page>1679</first_page><cYear>2003</cYear><article_title>Mouse Apg16L, a novel WD-repeat protein, targets to the autophagic isolation membrane with the Apg12-Apg5 conjugate</article_title><doi>10.1242/jcs.00381</doi></citation><citation key="bib40"><journal_title>Genes &amp; Development</journal_title><author>Mizushima</author><volume>21</volume><first_page>2861</first_page><cYear>2007</cYear><article_title>Autophagy: process and function</article_title><doi>10.1101/gad.1599207</doi></citation><citation key="bib41"><journal_title>Journal of Clinical Investigation</journal_title><author>Mucida</author><volume>115</volume><first_page>1923</first_page><cYear>2005</cYear><article_title>Oral tolerance in the absence of naturally occurring Tregs</article_title><doi>10.1172/JCI24487</doi></citation><citation key="bib42"><journal_title>Nature</journal_title><author>Murthy</author><volume>506</volume><first_page>456</first_page><cYear>2014</cYear><article_title>A Crohn’s disease variant in Atg16l1 enhances its degradation by caspase 3</article_title><doi>10.1038/nature13044</doi></citation><citation key="bib43"><journal_title>Immunity</journal_title><author>O’Sullivan</author><volume>41</volume><first_page>75</first_page><cYear>2014</cYear><article_title>Memory CD8+ T Cells Use Cell-Intrinsic Lipolysis to Support the Metabolic Programming Necessary for Development</article_title><doi>10.1016/j.immuni.2014.06.005</doi></citation><citation key="bib44"><journal_title>The Journal of Immunology</journal_title><author>Parekh</author><volume>190</volume><first_page>5086</first_page><cYear>2013</cYear><article_title>Impaired Autophagy, Defective T Cell Homeostasis, and a Wasting Syndrome in Mice with a T Cell-Specific Deletion of Vps34</article_title><doi>10.4049/jimmunol.1202071</doi></citation><citation key="bib45"><journal_title>Nature</journal_title><author>Pearce</author><volume>460</volume><first_page>103</first_page><cYear>2009</cYear><article_title>Enhancing CD8 T-cell memory by modulating fatty acid metabolism</article_title><doi>10.1038/nature08097</doi></citation><citation key="bib46"><journal_title>Science</journal_title><author>Pearce</author><volume>342</volume><first_page>1242454</first_page><cYear>2013</cYear><article_title>Fueling Immunity: Insights into Metabolism and Lymphocyte Function</article_title><doi>10.1126/science.1242454</doi></citation><citation key="bib47"><journal_title>Gut</journal_title><author>Plantinga</author><volume>60</volume><first_page>1229</first_page><cYear>2011</cYear><article_title>Crohn's disease-associated ATG16L1 polymorphism modulates pro-inflammatory cytokine responses selectively upon activation of NOD2</article_title><doi>10.1136/gut.2010.228908</doi></citation><citation key="bib48"><journal_title>Trends in Immunology</journal_title><author>Pollizzi</author><volume>36</volume><first_page>13</first_page><cYear>2015</cYear><article_title>Regulation of T cells by mTOR: the known knowns and the known unknowns</article_title><doi>10.1016/j.it.2014.11.005</doi></citation><citation key="bib49"><journal_title>Autophagy</journal_title><author>Poon</author><volume>8</volume><first_page>694</first_page><cYear>2012</cYear><article_title>ATG5, autophagy and lung function in asthma</article_title><doi>10.4161/auto.19315</doi></citation><citation key="bib50"><journal_title>The Journal of Immunology</journal_title><author>Pua</author><volume>182</volume><first_page>4046</first_page><cYear>2009</cYear><article_title>Autophagy Is Essential for Mitochondrial Clearance in Mature T Lymphocytes</article_title><doi>10.4049/jimmunol.0801143</doi></citation><citation key="bib51"><journal_title>eLife</journal_title><author>Puleston</author><volume>3</volume><cYear>2014</cYear><article_title>Autophagy is a critical regulator of memory CD8(+) T cell formation</article_title><doi>10.7554/eLife.03706</doi><elocation_id>e03706</elocation_id></citation><citation key="bib52"><journal_title>The Journal of Immunology</journal_title><author>Riedl</author><volume>174</volume><first_page>7440</first_page><cYear>2005</cYear><article_title>Initial High-Dose Nasal Allergen Exposure Prevents Allergic Sensitization to a Neoantigen</article_title><doi>10.4049/jimmunol.174.11.7440</doi></citation><citation key="bib53"><journal_title>Nature Genetics</journal_title><author>Rioux</author><volume>39</volume><first_page>596</first_page><cYear>2007</cYear><article_title>Genome-wide association study identifies new susceptibility loci for Crohn disease and implicates autophagy in disease pathogenesis</article_title><doi>10.1038/ng2032</doi></citation><citation key="bib54"><journal_title>Immunity</journal_title><author>Rubtsov</author><volume>28</volume><first_page>546</first_page><cYear>2008</cYear><article_title>Regulatory T Cell-Derived Interleukin-10 Limits Inflammation at Environmental Interfaces</article_title><doi>10.1016/j.immuni.2008.02.017</doi></citation><citation key="bib55"><journal_title>Nature</journal_title><author>Saitoh</author><volume>456</volume><first_page>264</first_page><cYear>2008</cYear><article_title>Loss of the autophagy protein Atg16L1 enhances endotoxin-induced IL-1β production</article_title><doi>10.1038/nature07383</doi></citation><citation key="bib56"><journal_title>The Journal of Immunology</journal_title><author>Schlie</author><volume>194</volume><first_page>4277</first_page><cYear>2015</cYear><article_title>Survival of Effector CD8+ T Cells during Influenza Infection Is Dependent on Autophagy</article_title><doi>10.4049/jimmunol.1402571</doi></citation><citation key="bib57"><journal_title>Immunological Reviews</journal_title><author>Shale</author><volume>252</volume><first_page>164</first_page><cYear>2013</cYear><article_title>CD4(+) T-cell subsets in intestinal inflammation</article_title><doi>10.1111/imr.12039</doi></citation><citation key="bib58"><journal_title>ACS Chemical Biology</journal_title><author>Shaw</author><volume>8</volume><first_page>2724</first_page><cYear>2013</cYear><article_title>Selective Modulation of Autophagy, Innate Immunity, and Adaptive Immunity by Small Molecules</article_title><doi>10.1021/cb400352d</doi></citation><citation key="bib59"><journal_title>Nature</journal_title><author>Singh</author><volume>458</volume><first_page>1131</first_page><cYear>2009</cYear><article_title>Autophagy regulates lipid metabolism</article_title><doi>10.1038/nature07976</doi></citation><citation key="bib60"><journal_title>Methods Mol. Biol</journal_title><author>Song-Zhao</author><volume>1193</volume><first_page>199</first_page><cYear>2014</cYear><article_title>Experimental mouse models of T cell-dependent inflammatory bowel disease</article_title><doi>10.1007/978-1-4939-1212-4_18</doi></citation><citation key="bib61"><journal_title>Autophagy</journal_title><author>Stephenson</author><volume>5</volume><first_page>625</first_page><cYear>2009</cYear><article_title>Identification of Atg5 -dependent transcriptional changes and increases in mitochondrial mass in Atg5 -deficient T lymphocytes</article_title><doi>10.4161/auto.5.5.8133</doi></citation><citation key="bib62"><journal_title>Annual Review of Immunology</journal_title><author>Strober</author><volume>20</volume><first_page>495</first_page><cYear>2002</cYear><article_title>The immunology of mucosal models of inflammation</article_title><doi>10.1146/annurev.immunol.20.100301.064816</doi></citation><citation key="bib63"><journal_title>Immunology</journal_title><author>Sudowe</author><volume>91</volume><first_page>464</first_page><cYear>1997</cYear><article_title>Antigen dose-dependent predominance of either direct or sequential switch'qc in IgE antibody responses</article_title><doi>10.1046/j.1365-2567.1997.00268.x</doi></citation><citation key="bib64"><journal_title>New England Journal of Medicine</journal_title><author>Tehranchi</author><volume>363</volume><first_page>1025</first_page><cYear>2010</cYear><article_title>Persistent Malignant Stem Cells in del(5q) Myelodysplasia in Remission</article_title><doi>10.1056/NEJMoa0912228</doi></citation><citation key="bib65"><journal_title>The Journal of Immunology</journal_title><author>Uhlig</author><volume>177</volume><first_page>5852</first_page><cYear>2006</cYear><article_title>Characterization of Foxp3+CD4+CD25+ and IL-10-Secreting CD4+CD25+ T Cells during Cure of Colitis</article_title><doi>10.4049/jimmunol.177.9.5852</doi></citation><citation key="bib66"><journal_title>Nature Reviews Gastroenterology &amp; Hepatology</journal_title><author>Van Limbergen</author><volume>11</volume><first_page>372</first_page><cYear>2014</cYear><article_title>Advances in IBD genetics</article_title><doi>10.1038/nrgastro.2014.27</doi></citation><citation key="bib67"><journal_title>Trends in Immunology</journal_title><author>Wan</author><volume>35</volume><first_page>233</first_page><cYear>2014</cYear><article_title>GATA3: a master of many trades in immune regulation</article_title><doi>10.1016/j.it.2014.04.002</doi></citation><citation key="bib68"><journal_title>Immunity</journal_title><author>Wang</author><volume>35</volume><first_page>871</first_page><cYear>2011</cYear><article_title>The Transcription Factor Myc Controls Metabolic Reprogramming upon T Lymphocyte Activation</article_title><doi>10.1016/j.immuni.2011.09.021</doi></citation><citation key="bib69"><journal_title>Nature Immunology</journal_title><author>Wang</author><volume>14</volume><first_page>714</first_page><cYear>2013</cYear><article_title>GATA-3 controls the maintenance and proliferation of T cells downstream of TCR and cytokine signaling</article_title><doi>10.1038/ni.2623</doi></citation><citation key="bib70"><journal_title>Nature Immunology</journal_title><author>Wei</author><volume>17</volume><first_page>277</first_page><cYear>2016</cYear><article_title>Autophagy enforces functional integrity of regulatory T cells by coupling environmental cues and metabolic homeostasis</article_title><doi>10.1038/ni.3365</doi></citation><citation key="bib71"><journal_title>Nature Immunology</journal_title><author>Xu</author><volume>15</volume><first_page>1152</first_page><cYear>2014</cYear><article_title>Autophagy is essential for effector CD8+ T cell survival and memory formation</article_title><doi>10.1038/ni.3025</doi></citation><citation key="bib72"><journal_title>Immunity</journal_title><author>Yang</author><volume>39</volume><first_page>1043</first_page><cYear>2013</cYear><article_title>T Cell Exit from Quiescence and Differentiation into Th2 Cells Depend on Raptor-mTORC1-Mediated Metabolic Reprogramming</article_title><doi>10.1016/j.immuni.2013.09.015</doi></citation><citation key="bib73"><journal_title>Cell Host &amp; Microbe</journal_title><author>Yuk</author><volume>6</volume><first_page>231</first_page><cYear>2009</cYear><article_title>Vitamin D3 Induces Autophagy in Human Monocytes/Macrophages via Cathelicidin</article_title><doi>10.1016/j.chom.2009.08.004</doi></citation><citation key="bib74"><journal_title>Nature</journal_title><author>Zeng</author><volume>499</volume><first_page>485</first_page><cYear>2013</cYear><article_title>mTORC1 couples immune signals and metabolic programming to establish Treg-cell function</article_title><doi>10.1038/nature12297</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.12444.001</doi><resource>https://elifesciences.org/articles/12444#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>eLife digest</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.12444.002</doi><resource>https://elifesciences.org/articles/12444#digest</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Aged Atg16l1ΔCD4 mice develop intestinal inflammation.</title><subtitle>(A) FACS analysis of LC3+ autophagosome formation in CD4+ T cells from cLP of Atg16l1ΔCD4 and Atg16l1fl/fl mice after overnight activation with or without α-CD3 (5 μg/ml) and α-CD28 (1 μg/ml). (B) Western blot analysis of LC3 lipidation in naïve splenic CD4+ T cells isolated from Atg16l1ΔCD4 mice and Atg16l1fl/fl mice after 3hr activation with α-CD3 (5 μg/ml) and α-CD28 (1 μg/ml) with or without chloroquine (CQ, inhibitor of lysosomal degradation, 50 μM). (C) Weight curves of Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (D) Representative images of spleens and mesenteric lymph nodes (mLN) from aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates and (E) spleen weights of young and aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (F,H) Representative photomicrographs of haemotoxilin and eosin (H&amp;E) stained sections of (F) jejunum and (H) mid-colon from young and aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates, scale bar 150 μm. (G,I) Quantification of (G) SI lengths and (I) mid-colon crypt lengths in aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are representative of at least three independent experiments (A-E, F, H) or combined from two (G) or three (I) independent experiments, with at least 3 mice per group. Data shown as mean ± s.e.m (A,C). Each dot represents an individual mouse and horizontal bars denote means (E,G). In (I) each dot represents an individual crypt measurement and horizontal bars denote means. Statistical significance was determined using two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (C) or the Mann–Whitney test (E,G,I), **p&lt;0.01; ***p&lt;0.001. SI LP– small intestine lamina propria, cLP – colonic lamina propria. Young mice: 8–12 weeks old, aged mice &gt;5 months old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.003</doi><resource>https://elifesciences.org/articles/12444#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. Atg16l1ΔCD4 mice exhibit reciprocal dysregulation of intestinal TH2 and Treg cells before the onset of intestinal inflammation.</title><subtitle>(A) Frequencies of CD4+ T cells as a proportion of live cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Frequencies and (C) total numbers of IFN-γ+ TH1, IL-17A+ TH17 and IL-13+ TH2 cells isolated from cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ T cells). (D) Representative FACS plots of Gata3 and IL-13 (top) or IFN-γ and IL-17A (bottom) expression by cLP CD4+ T cells isolated from young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- live cells). (E) Frequencies of Gata3+ CD4+ T cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- cells). (F) Representative FACS plots and (G) frequencies of Foxp3+ Treg cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ cells). Data are combined from three or more independent experiments with at least two mice per group (A,B, D, E, G) or are representative of four independent experiments with at least four mice per group (D, F). Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates or quadrants. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. SI LP– small intestine lamina propria, cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.004</doi><resource>https://elifesciences.org/articles/12444#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. Characterization of immune cell compartments in young Atg16l1ΔCD4mice.</title><subtitle>(A) Frequencies and (B) representative FACS plots of single positive CD4+, single positive CD8+, double positive (DP) CD4+ CD8+ and double negative (DN) CD4- CD8- thymocytes in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (C) Frequencies of CD8+ T cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (D) Total numbers of CD4+ T cells in spleen, mLN, and cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are combined from (A,C,D) or representative of (B) two or three independent experiments with at least 4 mice per group. Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in quadrants. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. cLP – colonic lamina propria, mLN - mesenteric lymph nodes. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.005</doi><resource>https://elifesciences.org/articles/12444/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 2. Atg16l1ΔCD4 mice have increased susceptibility to T-cell-mediated experimental IBD.</title><subtitle>Cohorts of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were infected with Helicobacter hepaticus by oral gavage (three feeds of 1x108 CFU) and treated with anti-IL-10R mAb (1mg/mouse i.p. given weekly; H.h + αIL10R) or left untreated (Ctr). Two weeks post-infection mice were sacrificed for analyses. (A) Caecum and colon histopathology scores in H.h + αIL10R-treated Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Representative photomicrographs of H&amp;E stained caecum of untreated Ctr (left panels) or H.h + αIL10R-treated (middle and right panels) Atg16l1ΔCD4 and Atg16l1fl/fl littermates, scale bar 150 μm. (C) Total lamina propria leukocyte numbers and (D,E) frequencies of (D) neutrophils (Gr1hi CD11b+) and (E) CD4+ T cells in cLP isolated from untreated Ctr or H.h + αIL10R-treated Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are combined from two or three independent experiments with at least two mice per group. Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.006</doi><resource>https://elifesciences.org/articles/12444/figures#fig2s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 3. Elevated type 2 innate responses in Atg16l1ΔCD4 mice.</title><subtitle>(A) Frequencies of eosinophils (Ly6Clow Ly6Glow CD11b+ F4/80-) in spleen and mLN of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Serum MCPT-1 levels in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. Data are combined from (A) or representative of (B) two or three independent experiments with at least four mice per group. Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.007</doi><resource>https://elifesciences.org/articles/12444/figures#fig2s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 4. Characterization of Atg16l1-deficient Treg cells.</title><subtitle>(A) Foxp3+ Treg cell numbers in spleen, mLN, cLP and SI LP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Frequencies of Foxp3+ Treg in the thymus of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on single positive CD4+ TCRβ+ cells). (C) Frequencies of Neuropilin-1+ (Nrp1+) Foxp3+ Treg cells in the cLP and SI LP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3+ T cells). (D) Frequencies of Helios+ Foxp3+ Treg cells in the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3+ T cells). (E) Frequencies of IL-17A+ or IFN-γ+ of Foxp3+ Treg cells in the cLP and SI LP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (F) Expression of CD103, CTLA4, CD25, CD69 and KLRG1 by cLP Foxp3+ Treg cells from young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (G) Representative FACS plots and (H) frequencies of Ki67+ Foxp3+ Treg cells in cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (I) Mean fluorescence intensity (MFI) of phospo-S6 (P-S6) in Foxp3+ Treg cells in cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are combined from two independent experiments with at least four mice per group (A,B,E), are representative from two independent experiments with at least four mice per group (C,F-H), or are from one experiment (D,I). Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes, SI LP– small intestine lamina propria, cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.008</doi><resource>https://elifesciences.org/articles/12444/figures#fig2s4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Atg16l1ΔCD4 mice develop elevated TH2-associated antibodies against intestinal luminal antigens.</title><subtitle>(A) Serum IgE concentrations in cohorts of young and aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (B) Serum antibody IgG1, IgG2b, IgG2c, IgA and IgM isotype levels in aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (C) Representative photomicrographs of H&amp;E stained sections of Peyer’s patch (PP) in the SI (jejunum) of aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates, scale bar 150 μm. (D) Serum levels of Soy-specific IgA, IgG1, IgG2b, IgG2c antibodies in aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (E) Young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were fed with ovalbumin (OVA) alone or with cholera toxin (CT) as described in methods and levels of OVA-specific serum IgE were measured 8 weeks after first challenge by ELISA. (F) Levels of CBir1-specific IgA, IgG1, IgG2b and IgG2c antibodies in serum of aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA, serum was diluted 50x. Data are representative from at least two independent experiments with at least three mice per group (A-D) or combined from two (E) or three (F) independent experiments with at least three mice per group. Each dot represents an individual mouse and horizontal bars denote means (A,D,E,F). Serum isotype levels are shown as mean ± s.e.m (B). Statistical significance was determined using the Mann–Whitney test (A,D-F) or two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (B), *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. SI – small intestine. Young mice: 8–12 weeks old, aged mice &gt; 5 months old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.009</doi><resource>https://elifesciences.org/articles/12444#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. Dysregulated humoral responses in young Atg16l1ΔCD4 mice.</title><subtitle>(A) Serum antibody IgA and IgG1 isotype levels in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (B) Frequencies of B cells (B220+), germinal center B cells (GC: B220+ GL7+ CD95+), memory B cells (B220+ Gl7- IgM- IgG+) and plasma cells (CD138+) in the spleen and mLN of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on live CD45+ cells). (C) Serum levels of Soy-specific IgA, IgG1, IgG2b, IgG2c antibodies in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (D) Cohorts of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were infected with Helicobacter hepaticus by oral gavage (three feeds of 1x108 CFU) and levels of serum Helicobacter-specific IgG1, IgG2c and IgA antibodies were determined three weeks later by ELISA. (E) Cohorts of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were orally infected with Trichuris muris (200 eggs) and levels of T. muris-specific IgG1 in serum were determined 34 days later by ELISA. Data are from one experiment with at least three mice per group (A-D) or representative from two independent experiments with five mice per group (E). Each dot represents an individual mouse and horizontal bars denote means (B,C) or data represent mean ± s.e.m (A,D,E). Statistical significance was determined using the Mann–Whitney test (A,C) or two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (B,D,E): statistical significance was determined between infected groups (b,c), *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.010</doi><resource>https://elifesciences.org/articles/12444/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. Atg16l1 promotes survival of Treg cells and limits TH2 cell survival.</title><subtitle>(A,B) Atg16l1ΔCD4 or Atg16l1fl/fl naïve CD4+ T cells were cultured in TH0, Treg, or TH2 polarizing conditions for 48 hr and analyzed by FACS. Representative FACS plots show (A) Foxp3 and (B) Gata3 expression (gated on CD4+ TCRβ+ T cells). (C) Frequencies of Treg cells (Foxp3+) and TH2 cells (Gata3+) arising from Atg16l1ΔCD4 or Atg16l1fl/fl naïve CD4+ T cells cultured in Treg or TH2 polarizing conditions for 5 days. (D) Atg16l1ΔCD4 or Atg16l1fl/fl Treg cells were cultured with anti-CD3 (3 μg/ml) and anti-CD28 (1 μg/ml) for 48 hr, then maintained in the presence of IL-4 and IL-13 for a further 5 days before FACS analysis of Foxp3 and CD25 expression of live CD4+ T cells. (E,F) Naïve Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells were cultured with (E) 1 μg/ml or (F) 5 μg/ml anti-CD3 plus anti-CD28 (1 μg/ml) for 48 hr in Treg or TH2 polarizing conditions, then maintained in polarizing conditions for a further 5 days before FACS analysis of cell survival. Histograms show gates and frequencies of live CD4+ T cells. (G) Representative FACS plots of viability dye and Annexin V staining of Treg cells and TH2 cells from the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates, gated on CD4+ TCRβ+ Foxp3+ (left panel), or CD4+ TCRβ+ Gata3+ (right panel). Data are representative from two (D,G) or three independent experiments (A,B,E,F), or are combined from three independent experiments (C). Each dot represents an individual cell culture (C) or data are shown as mean ± s.e.m (A,B,D-F). Numbers indicate percentage of cells in quadrants (G). cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.011</doi><resource>https://elifesciences.org/articles/12444#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Autophagy contributes to the elevated TH2 responses in Atg16l1ΔCD4 mice in a cell-intrinsic manner.</title><subtitle>Young Atg16l1ΔCD4 mice (CD45.2+) were adoptively transferred with 4-5x106 naïve WT CD4+ T cells (CD45.1+) and analyzed 3 months later. (A) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) CD4+ T cells in the spleen, mLN and cLP. (B) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) Foxp3+ Treg cells in the spleen, mLN and cLP (gated on CD4+ TCRβ+ T cells). (C) Representative FACS plots showing gating of WT (CD45.1+) and Atg16l1-deficient (CD45.1-) CD4+ T cells and expression of IL-13 (TH2), IFN-γ (TH1) and IL-17A (TH17) in the cLP (gated on CD4+ TCRβ+ Foxp3- T cells). (D) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) TH2 (IL-13+), TH1 (IFN- γ+) and TH17 (IL-17A+) cells among CD4+ TCRβ+ Foxp3- T cells in the cLP. (E) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) Gata3+ CD4+ T cells in the spleen, mLN and cLP (gated on CD4+ TCRβ+ Foxp3- T cells). (F) SI lengths and (G) representative photomicrographs of jejunum of control untreated Atg16l1fl/fl or Atg16l1ΔCD4 littermates and reconstituted Atg16l1ΔCD4 mice, scale bar 150 μm. (H) Serum IgE concentrations in control untreated Atg16l1fl/fl or Atg16l1ΔCD4 littermates and adoptively transferred Atg16l1ΔCD4 mice were measured by ELISA. Data are representative of two independent experiments with at least four mice per group (A-E,G) or combined from two independent experiments (F,H). Each dot represents cells coming from the donor or the hosts within the individual transferred mouse (A,B,D,E) or each dot represents an individual mouse (F,H), horizontal bars denote mean. Numbers indicate percentage of cells in gates. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 10–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.012</doi><resource>https://elifesciences.org/articles/12444#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5—figure supplement 1. Reconstitution of intestinal CD4+ T cell compartments in adoptively transferred Atg16l1ΔCD4 mice.</title><subtitle>Young Atg16l1ΔCD4 mice (CD45.2+) were adoptively transferred with 4-5x106 naïve WT CD4+ T cells (CD45.1+) i.v. and cLP populations analyzed 3 months later. (A) Frequencies of total CD4+ T cells. (B) Frequencies and total numbers of Foxp3+ Treg cells (gated on CD4+ TCRβ+ T cells). (C) Frequencies and total numbers of TH2 (IL-13+) cells (gated on CD4+ TCRβ+ Foxp3- T cells). Data are combined from two independent experiments with at least four mice per group. Each dot represents an individual mouse, horizontal bars denote mean. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. cLP – colonic lamina propria. Young mice: 10–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.013</doi><resource>https://elifesciences.org/articles/12444/figures#fig5s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6. Aged Atg16l1ΔFoxp3 mice develop spontaneous multi-organ inflammation.</title><subtitle>(A) LC3+ autophagosome formation by Foxp3- CD4+ T cells and Foxp3+ Treg cells from cLP and mLN of WT mice in unstimulated cells or after overnight activation with α-CD3 (5 μg/ml) and α-CD28 (1 μg/ml). (B) Representative LC3 staining of unstimulated cells (gated on Foxp3+ CD4+ TCRβ+ Treg cells or Foxp3- CD4+ TCRβ+ T cells). (C) Weight curves and (D) spleen weights and representative images of spleen and mLN of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates. (E) Representative photomicrographs of H&amp;E stained sections of liver, spleen, stomach, SI (jejunum), proximal colon and mid-colon of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates, scale bar 150 μm. (F) Quantification of SI length. Data are combined from two to four independent experiments with two to five mice per group (A,D,F) or are representative of two to three independent experiments with two to five mice per group (B,C,E). Each dot represents an individual mouse and horizontal bars denote means (A,D,F). Data shown as mean ± s.e.m (C). Statistical significance was determined using two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (C) or using the Mann–Whitney test (A,D,F), *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. mLN - mesenteric lymph nodes, SI – small intestine lamina propria, cLP – colonic lamina propria. Aged mice &gt;5 months old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.014</doi><resource>https://elifesciences.org/articles/12444#fig6</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6—figure supplement 1. Impaired reconstitution of mixed bone marrow chimeras by Atg16l1-deficient T cells.</title><subtitle>(A) Experimental design for the generation of mixed bone marrow (BM) chimeras. BM cells isolated from WT (CD45.1+) and Atg16l1fl/fl or Atg16l1ΔCD4 (CD45.2+) mice were injected at a 1:1 ratio into lethally irradiated (1100 Rad) Rag1-/- recipients (total of 1x107 cells per mouse). (B) Representative FACS plots showing frequencies of Atg16l1ΔCD4 or Atg16l1fl/fl (CD45.2+) and WT (CD45.2-) CD4+ T cells in the thymus, spleen and cLP of mixed BM chimeras (gated on CD4+ TCRβ+ T cells). (C) Frequencies of Atg16l1ΔCD4 or Atg16l1fl/fl (CD45.2+) CD4+ T cells in mixed BM chimeras (shown as percentage of total CD4+ TCRβ+ T cells). (D) Representative FACS plots and (E) frequencies of Foxp3+ Treg cells derived from Atg16l1ΔCD4 or Atg16l1fl/fl (CD45.2+) cells in mixed BM chimeras (gated on CD4+ TCRβ+ T cells). Highlighted top right quadrants indicate Treg cells derived from Atg16l1fl/fl orAtg16l1ΔCD4 BM. Data are representative from two independent experiments with at least seven mice per group. Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates. Statistical significance was determined using the Mann–Whitney test, **p&lt;0.01; ***p&lt;0.001.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.015</doi><resource>https://elifesciences.org/articles/12444/figures#fig6s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6—figure supplement 2. Analysis of Atg16l1 expression in Atg16l1ΔFoxp3 mice.</title><subtitle>(A) qPCR analysis of Atg16l1 exon 3 levels in sorted CD4+ Foxp3- T cells and Foxp3+ Treg cells from spleen and cLP of Atg16l1ΔFoxp3 and Foxp3Cre mice. Data are representative from two independent experiments with 5 mice per group. Atg16l1 exon 3 levels are shown as mean ± s.e.m of three technical replicates, normalised to expression of hprt. cLP – colonic lamina propria.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.016</doi><resource>https://elifesciences.org/articles/12444/figures#fig6s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 7. Atg16l1ΔFoxp3 mice cannot control pro-inflammatory TH effector responses.</title><subtitle>(A) Representative immunofluorescence images of small intestine and proximal and mid colon of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates stained for CD3 (red), β-catenin (green) and DAPI (blue). (B) Frequencies and (C) total numbers of cLP CD4+ TCRβ+ T cells in aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates. (D) Frequencies of effector (CD44+CD62L-) CD4+ T cells in the mLN and cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (E) Frequencies and (F) total numbers of TH1 (IFN-γ+), TH17 (IL-17A+), TH2 (IL-13+) T cells in the cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (G) Frequencies of Gata3+ CD4+ T cells in aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (H) Serum IgE concentrations in Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates were measured by ELISA. Data are combined from two to four independent experiments with two to five mice per group (B-H) or are representative of two independent experiments with two to five mice per group (A). Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 8–12 weeks old, aged mice &gt;5 months old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.017</doi><resource>https://elifesciences.org/articles/12444#fig7</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 7—figure supplement 1. Additional characterization of Atg16l1ΔFoxp3 mice.</title><subtitle>(A) Representative FACS plots of CD44 and CD62L expression by CD4+ T cells from cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (B) Frequencies of TH1 (IFN-γ+), TH17 (IL-17A+), TH2 (IL-13+) T cells in the cLP of young Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (C) Serum antibody IgA, IgG1, IgG2b, IgG2c isotype levels in aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates. Data are combined from three independent experiments with two to five mice per group (B) or are representative from two to three independent experiments with two to five mice per group (A,C). Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates. Data shown as mean ± s.e.m (C). Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 8–12 weeks old, aged mice &gt;5 months old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.018</doi><resource>https://elifesciences.org/articles/12444/figures#fig7s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 8. Cell-intrinsic autophagy is required for metabolic adaptation and survival of intestinal Foxp3+ Treg cells.</title><subtitle>(A) Foxp3+ Treg cell frequencies among CD4+ TCRβ+ T cells in Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates and (B) representative FACS plots of Foxp3 expression in cLP CD4+ T cells from young Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ T cells). (C) qPCR analysis of glycolytic gene levels in sorted Foxp3+ Treg cells from spleen and cLP of young Atg16l1ΔFoxp3 and Foxp3Cre mice (sorted for CD4+ TCRβ+ YFP+). (D) qPCR analysis of FAS and FAO gene levels in Foxp3+ Treg cells from the spleen and cLP of young Atg16l1ΔFoxp3 and Foxp3Cre mice (sorted for CD4+ TCRβ+ YFP+). FAS: fatty acid synthesis, FAO: fatty acid oxidation, Glut1: glucose transporter 1, Slc16ac: solute carrier family 16 member 3 (lactic acid and pyruvate transporter), Tpi1: triosephosphate isomerase 1, Aldo–α: aldolase α, Ldh-α: lactate dehydrogenase α, Gpi1: Glucose phosphate isomerase 1, Pgk1: Phosphoglycerate kinase 1, Acc1: acetyl-CoA carboxylase 1, Acc2: acetyl-CoA carboxylase 2, Srebf1: sterol regulatory element binding transcription factor 1, Srebf2: sterol regulatory element binding transcription factor 2, Fdft1: farnesyl-diphosphate farnesyltransferase 1, Fabp: Fatty acid-binding protein. Data are representative from two (C,D) or three independent experiments (A,B). Each dot represents individual mouse (A) or data are shown as mean ± s.e.m (C,D). Gene expression levels are shown as mean ± s.e.m of three technical replicates (C,D). Numbers indicate percentage of cells in gates (B). cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.019</doi><resource>https://elifesciences.org/articles/12444#fig8</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 8—figure supplement 1. Atg16l1-deficient colonic Treg cells exhibit increased cytokine secretion.</title><subtitle>(A) Frequencies of IFN-γ+, IL-17A+, IL-4+, IL-13+ Foxp3+ Treg cells in the cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (B) qPCR analysis of Bcl2, Bim and Bax levels in Foxp3+ Treg cells from young cLP of Atg16l1ΔFoxp3 and Foxp3Cre mice (sorted for CD4+ TCRβ+ YFP+). Data are combined from three independent experiments with two to five mice per group (A) or are representative from two independent experiments (B). Each dot represents an individual mouse and horizontal bars denote means (A). Gene expression levels are shown as mean ± s.e.m of three technical replicates (B). cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.020</doi><resource>https://elifesciences.org/articles/12444/figures#fig8s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 8—figure supplement 2. Increased lipid uptake by intestinal Treg cells.</title><subtitle>(A,B) Atg16l1fl/fl and Atg16l1ΔCD4 littermates were injected i.p. with 50 μg of fluorescent 16-carbon fatty acid analog BODIPY C-16 and culled 1 hr later and tissue was collected for analysis by flow cytometry. (A) Representative FACS plots and (B) quantification of C16-Bodipy uptake by Foxp3+ Treg cells in the spleen, mLN and cLP (gated on Foxp3+ CD4+ TCRβ+ T cells). (C) Representative FACS plots and (D) quantification of CD36 expression by Foxp3+ Treg cells in the spleen, mLN and cLP of Atg16l1fl/fl and Atg16l1ΔCD4 littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). Data are combined from (B,D) or are representative of (A,C) two independent experiments with 3–5 mice per group. Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.021</doi><resource>https://elifesciences.org/articles/12444/figures#fig8s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 8—figure supplement 3. TH2 cells exhibit an enhanced glycolytic metabolic profile that is independent of autophagy.</title><subtitle>(A) Representative FACS plot and quantification of the cell size (FSC-H) of naïve (CD44- CD62L+) CD4+ T cells from the spleen of Atg16l1ΔCD4 or Atg16l1fl/fl littermates. (B) Basal level of oxygen consumption rate (OCR) and extracellular acidification rate (ECAR) in naïve (CD44- CD62L+) unstimulated CD4+ T cells isolated from the spleen of Atg16l1ΔCD4 or Atg16l1fl/fl littermates measured using the Seahorse metabolic flux analyzer. (C,D) Expression of c-Myc (C) and cell size (D) was analyzed by FACS in Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells that were cultured in TH2 or Treg-polarizing conditions for 3 days and rested for one day in the presence of polarizing cytokines. (E) Basal level of OCR and ECAR were measured by Seahorse metabolic flux analyzer in Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured in TH2 or Treg- polarizing conditions for 3 days and rested for 2 days in the presence of polarizing cytokines. (F) qPCR analysis of glycolytic gene levels in Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured in TH2 or Treg polarizing conditions for 3 days and rested for 1 day in the presence of polarizing cytokines. Data are combined from two independent experiments (A), or are representative of two independent experiments (B-D), or are from one experiment (E,F). Each dot represents an individual mouse (A) or individual cell culture (D). ECAR and OCAR data represent mean ± s.e.m values of T cell populations that were assayed in triplicates or quadruplicates (B,E). Gene expression data of triplicate cultures represent normalized expression values for each gene that were scaled to a mean of 0 and a standard deviation of 1 (F). Statistical significance was determined using the Mann–Whitney test (A) or unpaired Student’s t –test (B,D,E), **p&lt;0.01; **p&lt;0.001.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.022</doi><resource>https://elifesciences.org/articles/12444/figures#fig8s3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.12444.024</doi><resource>https://elifesciences.org/articles/12444#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response image 1. Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.12444.025</doi><resource>https://elifesciences.org/articles/12444#SA2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response image 1. Autophagy deficiency does not influence expression of IL-2 receptor on TH2 cells (A) Expression of IL-2Ra (CD25) by TH2cells in the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- Gata3+ T cells), data are representative of two independent experiments.</title><subtitle>(B) Expression of CD25 was measured in naïve Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured with anti-CD3 (5μg/ml) and anti-CD28 (1μg/ml) in TH2 polarizing conditions for 2 or 5 days, data are from one experiment.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.12444.023</doi><resource>https://elifesciences.org/articles/12444#fig9</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-12444-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>02</month>
+					<day>24</day>
+					<year>2016</year>
+				</publication_date>
+				<journal_volume>
+					<volume>5</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>The autophagy gene Atg16l1 differentially regulates Treg and TH2 cells to control intestinal inflammation</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Agnieszka M</given_name>
+						<surname>Kabat</surname>
+						<affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Oliver J</given_name>
+						<surname>Harrison</surname>
+						<affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation>
+						<affiliation>Immunity at Barrier Sites Initiative, National Institute of Allergy and Infectious Diseases, National Institutes of Health, Bethesda, United States</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Thomas</given_name>
+						<surname>Riffelmacher</surname>
+						<affiliation>MRC Human Immunology Unit, Weatherall Institute of Molecular Medicine, University of Oxford, Oxford, United Kingdom</affiliation>
+						<affiliation>John Radcliffe Hospital, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Amin E</given_name>
+						<surname>Moghaddam</surname>
+						<affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Claire F</given_name>
+						<surname>Pearson</surname>
+						<affiliation>Kennedy Institute of Rheumatology, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Adam</given_name>
+						<surname>Laing</surname>
+						<affiliation>Peter Gorer Department of Immunobiology, King's College London, London, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Lucie</given_name>
+						<surname>Abeler-Dörner</surname>
+						<affiliation>Peter Gorer Department of Immunobiology, King's College London, London, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Simon P</given_name>
+						<surname>Forman</surname>
+						<affiliation>Faculty of Life Sciences, The University of Manchester, Manchester, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Richard K</given_name>
+						<surname>Grencis</surname>
+						<affiliation>Faculty of Life Sciences, The University of Manchester, Manchester, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Quentin</given_name>
+						<surname>Sattentau</surname>
+						<affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Anna Katharina</given_name>
+						<surname>Simon</surname>
+						<affiliation>MRC Human Immunology Unit, Weatherall Institute of Molecular Medicine, University of Oxford, Oxford, United Kingdom</affiliation>
+						<affiliation>John Radcliffe Hospital, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Johanna</given_name>
+						<surname>Pott</surname>
+						<affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Kevin J</given_name>
+						<surname>Maloy</surname>
+						<affiliation>Sir William Dunn School of Pathology, University of Oxford, Oxford, United Kingdom</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0001-5795-7688</ORCID>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>A polymorphism in the autophagy gene Atg16l1 is associated with susceptibility to inflammatory bowel disease (IBD); however, it remains unclear how autophagy contributes to intestinal immune homeostasis. Here, we demonstrate that autophagy is essential for maintenance of balanced CD4+ T cell responses in the intestine. Selective deletion of Atg16l1 in T cells in mice resulted in spontaneous intestinal inflammation that was characterized by aberrant type 2 responses to dietary and microbiota antigens, and by a loss of Foxp3+ Treg cells. Specific ablation of Atg16l1 in Foxp3+ Treg cells in mice demonstrated that autophagy directly promotes their survival and metabolic adaptation in the intestine. Moreover, we also identify an unexpected role for autophagy in directly limiting mucosal TH2 cell expansion. These findings provide new insights into the reciprocal control of distinct intestinal TH cell responses by autophagy, with important implications for understanding and treatment of chronic inflammatory disorders.</jats:p>
+				</jats:abstract>
+				<jats:abstract abstract-type="executive-summary">
+					<jats:p>The gut presents a puzzle to our immune system. Immune cells must rapidly respond to antigens produced by harmful bacteria, but food and the beneficial bacteria that inhabit the gut also produce antigens that our immune system must tolerate. Inappropriate immune responses in the gut can lead to inflammatory bowel disease, a debilitating disease with no current cure. We do not fully understand why these harmful inflammatory responses arise, but we know that genetic factors are important. Mutations in genes that affect a process known as autophagy – a pathway that breaks down and recycles unwanted material inside cells – make inflammatory bowel disease more likely to develop, but exactly how they do so remains unclear.</jats:p>
+					<jats:p>T helper cells are crucial controllers of intestinal immune responses and changes in their numbers and behaviour occur during inflammatory bowel disease. Kabat et al. explored how the autophagy pathway affects these key immune cells in mice. Blocking autophagy in T cells altered the balance of different types of T helper cells in the gut. A crucial population of regulatory T cells, which keep inflammatory responses in check, was lost. At the same time, another population of T cells expanded: the T helper 2 (TH2) cells that are responsible for driving allergies. As a result, the mice developed intestinal inflammation and produced antibodies against gut bacteria and food.</jats:p>
+					<jats:p>Overall, Kabat et al.’s results show that autophagy defects can alter the balance of different types of T cells in the gut, leading to inflammation in the intestine. These observations contribute to our understanding of how genetic changes may influence susceptibility to inflammatory bowel disease. They also suggest that drugs that activate autophagy could help to treat diseases associated with changes in regulatory T cells or TH2 cells, including inflammatory bowel disease and allergies. It will now be important to test this and to confirm whether similar changes in T cells are present in humans that have mutations in autophagy genes.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>02</month>
+					<day>24</day>
+					<year>2016</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e12444</item_number>
+					<identifier id_type="doi">10.7554/eLife.12444</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Graduate Student Scholarship 097112</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">100290</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">100156</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Medical Research Council
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000265</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">MR/K011898/1</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Wellcome Trust
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/100004440</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">102972</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/publicdomain/zero/1.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.12444</doi>
+					<resource>https://elifesciences.org/articles/12444</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/12444/elife-12444-v2.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/12444/elife-12444-v2.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>New England Journal of Medicine</journal_title>
+						<author>Abraham</author>
+						<volume>361</volume>
+						<first_page>2066</first_page>
+						<cYear>2009</cYear>
+						<article_title>Inflammatory Bowel Disease</article_title>
+						<doi>10.1056/NEJMra0804647</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Biochemical Journal</journal_title>
+						<author>Backer</author>
+						<volume>410</volume>
+						<first_page>1</first_page>
+						<cYear>2008</cYear>
+						<article_title>The regulation and function of Class III PI3Ks: novel roles for Vps34</article_title>
+						<doi>10.1042/BJ20071427</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Trends in Immunology</journal_title>
+						<author>Berin</author>
+						<volume>34</volume>
+						<first_page>390</first_page>
+						<cYear>2013</cYear>
+						<article_title>Food allergy: an enigmatic epidemic</article_title>
+						<doi>10.1016/j.it.2013.04.003</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>Nature Medicine</journal_title>
+						<author>Berod</author>
+						<volume>20</volume>
+						<first_page>1327</first_page>
+						<cYear>2014</cYear>
+						<article_title>De novo fatty acid synthesis controls the fate between regulatory T and T helper 17 cells</article_title>
+						<doi>10.1038/nm.3704</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>Nature Immunology</journal_title>
+						<author>Burzyn</author>
+						<volume>14</volume>
+						<first_page>1007</first_page>
+						<cYear>2013</cYear>
+						<article_title>Regulatory T cells in nonlymphoid tissues</article_title>
+						<doi>10.1038/ni.2683</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Nature</journal_title>
+						<author>Cadwell</author>
+						<volume>456</volume>
+						<first_page>259</first_page>
+						<cYear>2008</cYear>
+						<article_title>A key role for autophagy and the autophagy gene Atg16l1 in mouse and human intestinal Paneth cells</article_title>
+						<doi>10.1038/nature07416</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>PLoS ONE</journal_title>
+						<author>Cai</author>
+						<volume>9</volume>
+						<cYear>2014</cYear>
+						<article_title>Serological Investigation of Food Specific Immunoglobulin G Antibodies in Patients with Inflammatory Bowel Diseases</article_title>
+						<doi>10.1371/journal.pone.0112154</doi>
+						<elocation_id>e112154</elocation_id>
+					</citation>
+					<citation key="bib8">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Cheng</author>
+						<volume>189</volume>
+						<first_page>1780</first_page>
+						<cYear>2012</cYear>
+						<article_title>IL-2 Receptor Signaling Is Essential for the Development of Klrg1+ Terminally Differentiated T Regulatory Cells</article_title>
+						<doi>10.4049/jimmunol.1103768</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>The Journal of Experimental Medicine</journal_title>
+						<author>Coccia</author>
+						<volume>209</volume>
+						<first_page>1595</first_page>
+						<cYear>2012</cYear>
+						<article_title>IL-1β mediates chronic intestinal inflammation by promoting the accumulation of IL-17A secreting innate lymphoid cells and CD4(+) Th17 cells</article_title>
+						<doi>10.1084/jem.20111453</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Immunity</journal_title>
+						<author>Curotto de Lafaille</author>
+						<volume>29</volume>
+						<first_page>114</first_page>
+						<cYear>2008</cYear>
+						<article_title>Adaptive Foxp3+ Regulatory T Cell-Dependent and -Independent Control of Allergic Inflammation</article_title>
+						<doi>10.1016/j.immuni.2008.05.010</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>Nature Immunology</journal_title>
+						<author>Dardalhon</author>
+						<volume>9</volume>
+						<first_page>1347</first_page>
+						<cYear>2008</cYear>
+						<article_title>IL-4 inhibits TGF-β-induced Foxp3+ T cells and, together with TGF-β, generates IL-9+ IL-10+ Foxp3− effector T cells</article_title>
+						<doi>10.1038/ni.1677</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Cell</journal_title>
+						<author>Feng</author>
+						<volume>158</volume>
+						<first_page>749</first_page>
+						<cYear>2014</cYear>
+						<article_title>Control of the Inheritance of Regulatory T Cell Identity by a cis Element in the Foxp3 Locus</article_title>
+						<doi>10.1016/j.cell.2014.07.031</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>Cell</journal_title>
+						<author>Galluzzi</author>
+						<volume>159</volume>
+						<first_page>1263</first_page>
+						<cYear>2014</cYear>
+						<article_title>Metabolic Control of Autophagy</article_title>
+						<doi>10.1016/j.cell.2014.11.006</doi>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Hampe</author>
+						<volume>39</volume>
+						<first_page>207</first_page>
+						<cYear>2007</cYear>
+						<article_title>A genome-wide association scan of nonsynonymous SNPs identifies a susceptibility variant for Crohn disease in ATG16L1</article_title>
+						<doi>10.1038/ng1954</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>Cell Host &amp; Microbe</journal_title>
+						<author>Hwang</author>
+						<volume>11</volume>
+						<first_page>397</first_page>
+						<cYear>2012</cYear>
+						<article_title>Nondegradative Role of Atg5-Atg12/ Atg16L1 Autophagy Protein Complex in Antiviral Activity of Interferon Gamma</article_title>
+						<doi>10.1016/j.chom.2012.03.002</doi>
+					</citation>
+					<citation key="bib16">
+						<journal_title>Blood</journal_title>
+						<author>Isakson</author>
+						<volume>116</volume>
+						<first_page>2324</first_page>
+						<cYear>2010</cYear>
+						<article_title>Autophagy contributes to therapy-induced degradation of the PML/RARA oncoprotein</article_title>
+						<doi>10.1182/blood-2010-01-261040</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Annual Review of Immunology</journal_title>
+						<author>Izcue</author>
+						<volume>27</volume>
+						<first_page>313</first_page>
+						<cYear>2009</cYear>
+						<article_title>Regulatory Lymphocytes and Intestinal Inflammation</article_title>
+						<doi>10.1146/annurev.immunol.021908.132657</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Jia</author>
+						<volume>186</volume>
+						<first_page>5313</first_page>
+						<cYear>2011</cYear>
+						<article_title>Temporal Regulation of Intracellular Organelle Homeostasis in T Lymphocytes by Autophagy</article_title>
+						<doi>10.4049/jimmunol.1002404</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>Cell Research</journal_title>
+						<author>Jiang</author>
+						<volume>24</volume>
+						<first_page>69</first_page>
+						<cYear>2014</cYear>
+						<article_title>Autophagy and human diseases</article_title>
+						<doi>10.1038/cr.2013.161</doi>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Nature</journal_title>
+						<author>Josefowicz</author>
+						<volume>482</volume>
+						<first_page>395</first_page>
+						<cYear>2012</cYear>
+						<article_title>Extrathymically generated regulatory T cells control mucosal TH2 inflammation</article_title>
+						<doi>10.1038/nature10772</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Nature Reviews Molecular Cell Biology</journal_title>
+						<author>Kaur</author>
+						<volume>16</volume>
+						<first_page>461</first_page>
+						<cYear>2015</cYear>
+						<article_title>Autophagy at the crossroads of catabolism and anabolism</article_title>
+						<doi>10.1038/nrm4024</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>Autophagy</journal_title>
+						<author>Klionsky</author>
+						<volume>8</volume>
+						<first_page>445</first_page>
+						<cYear>2012</cYear>
+						<article_title>Guidelines for the use and interpretation of assays for monitoring autophagy</article_title>
+						<doi>10.4161/auto.19496</doi>
+					</citation>
+					<citation key="bib23">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Komatsu</author>
+						<volume>106</volume>
+						<first_page>1903</first_page>
+						<cYear>2009</cYear>
+						<article_title>Heterogeneity of natural Foxp3+ T cells: a committed regulatory T-cell lineage and an uncommitted minor population retaining plasticity</article_title>
+						<doi>10.1073/pnas.0811556106</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Cell Death and Differentiation</journal_title>
+						<author>Kovacs</author>
+						<volume>19</volume>
+						<first_page>144</first_page>
+						<cYear>2012</cYear>
+						<article_title>Autophagy promotes T-cell survival through degradation of proteins of the cell death machinery</article_title>
+						<doi>10.1038/cdd.2011.78</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>PLoS ONE</journal_title>
+						<author>Kuballa</author>
+						<volume>3</volume>
+						<cYear>2008</cYear>
+						<article_title>Impaired Autophagy of an Intracellular Pathogen Induced by a Crohn's Disease Associated ATG16L1 Variant</article_title>
+						<doi>10.1371/journal.pone.0003391</doi>
+						<elocation_id>e3391</elocation_id>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Infection and Immunity</journal_title>
+						<author>Kullberg</author>
+						<volume>66</volume>
+						<first_page>5157</first_page>
+						<cYear>1998</cYear>
+						<article_title>Helicobacter hepaticus triggers colitis in specific-pathogen-free interleukin-10 (IL-10)-deficient mice through an IL-12- and gamma interferon-dependent mechanism</article_title>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Proceedings of the National Academy of Sciences of the United States of America</journal_title>
+						<author>Lassen</author>
+						<volume>111</volume>
+						<first_page>7741</first_page>
+						<cYear>2014</cYear>
+						<article_title>Atg16L1 T300A variant decreases selective autophagy resulting in altered cytokine signaling and decreased antibacterial defense</article_title>
+						<doi>10.1073/pnas.1407001111</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>Gut</journal_title>
+						<author>Lees</author>
+						<volume>60</volume>
+						<first_page>1739</first_page>
+						<cYear>2011</cYear>
+						<article_title>New IBD genetics: common pathways with other diseases</article_title>
+						<doi>10.1136/gut.2009.199679</doi>
+					</citation>
+					<citation key="bib29">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Li</author>
+						<volume>177</volume>
+						<first_page>5163</first_page>
+						<cYear>2006</cYear>
+						<article_title>Autophagy Is Induced in CD4+ T Cells and Important for the Growth Factor-Withdrawal Cell Death</article_title>
+						<doi>10.4049/jimmunol.177.8.5163</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Nature Reviews Immunology</journal_title>
+						<author>Liston</author>
+						<volume>14</volume>
+						<first_page>154</first_page>
+						<cYear>2014</cYear>
+						<article_title>Homeostatic control of regulatory T cell diversity</article_title>
+						<doi>10.1038/nri3605</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>Autophagy</journal_title>
+						<author>Lizaso</author>
+						<volume>9</volume>
+						<first_page>1228</first_page>
+						<cYear>2013</cYear>
+						<article_title>β-adrenergic receptor-stimulated lipolysis requires the RAB7-mediated autolysosomal lipid degradation</article_title>
+						<doi>10.4161/auto.24893</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Trends in Immunology</journal_title>
+						<author>Lochner</author>
+						<volume>36</volume>
+						<first_page>81</first_page>
+						<cYear>2015</cYear>
+						<article_title>Fatty acid metabolism in the regulation of T cell function</article_title>
+						<doi>10.1016/j.it.2014.12.005</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Journal of Clinical Investigation</journal_title>
+						<author>Lodes</author>
+						<volume>113</volume>
+						<first_page>1296</first_page>
+						<cYear>2004</cYear>
+						<article_title>Bacterial flagellin is a dominant antigen in Crohn disease</article_title>
+						<doi>10.1172/JCI200420295</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>Immunity</journal_title>
+						<author>Ma</author>
+						<volume>39</volume>
+						<first_page>211</first_page>
+						<cYear>2013</cYear>
+						<article_title>Autophagy and Cellular Immune Responses</article_title>
+						<doi>10.1016/j.immuni.2013.07.017</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>Annual Review of Immunology</journal_title>
+						<author>MacIver</author>
+						<volume>31</volume>
+						<first_page>259</first_page>
+						<cYear>2013</cYear>
+						<article_title>Metabolic Regulation of T Lymphocytes</article_title>
+						<doi>10.1146/annurev-immunol-032712-095956</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>Nature</journal_title>
+						<author>Maloy</author>
+						<volume>474</volume>
+						<first_page>298</first_page>
+						<cYear>2011</cYear>
+						<article_title>Intestinal homeostasis and its breakdown in inflammatory bowel disease</article_title>
+						<doi>10.1038/nature10208</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>PLoS ONE</journal_title>
+						<author>Martin</author>
+						<volume>7</volume>
+						<cYear>2012</cYear>
+						<article_title>Functional Variant in the Autophagy-Related 5 Gene Promotor is Associated with Childhood Asthma</article_title>
+						<doi>10.1371/journal.pone.0033454</doi>
+						<elocation_id>e33454</elocation_id>
+					</citation>
+					<citation key="bib38">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Michalek</author>
+						<volume>186</volume>
+						<first_page>3299</first_page>
+						<cYear>2011</cYear>
+						<article_title>Cutting Edge: Distinct Glycolytic and Lipid Oxidative Metabolic Programs Are Essential for Effector and Regulatory CD4+ T Cell Subsets</article_title>
+						<doi>10.4049/jimmunol.1003613</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>Journal of Cell Science</journal_title>
+						<author>Mizushima</author>
+						<volume>116</volume>
+						<first_page>1679</first_page>
+						<cYear>2003</cYear>
+						<article_title>Mouse Apg16L, a novel WD-repeat protein, targets to the autophagic isolation membrane with the Apg12-Apg5 conjugate</article_title>
+						<doi>10.1242/jcs.00381</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Genes &amp; Development</journal_title>
+						<author>Mizushima</author>
+						<volume>21</volume>
+						<first_page>2861</first_page>
+						<cYear>2007</cYear>
+						<article_title>Autophagy: process and function</article_title>
+						<doi>10.1101/gad.1599207</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Journal of Clinical Investigation</journal_title>
+						<author>Mucida</author>
+						<volume>115</volume>
+						<first_page>1923</first_page>
+						<cYear>2005</cYear>
+						<article_title>Oral tolerance in the absence of naturally occurring Tregs</article_title>
+						<doi>10.1172/JCI24487</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Nature</journal_title>
+						<author>Murthy</author>
+						<volume>506</volume>
+						<first_page>456</first_page>
+						<cYear>2014</cYear>
+						<article_title>A Crohn’s disease variant in Atg16l1 enhances its degradation by caspase 3</article_title>
+						<doi>10.1038/nature13044</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Immunity</journal_title>
+						<author>O’Sullivan</author>
+						<volume>41</volume>
+						<first_page>75</first_page>
+						<cYear>2014</cYear>
+						<article_title>Memory CD8+ T Cells Use Cell-Intrinsic Lipolysis to Support the Metabolic Programming Necessary for Development</article_title>
+						<doi>10.1016/j.immuni.2014.06.005</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Parekh</author>
+						<volume>190</volume>
+						<first_page>5086</first_page>
+						<cYear>2013</cYear>
+						<article_title>Impaired Autophagy, Defective T Cell Homeostasis, and a Wasting Syndrome in Mice with a T Cell-Specific Deletion of Vps34</article_title>
+						<doi>10.4049/jimmunol.1202071</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>Nature</journal_title>
+						<author>Pearce</author>
+						<volume>460</volume>
+						<first_page>103</first_page>
+						<cYear>2009</cYear>
+						<article_title>Enhancing CD8 T-cell memory by modulating fatty acid metabolism</article_title>
+						<doi>10.1038/nature08097</doi>
+					</citation>
+					<citation key="bib46">
+						<journal_title>Science</journal_title>
+						<author>Pearce</author>
+						<volume>342</volume>
+						<first_page>1242454</first_page>
+						<cYear>2013</cYear>
+						<article_title>Fueling Immunity: Insights into Metabolism and Lymphocyte Function</article_title>
+						<doi>10.1126/science.1242454</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>Gut</journal_title>
+						<author>Plantinga</author>
+						<volume>60</volume>
+						<first_page>1229</first_page>
+						<cYear>2011</cYear>
+						<article_title>Crohn's disease-associated ATG16L1 polymorphism modulates pro-inflammatory cytokine responses selectively upon activation of NOD2</article_title>
+						<doi>10.1136/gut.2010.228908</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Trends in Immunology</journal_title>
+						<author>Pollizzi</author>
+						<volume>36</volume>
+						<first_page>13</first_page>
+						<cYear>2015</cYear>
+						<article_title>Regulation of T cells by mTOR: the known knowns and the known unknowns</article_title>
+						<doi>10.1016/j.it.2014.11.005</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Autophagy</journal_title>
+						<author>Poon</author>
+						<volume>8</volume>
+						<first_page>694</first_page>
+						<cYear>2012</cYear>
+						<article_title>ATG5, autophagy and lung function in asthma</article_title>
+						<doi>10.4161/auto.19315</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Pua</author>
+						<volume>182</volume>
+						<first_page>4046</first_page>
+						<cYear>2009</cYear>
+						<article_title>Autophagy Is Essential for Mitochondrial Clearance in Mature T Lymphocytes</article_title>
+						<doi>10.4049/jimmunol.0801143</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>eLife</journal_title>
+						<author>Puleston</author>
+						<volume>3</volume>
+						<cYear>2014</cYear>
+						<article_title>Autophagy is a critical regulator of memory CD8(+) T cell formation</article_title>
+						<doi>10.7554/eLife.03706</doi>
+						<elocation_id>e03706</elocation_id>
+					</citation>
+					<citation key="bib52">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Riedl</author>
+						<volume>174</volume>
+						<first_page>7440</first_page>
+						<cYear>2005</cYear>
+						<article_title>Initial High-Dose Nasal Allergen Exposure Prevents Allergic Sensitization to a Neoantigen</article_title>
+						<doi>10.4049/jimmunol.174.11.7440</doi>
+					</citation>
+					<citation key="bib53">
+						<journal_title>Nature Genetics</journal_title>
+						<author>Rioux</author>
+						<volume>39</volume>
+						<first_page>596</first_page>
+						<cYear>2007</cYear>
+						<article_title>Genome-wide association study identifies new susceptibility loci for Crohn disease and implicates autophagy in disease pathogenesis</article_title>
+						<doi>10.1038/ng2032</doi>
+					</citation>
+					<citation key="bib54">
+						<journal_title>Immunity</journal_title>
+						<author>Rubtsov</author>
+						<volume>28</volume>
+						<first_page>546</first_page>
+						<cYear>2008</cYear>
+						<article_title>Regulatory T Cell-Derived Interleukin-10 Limits Inflammation at Environmental Interfaces</article_title>
+						<doi>10.1016/j.immuni.2008.02.017</doi>
+					</citation>
+					<citation key="bib55">
+						<journal_title>Nature</journal_title>
+						<author>Saitoh</author>
+						<volume>456</volume>
+						<first_page>264</first_page>
+						<cYear>2008</cYear>
+						<article_title>Loss of the autophagy protein Atg16L1 enhances endotoxin-induced IL-1β production</article_title>
+						<doi>10.1038/nature07383</doi>
+					</citation>
+					<citation key="bib56">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Schlie</author>
+						<volume>194</volume>
+						<first_page>4277</first_page>
+						<cYear>2015</cYear>
+						<article_title>Survival of Effector CD8+ T Cells during Influenza Infection Is Dependent on Autophagy</article_title>
+						<doi>10.4049/jimmunol.1402571</doi>
+					</citation>
+					<citation key="bib57">
+						<journal_title>Immunological Reviews</journal_title>
+						<author>Shale</author>
+						<volume>252</volume>
+						<first_page>164</first_page>
+						<cYear>2013</cYear>
+						<article_title>CD4(+) T-cell subsets in intestinal inflammation</article_title>
+						<doi>10.1111/imr.12039</doi>
+					</citation>
+					<citation key="bib58">
+						<journal_title>ACS Chemical Biology</journal_title>
+						<author>Shaw</author>
+						<volume>8</volume>
+						<first_page>2724</first_page>
+						<cYear>2013</cYear>
+						<article_title>Selective Modulation of Autophagy, Innate Immunity, and Adaptive Immunity by Small Molecules</article_title>
+						<doi>10.1021/cb400352d</doi>
+					</citation>
+					<citation key="bib59">
+						<journal_title>Nature</journal_title>
+						<author>Singh</author>
+						<volume>458</volume>
+						<first_page>1131</first_page>
+						<cYear>2009</cYear>
+						<article_title>Autophagy regulates lipid metabolism</article_title>
+						<doi>10.1038/nature07976</doi>
+					</citation>
+					<citation key="bib60">
+						<journal_title>Methods Mol. Biol</journal_title>
+						<author>Song-Zhao</author>
+						<volume>1193</volume>
+						<first_page>199</first_page>
+						<cYear>2014</cYear>
+						<article_title>Experimental mouse models of T cell-dependent inflammatory bowel disease</article_title>
+						<doi>10.1007/978-1-4939-1212-4_18</doi>
+					</citation>
+					<citation key="bib61">
+						<journal_title>Autophagy</journal_title>
+						<author>Stephenson</author>
+						<volume>5</volume>
+						<first_page>625</first_page>
+						<cYear>2009</cYear>
+						<article_title>Identification of Atg5 -dependent transcriptional changes and increases in mitochondrial mass in Atg5 -deficient T lymphocytes</article_title>
+						<doi>10.4161/auto.5.5.8133</doi>
+					</citation>
+					<citation key="bib62">
+						<journal_title>Annual Review of Immunology</journal_title>
+						<author>Strober</author>
+						<volume>20</volume>
+						<first_page>495</first_page>
+						<cYear>2002</cYear>
+						<article_title>The immunology of mucosal models of inflammation</article_title>
+						<doi>10.1146/annurev.immunol.20.100301.064816</doi>
+					</citation>
+					<citation key="bib63">
+						<journal_title>Immunology</journal_title>
+						<author>Sudowe</author>
+						<volume>91</volume>
+						<first_page>464</first_page>
+						<cYear>1997</cYear>
+						<article_title>Antigen dose-dependent predominance of either direct or sequential switch'qc in IgE antibody responses</article_title>
+						<doi>10.1046/j.1365-2567.1997.00268.x</doi>
+					</citation>
+					<citation key="bib64">
+						<journal_title>New England Journal of Medicine</journal_title>
+						<author>Tehranchi</author>
+						<volume>363</volume>
+						<first_page>1025</first_page>
+						<cYear>2010</cYear>
+						<article_title>Persistent Malignant Stem Cells in del(5q) Myelodysplasia in Remission</article_title>
+						<doi>10.1056/NEJMoa0912228</doi>
+					</citation>
+					<citation key="bib65">
+						<journal_title>The Journal of Immunology</journal_title>
+						<author>Uhlig</author>
+						<volume>177</volume>
+						<first_page>5852</first_page>
+						<cYear>2006</cYear>
+						<article_title>Characterization of Foxp3+CD4+CD25+ and IL-10-Secreting CD4+CD25+ T Cells during Cure of Colitis</article_title>
+						<doi>10.4049/jimmunol.177.9.5852</doi>
+					</citation>
+					<citation key="bib66">
+						<journal_title>Nature Reviews Gastroenterology &amp; Hepatology</journal_title>
+						<author>Van Limbergen</author>
+						<volume>11</volume>
+						<first_page>372</first_page>
+						<cYear>2014</cYear>
+						<article_title>Advances in IBD genetics</article_title>
+						<doi>10.1038/nrgastro.2014.27</doi>
+					</citation>
+					<citation key="bib67">
+						<journal_title>Trends in Immunology</journal_title>
+						<author>Wan</author>
+						<volume>35</volume>
+						<first_page>233</first_page>
+						<cYear>2014</cYear>
+						<article_title>GATA3: a master of many trades in immune regulation</article_title>
+						<doi>10.1016/j.it.2014.04.002</doi>
+					</citation>
+					<citation key="bib68">
+						<journal_title>Immunity</journal_title>
+						<author>Wang</author>
+						<volume>35</volume>
+						<first_page>871</first_page>
+						<cYear>2011</cYear>
+						<article_title>The Transcription Factor Myc Controls Metabolic Reprogramming upon T Lymphocyte Activation</article_title>
+						<doi>10.1016/j.immuni.2011.09.021</doi>
+					</citation>
+					<citation key="bib69">
+						<journal_title>Nature Immunology</journal_title>
+						<author>Wang</author>
+						<volume>14</volume>
+						<first_page>714</first_page>
+						<cYear>2013</cYear>
+						<article_title>GATA-3 controls the maintenance and proliferation of T cells downstream of TCR and cytokine signaling</article_title>
+						<doi>10.1038/ni.2623</doi>
+					</citation>
+					<citation key="bib70">
+						<journal_title>Nature Immunology</journal_title>
+						<author>Wei</author>
+						<volume>17</volume>
+						<first_page>277</first_page>
+						<cYear>2016</cYear>
+						<article_title>Autophagy enforces functional integrity of regulatory T cells by coupling environmental cues and metabolic homeostasis</article_title>
+						<doi>10.1038/ni.3365</doi>
+					</citation>
+					<citation key="bib71">
+						<journal_title>Nature Immunology</journal_title>
+						<author>Xu</author>
+						<volume>15</volume>
+						<first_page>1152</first_page>
+						<cYear>2014</cYear>
+						<article_title>Autophagy is essential for effector CD8+ T cell survival and memory formation</article_title>
+						<doi>10.1038/ni.3025</doi>
+					</citation>
+					<citation key="bib72">
+						<journal_title>Immunity</journal_title>
+						<author>Yang</author>
+						<volume>39</volume>
+						<first_page>1043</first_page>
+						<cYear>2013</cYear>
+						<article_title>T Cell Exit from Quiescence and Differentiation into Th2 Cells Depend on Raptor-mTORC1-Mediated Metabolic Reprogramming</article_title>
+						<doi>10.1016/j.immuni.2013.09.015</doi>
+					</citation>
+					<citation key="bib73">
+						<journal_title>Cell Host &amp; Microbe</journal_title>
+						<author>Yuk</author>
+						<volume>6</volume>
+						<first_page>231</first_page>
+						<cYear>2009</cYear>
+						<article_title>Vitamin D3 Induces Autophagy in Human Monocytes/Macrophages via Cathelicidin</article_title>
+						<doi>10.1016/j.chom.2009.08.004</doi>
+					</citation>
+					<citation key="bib74">
+						<journal_title>Nature</journal_title>
+						<author>Zeng</author>
+						<volume>499</volume>
+						<first_page>485</first_page>
+						<cYear>2013</cYear>
+						<article_title>mTORC1 couples immune signals and metabolic programming to establish Treg-cell function</article_title>
+						<doi>10.1038/nature12297</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.001</doi>
+							<resource>https://elifesciences.org/articles/12444#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>eLife digest</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.002</doi>
+							<resource>https://elifesciences.org/articles/12444#digest</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Aged Atg16l1ΔCD4 mice develop intestinal inflammation.</title>
+							<subtitle>(A) FACS analysis of LC3+ autophagosome formation in CD4+ T cells from cLP of Atg16l1ΔCD4 and Atg16l1fl/fl mice after overnight activation with or without α-CD3 (5 μg/ml) and α-CD28 (1 μg/ml). (B) Western blot analysis of LC3 lipidation in naïve splenic CD4+ T cells isolated from Atg16l1ΔCD4 mice and Atg16l1fl/fl mice after 3hr activation with α-CD3 (5 μg/ml) and α-CD28 (1 μg/ml) with or without chloroquine (CQ, inhibitor of lysosomal degradation, 50 μM). (C) Weight curves of Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (D) Representative images of spleens and mesenteric lymph nodes (mLN) from aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates and (E) spleen weights of young and aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (F,H) Representative photomicrographs of haemotoxilin and eosin (H&amp;E) stained sections of (F) jejunum and (H) mid-colon from young and aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates, scale bar 150 μm. (G,I) Quantification of (G) SI lengths and (I) mid-colon crypt lengths in aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are representative of at least three independent experiments (A-E, F, H) or combined from two (G) or three (I) independent experiments, with at least 3 mice per group. Data shown as mean ± s.e.m (A,C). Each dot represents an individual mouse and horizontal bars denote means (E,G). In (I) each dot represents an individual crypt measurement and horizontal bars denote means. Statistical significance was determined using two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (C) or the Mann–Whitney test (E,G,I), **p&lt;0.01; ***p&lt;0.001. SI LP– small intestine lamina propria, cLP – colonic lamina propria. Young mice: 8–12 weeks old, aged mice &gt;5 months old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.003</doi>
+							<resource>https://elifesciences.org/articles/12444#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. Atg16l1ΔCD4 mice exhibit reciprocal dysregulation of intestinal TH2 and Treg cells before the onset of intestinal inflammation.</title>
+							<subtitle>(A) Frequencies of CD4+ T cells as a proportion of live cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Frequencies and (C) total numbers of IFN-γ+ TH1, IL-17A+ TH17 and IL-13+ TH2 cells isolated from cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ T cells). (D) Representative FACS plots of Gata3 and IL-13 (top) or IFN-γ and IL-17A (bottom) expression by cLP CD4+ T cells isolated from young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- live cells). (E) Frequencies of Gata3+ CD4+ T cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- cells). (F) Representative FACS plots and (G) frequencies of Foxp3+ Treg cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ cells). Data are combined from three or more independent experiments with at least two mice per group (A,B, D, E, G) or are representative of four independent experiments with at least four mice per group (D, F). Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates or quadrants. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. SI LP– small intestine lamina propria, cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.004</doi>
+							<resource>https://elifesciences.org/articles/12444#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. Characterization of immune cell compartments in young Atg16l1ΔCD4mice.</title>
+							<subtitle>(A) Frequencies and (B) representative FACS plots of single positive CD4+, single positive CD8+, double positive (DP) CD4+ CD8+ and double negative (DN) CD4- CD8- thymocytes in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (C) Frequencies of CD8+ T cells in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (D) Total numbers of CD4+ T cells in spleen, mLN, and cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are combined from (A,C,D) or representative of (B) two or three independent experiments with at least 4 mice per group. Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in quadrants. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. cLP – colonic lamina propria, mLN - mesenteric lymph nodes. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.005</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 2. Atg16l1ΔCD4 mice have increased susceptibility to T-cell-mediated experimental IBD.</title>
+							<subtitle>Cohorts of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were infected with Helicobacter hepaticus by oral gavage (three feeds of 1x108 CFU) and treated with anti-IL-10R mAb (1mg/mouse i.p. given weekly; H.h + αIL10R) or left untreated (Ctr). Two weeks post-infection mice were sacrificed for analyses. (A) Caecum and colon histopathology scores in H.h + αIL10R-treated Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Representative photomicrographs of H&amp;E stained caecum of untreated Ctr (left panels) or H.h + αIL10R-treated (middle and right panels) Atg16l1ΔCD4 and Atg16l1fl/fl littermates, scale bar 150 μm. (C) Total lamina propria leukocyte numbers and (D,E) frequencies of (D) neutrophils (Gr1hi CD11b+) and (E) CD4+ T cells in cLP isolated from untreated Ctr or H.h + αIL10R-treated Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are combined from two or three independent experiments with at least two mice per group. Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.006</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig2s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 3. Elevated type 2 innate responses in Atg16l1ΔCD4 mice.</title>
+							<subtitle>(A) Frequencies of eosinophils (Ly6Clow Ly6Glow CD11b+ F4/80-) in spleen and mLN of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Serum MCPT-1 levels in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. Data are combined from (A) or representative of (B) two or three independent experiments with at least four mice per group. Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.007</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig2s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 4. Characterization of Atg16l1-deficient Treg cells.</title>
+							<subtitle>(A) Foxp3+ Treg cell numbers in spleen, mLN, cLP and SI LP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. (B) Frequencies of Foxp3+ Treg in the thymus of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on single positive CD4+ TCRβ+ cells). (C) Frequencies of Neuropilin-1+ (Nrp1+) Foxp3+ Treg cells in the cLP and SI LP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3+ T cells). (D) Frequencies of Helios+ Foxp3+ Treg cells in the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3+ T cells). (E) Frequencies of IL-17A+ or IFN-γ+ of Foxp3+ Treg cells in the cLP and SI LP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (F) Expression of CD103, CTLA4, CD25, CD69 and KLRG1 by cLP Foxp3+ Treg cells from young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (G) Representative FACS plots and (H) frequencies of Ki67+ Foxp3+ Treg cells in cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (I) Mean fluorescence intensity (MFI) of phospo-S6 (P-S6) in Foxp3+ Treg cells in cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates. Data are combined from two independent experiments with at least four mice per group (A,B,E), are representative from two independent experiments with at least four mice per group (C,F-H), or are from one experiment (D,I). Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes, SI LP– small intestine lamina propria, cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.008</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig2s4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Atg16l1ΔCD4 mice develop elevated TH2-associated antibodies against intestinal luminal antigens.</title>
+							<subtitle>(A) Serum IgE concentrations in cohorts of young and aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (B) Serum antibody IgG1, IgG2b, IgG2c, IgA and IgM isotype levels in aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (C) Representative photomicrographs of H&amp;E stained sections of Peyer’s patch (PP) in the SI (jejunum) of aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates, scale bar 150 μm. (D) Serum levels of Soy-specific IgA, IgG1, IgG2b, IgG2c antibodies in aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (E) Young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were fed with ovalbumin (OVA) alone or with cholera toxin (CT) as described in methods and levels of OVA-specific serum IgE were measured 8 weeks after first challenge by ELISA. (F) Levels of CBir1-specific IgA, IgG1, IgG2b and IgG2c antibodies in serum of aged Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA, serum was diluted 50x. Data are representative from at least two independent experiments with at least three mice per group (A-D) or combined from two (E) or three (F) independent experiments with at least three mice per group. Each dot represents an individual mouse and horizontal bars denote means (A,D,E,F). Serum isotype levels are shown as mean ± s.e.m (B). Statistical significance was determined using the Mann–Whitney test (A,D-F) or two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (B), *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. SI – small intestine. Young mice: 8–12 weeks old, aged mice &gt; 5 months old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.009</doi>
+							<resource>https://elifesciences.org/articles/12444#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. Dysregulated humoral responses in young Atg16l1ΔCD4 mice.</title>
+							<subtitle>(A) Serum antibody IgA and IgG1 isotype levels in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (B) Frequencies of B cells (B220+), germinal center B cells (GC: B220+ GL7+ CD95+), memory B cells (B220+ Gl7- IgM- IgG+) and plasma cells (CD138+) in the spleen and mLN of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on live CD45+ cells). (C) Serum levels of Soy-specific IgA, IgG1, IgG2b, IgG2c antibodies in young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were measured by ELISA. (D) Cohorts of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were infected with Helicobacter hepaticus by oral gavage (three feeds of 1x108 CFU) and levels of serum Helicobacter-specific IgG1, IgG2c and IgA antibodies were determined three weeks later by ELISA. (E) Cohorts of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates were orally infected with Trichuris muris (200 eggs) and levels of T. muris-specific IgG1 in serum were determined 34 days later by ELISA. Data are from one experiment with at least three mice per group (A-D) or representative from two independent experiments with five mice per group (E). Each dot represents an individual mouse and horizontal bars denote means (B,C) or data represent mean ± s.e.m (A,D,E). Statistical significance was determined using the Mann–Whitney test (A,C) or two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (B,D,E): statistical significance was determined between infected groups (b,c), *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.010</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. Atg16l1 promotes survival of Treg cells and limits TH2 cell survival.</title>
+							<subtitle>(A,B) Atg16l1ΔCD4 or Atg16l1fl/fl naïve CD4+ T cells were cultured in TH0, Treg, or TH2 polarizing conditions for 48 hr and analyzed by FACS. Representative FACS plots show (A) Foxp3 and (B) Gata3 expression (gated on CD4+ TCRβ+ T cells). (C) Frequencies of Treg cells (Foxp3+) and TH2 cells (Gata3+) arising from Atg16l1ΔCD4 or Atg16l1fl/fl naïve CD4+ T cells cultured in Treg or TH2 polarizing conditions for 5 days. (D) Atg16l1ΔCD4 or Atg16l1fl/fl Treg cells were cultured with anti-CD3 (3 μg/ml) and anti-CD28 (1 μg/ml) for 48 hr, then maintained in the presence of IL-4 and IL-13 for a further 5 days before FACS analysis of Foxp3 and CD25 expression of live CD4+ T cells. (E,F) Naïve Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells were cultured with (E) 1 μg/ml or (F) 5 μg/ml anti-CD3 plus anti-CD28 (1 μg/ml) for 48 hr in Treg or TH2 polarizing conditions, then maintained in polarizing conditions for a further 5 days before FACS analysis of cell survival. Histograms show gates and frequencies of live CD4+ T cells. (G) Representative FACS plots of viability dye and Annexin V staining of Treg cells and TH2 cells from the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates, gated on CD4+ TCRβ+ Foxp3+ (left panel), or CD4+ TCRβ+ Gata3+ (right panel). Data are representative from two (D,G) or three independent experiments (A,B,E,F), or are combined from three independent experiments (C). Each dot represents an individual cell culture (C) or data are shown as mean ± s.e.m (A,B,D-F). Numbers indicate percentage of cells in quadrants (G). cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.011</doi>
+							<resource>https://elifesciences.org/articles/12444#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Autophagy contributes to the elevated TH2 responses in Atg16l1ΔCD4 mice in a cell-intrinsic manner.</title>
+							<subtitle>Young Atg16l1ΔCD4 mice (CD45.2+) were adoptively transferred with 4-5x106 naïve WT CD4+ T cells (CD45.1+) and analyzed 3 months later. (A) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) CD4+ T cells in the spleen, mLN and cLP. (B) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) Foxp3+ Treg cells in the spleen, mLN and cLP (gated on CD4+ TCRβ+ T cells). (C) Representative FACS plots showing gating of WT (CD45.1+) and Atg16l1-deficient (CD45.1-) CD4+ T cells and expression of IL-13 (TH2), IFN-γ (TH1) and IL-17A (TH17) in the cLP (gated on CD4+ TCRβ+ Foxp3- T cells). (D) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) TH2 (IL-13+), TH1 (IFN- γ+) and TH17 (IL-17A+) cells among CD4+ TCRβ+ Foxp3- T cells in the cLP. (E) Frequencies of WT (CD45.1+) and Atg16l1-deficient (CD45.2+) Gata3+ CD4+ T cells in the spleen, mLN and cLP (gated on CD4+ TCRβ+ Foxp3- T cells). (F) SI lengths and (G) representative photomicrographs of jejunum of control untreated Atg16l1fl/fl or Atg16l1ΔCD4 littermates and reconstituted Atg16l1ΔCD4 mice, scale bar 150 μm. (H) Serum IgE concentrations in control untreated Atg16l1fl/fl or Atg16l1ΔCD4 littermates and adoptively transferred Atg16l1ΔCD4 mice were measured by ELISA. Data are representative of two independent experiments with at least four mice per group (A-E,G) or combined from two independent experiments (F,H). Each dot represents cells coming from the donor or the hosts within the individual transferred mouse (A,B,D,E) or each dot represents an individual mouse (F,H), horizontal bars denote mean. Numbers indicate percentage of cells in gates. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 10–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.012</doi>
+							<resource>https://elifesciences.org/articles/12444#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5—figure supplement 1. Reconstitution of intestinal CD4+ T cell compartments in adoptively transferred Atg16l1ΔCD4 mice.</title>
+							<subtitle>Young Atg16l1ΔCD4 mice (CD45.2+) were adoptively transferred with 4-5x106 naïve WT CD4+ T cells (CD45.1+) i.v. and cLP populations analyzed 3 months later. (A) Frequencies of total CD4+ T cells. (B) Frequencies and total numbers of Foxp3+ Treg cells (gated on CD4+ TCRβ+ T cells). (C) Frequencies and total numbers of TH2 (IL-13+) cells (gated on CD4+ TCRβ+ Foxp3- T cells). Data are combined from two independent experiments with at least four mice per group. Each dot represents an individual mouse, horizontal bars denote mean. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01. cLP – colonic lamina propria. Young mice: 10–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.013</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig5s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6. Aged Atg16l1ΔFoxp3 mice develop spontaneous multi-organ inflammation.</title>
+							<subtitle>(A) LC3+ autophagosome formation by Foxp3- CD4+ T cells and Foxp3+ Treg cells from cLP and mLN of WT mice in unstimulated cells or after overnight activation with α-CD3 (5 μg/ml) and α-CD28 (1 μg/ml). (B) Representative LC3 staining of unstimulated cells (gated on Foxp3+ CD4+ TCRβ+ Treg cells or Foxp3- CD4+ TCRβ+ T cells). (C) Weight curves and (D) spleen weights and representative images of spleen and mLN of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates. (E) Representative photomicrographs of H&amp;E stained sections of liver, spleen, stomach, SI (jejunum), proximal colon and mid-colon of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates, scale bar 150 μm. (F) Quantification of SI length. Data are combined from two to four independent experiments with two to five mice per group (A,D,F) or are representative of two to three independent experiments with two to five mice per group (B,C,E). Each dot represents an individual mouse and horizontal bars denote means (A,D,F). Data shown as mean ± s.e.m (C). Statistical significance was determined using two-way analysis of variance (ANOVA) with Bonferroni’s correction for multiple comparisons (C) or using the Mann–Whitney test (A,D,F), *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. mLN - mesenteric lymph nodes, SI – small intestine lamina propria, cLP – colonic lamina propria. Aged mice &gt;5 months old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.014</doi>
+							<resource>https://elifesciences.org/articles/12444#fig6</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6—figure supplement 1. Impaired reconstitution of mixed bone marrow chimeras by Atg16l1-deficient T cells.</title>
+							<subtitle>(A) Experimental design for the generation of mixed bone marrow (BM) chimeras. BM cells isolated from WT (CD45.1+) and Atg16l1fl/fl or Atg16l1ΔCD4 (CD45.2+) mice were injected at a 1:1 ratio into lethally irradiated (1100 Rad) Rag1-/- recipients (total of 1x107 cells per mouse). (B) Representative FACS plots showing frequencies of Atg16l1ΔCD4 or Atg16l1fl/fl (CD45.2+) and WT (CD45.2-) CD4+ T cells in the thymus, spleen and cLP of mixed BM chimeras (gated on CD4+ TCRβ+ T cells). (C) Frequencies of Atg16l1ΔCD4 or Atg16l1fl/fl (CD45.2+) CD4+ T cells in mixed BM chimeras (shown as percentage of total CD4+ TCRβ+ T cells). (D) Representative FACS plots and (E) frequencies of Foxp3+ Treg cells derived from Atg16l1ΔCD4 or Atg16l1fl/fl (CD45.2+) cells in mixed BM chimeras (gated on CD4+ TCRβ+ T cells). Highlighted top right quadrants indicate Treg cells derived from Atg16l1fl/fl orAtg16l1ΔCD4 BM. Data are representative from two independent experiments with at least seven mice per group. Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates. Statistical significance was determined using the Mann–Whitney test, **p&lt;0.01; ***p&lt;0.001.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.015</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig6s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6—figure supplement 2. Analysis of Atg16l1 expression in Atg16l1ΔFoxp3 mice.</title>
+							<subtitle>(A) qPCR analysis of Atg16l1 exon 3 levels in sorted CD4+ Foxp3- T cells and Foxp3+ Treg cells from spleen and cLP of Atg16l1ΔFoxp3 and Foxp3Cre mice. Data are representative from two independent experiments with 5 mice per group. Atg16l1 exon 3 levels are shown as mean ± s.e.m of three technical replicates, normalised to expression of hprt. cLP – colonic lamina propria.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.016</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig6s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 7. Atg16l1ΔFoxp3 mice cannot control pro-inflammatory TH effector responses.</title>
+							<subtitle>(A) Representative immunofluorescence images of small intestine and proximal and mid colon of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates stained for CD3 (red), β-catenin (green) and DAPI (blue). (B) Frequencies and (C) total numbers of cLP CD4+ TCRβ+ T cells in aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates. (D) Frequencies of effector (CD44+CD62L-) CD4+ T cells in the mLN and cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (E) Frequencies and (F) total numbers of TH1 (IFN-γ+), TH17 (IL-17A+), TH2 (IL-13+) T cells in the cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (G) Frequencies of Gata3+ CD4+ T cells in aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (H) Serum IgE concentrations in Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates were measured by ELISA. Data are combined from two to four independent experiments with two to five mice per group (B-H) or are representative of two independent experiments with two to five mice per group (A). Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 8–12 weeks old, aged mice &gt;5 months old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.017</doi>
+							<resource>https://elifesciences.org/articles/12444#fig7</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 7—figure supplement 1. Additional characterization of Atg16l1ΔFoxp3 mice.</title>
+							<subtitle>(A) Representative FACS plots of CD44 and CD62L expression by CD4+ T cells from cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (B) Frequencies of TH1 (IFN-γ+), TH17 (IL-17A+), TH2 (IL-13+) T cells in the cLP of young Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- T cells). (C) Serum antibody IgA, IgG1, IgG2b, IgG2c isotype levels in aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates. Data are combined from three independent experiments with two to five mice per group (B) or are representative from two to three independent experiments with two to five mice per group (A,C). Each dot represents an individual mouse and horizontal bars denote means. Numbers indicate percentage of cells in gates. Data shown as mean ± s.e.m (C). Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05; **p&lt;0.01; ***p&lt;0.001. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 8–12 weeks old, aged mice &gt;5 months old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.018</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig7s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 8. Cell-intrinsic autophagy is required for metabolic adaptation and survival of intestinal Foxp3+ Treg cells.</title>
+							<subtitle>(A) Foxp3+ Treg cell frequencies among CD4+ TCRβ+ T cells in Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates and (B) representative FACS plots of Foxp3 expression in cLP CD4+ T cells from young Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ T cells). (C) qPCR analysis of glycolytic gene levels in sorted Foxp3+ Treg cells from spleen and cLP of young Atg16l1ΔFoxp3 and Foxp3Cre mice (sorted for CD4+ TCRβ+ YFP+). (D) qPCR analysis of FAS and FAO gene levels in Foxp3+ Treg cells from the spleen and cLP of young Atg16l1ΔFoxp3 and Foxp3Cre mice (sorted for CD4+ TCRβ+ YFP+). FAS: fatty acid synthesis, FAO: fatty acid oxidation, Glut1: glucose transporter 1, Slc16ac: solute carrier family 16 member 3 (lactic acid and pyruvate transporter), Tpi1: triosephosphate isomerase 1, Aldo–α: aldolase α, Ldh-α: lactate dehydrogenase α, Gpi1: Glucose phosphate isomerase 1, Pgk1: Phosphoglycerate kinase 1, Acc1: acetyl-CoA carboxylase 1, Acc2: acetyl-CoA carboxylase 2, Srebf1: sterol regulatory element binding transcription factor 1, Srebf2: sterol regulatory element binding transcription factor 2, Fdft1: farnesyl-diphosphate farnesyltransferase 1, Fabp: Fatty acid-binding protein. Data are representative from two (C,D) or three independent experiments (A,B). Each dot represents individual mouse (A) or data are shown as mean ± s.e.m (C,D). Gene expression levels are shown as mean ± s.e.m of three technical replicates (C,D). Numbers indicate percentage of cells in gates (B). cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.019</doi>
+							<resource>https://elifesciences.org/articles/12444#fig8</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 8—figure supplement 1. Atg16l1-deficient colonic Treg cells exhibit increased cytokine secretion.</title>
+							<subtitle>(A) Frequencies of IFN-γ+, IL-17A+, IL-4+, IL-13+ Foxp3+ Treg cells in the cLP of aged Atg16l1ΔFoxp3 and Atg16l1fl/fl littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). (B) qPCR analysis of Bcl2, Bim and Bax levels in Foxp3+ Treg cells from young cLP of Atg16l1ΔFoxp3 and Foxp3Cre mice (sorted for CD4+ TCRβ+ YFP+). Data are combined from three independent experiments with two to five mice per group (A) or are representative from two independent experiments (B). Each dot represents an individual mouse and horizontal bars denote means (A). Gene expression levels are shown as mean ± s.e.m of three technical replicates (B). cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.020</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig8s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 8—figure supplement 2. Increased lipid uptake by intestinal Treg cells.</title>
+							<subtitle>(A,B) Atg16l1fl/fl and Atg16l1ΔCD4 littermates were injected i.p. with 50 μg of fluorescent 16-carbon fatty acid analog BODIPY C-16 and culled 1 hr later and tissue was collected for analysis by flow cytometry. (A) Representative FACS plots and (B) quantification of C16-Bodipy uptake by Foxp3+ Treg cells in the spleen, mLN and cLP (gated on Foxp3+ CD4+ TCRβ+ T cells). (C) Representative FACS plots and (D) quantification of CD36 expression by Foxp3+ Treg cells in the spleen, mLN and cLP of Atg16l1fl/fl and Atg16l1ΔCD4 littermates (gated on Foxp3+ CD4+ TCRβ+ T cells). Data are combined from (B,D) or are representative of (A,C) two independent experiments with 3–5 mice per group. Each dot represents an individual mouse and horizontal bars denote means. Statistical significance was determined using the Mann–Whitney test, *p&lt;0.05. mLN - mesenteric lymph nodes, cLP – colonic lamina propria. Young mice: 8–12 weeks old.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.021</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig8s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 8—figure supplement 3. TH2 cells exhibit an enhanced glycolytic metabolic profile that is independent of autophagy.</title>
+							<subtitle>(A) Representative FACS plot and quantification of the cell size (FSC-H) of naïve (CD44- CD62L+) CD4+ T cells from the spleen of Atg16l1ΔCD4 or Atg16l1fl/fl littermates. (B) Basal level of oxygen consumption rate (OCR) and extracellular acidification rate (ECAR) in naïve (CD44- CD62L+) unstimulated CD4+ T cells isolated from the spleen of Atg16l1ΔCD4 or Atg16l1fl/fl littermates measured using the Seahorse metabolic flux analyzer. (C,D) Expression of c-Myc (C) and cell size (D) was analyzed by FACS in Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells that were cultured in TH2 or Treg-polarizing conditions for 3 days and rested for one day in the presence of polarizing cytokines. (E) Basal level of OCR and ECAR were measured by Seahorse metabolic flux analyzer in Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured in TH2 or Treg- polarizing conditions for 3 days and rested for 2 days in the presence of polarizing cytokines. (F) qPCR analysis of glycolytic gene levels in Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured in TH2 or Treg polarizing conditions for 3 days and rested for 1 day in the presence of polarizing cytokines. Data are combined from two independent experiments (A), or are representative of two independent experiments (B-D), or are from one experiment (E,F). Each dot represents an individual mouse (A) or individual cell culture (D). ECAR and OCAR data represent mean ± s.e.m values of T cell populations that were assayed in triplicates or quadruplicates (B,E). Gene expression data of triplicate cultures represent normalized expression values for each gene that were scaled to a mean of 0 and a standard deviation of 1 (F). Statistical significance was determined using the Mann–Whitney test (A) or unpaired Student’s t –test (B,D,E), **p&lt;0.01; **p&lt;0.001.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.022</doi>
+							<resource>https://elifesciences.org/articles/12444/figures#fig8s3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.024</doi>
+							<resource>https://elifesciences.org/articles/12444#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response image 1. Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.025</doi>
+							<resource>https://elifesciences.org/articles/12444#SA2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response image 1. Autophagy deficiency does not influence expression of IL-2 receptor on TH2 cells (A) Expression of IL-2Ra (CD25) by TH2cells in the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- Gata3+ T cells), data are representative of two independent experiments.</title>
+							<subtitle>(B) Expression of CD25 was measured in naïve Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured with anti-CD3 (5μg/ml) and anti-CD28 (1μg/ml) in TH2 polarizing conditions for 2 or 5 days, data are from one experiment.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.12444.023</doi>
+							<resource>https://elifesciences.org/articles/12444#fig9</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-12444-20170717071707.xml
+++ b/tests/test_data/elife-crossref-12444-20170717071707.xml
@@ -1084,26 +1084,6 @@
 					</component>
 					<component parent_relation="isPartOf">
 						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.12444.024</doi>
-							<resource>https://elifesciences.org/articles/12444#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response image 1. Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.12444.025</doi>
-							<resource>https://elifesciences.org/articles/12444#SA2</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
 							<title>Author response image 1. Autophagy deficiency does not influence expression of IL-2 receptor on TH2 cells (A) Expression of IL-2Ra (CD25) by TH2cells in the cLP of young Atg16l1ΔCD4 and Atg16l1fl/fl littermates (gated on CD4+ TCRβ+ Foxp3- Gata3+ T cells), data are representative of two independent experiments.</title>
 							<subtitle>(B) Expression of CD25 was measured in naïve Atg16l1ΔCD4 or Atg16l1fl/fl CD4+ T cells cultured with anti-CD3 (5μg/ml) and anti-CD28 (1μg/ml) in TH2 polarizing conditions for 2 or 5 days, data are from one experiment.</subtitle>
 						</titles>

--- a/tests/test_data/elife-crossref-15743-20170717071707.xml
+++ b/tests/test_data/elife-crossref-15743-20170717071707.xml
@@ -1,1 +1,88 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-15743-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>03</month><day>23</day><year>2016</year></publication_date><journal_volume><volume>5</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>Correction: Dosage compensation can buffer copy-number variation in wild yeast</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>James</given_name><surname>Hose</surname></person_name><person_name contributor_role="author" sequence="additional"><given_name>Chris Mun</given_name><surname>Yong</surname></person_name><person_name contributor_role="author" sequence="additional"><given_name>Maria</given_name><surname>Sardi</surname></person_name><person_name contributor_role="author" sequence="additional"><given_name>Zhishi</given_name><surname>Wang</surname></person_name><person_name contributor_role="author" sequence="additional"><given_name>Michael A</given_name><surname>Newton</surname></person_name><person_name contributor_role="author" sequence="additional"><given_name>Audrey P</given_name><surname>Gasch</surname><ORCID authenticated="true">http://orcid.org/0000-0002-8182-257X</ORCID></person_name></contributors><publication_date media_type="online"><month>03</month><day>23</day><year>2016</year></publication_date><publisher_item><item_number item_number_type="article_number">e15743</item_number><identifier id_type="doi">10.7554/eLife.15743</identifier></publisher_item><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.15743</doi><resource>https://elifesciences.org/articles/15743</resource><collection property="text-mining"><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/15743/elife-15743-v1.xml</resource></item></collection></doi_data></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-15743-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>03</month>
+					<day>23</day>
+					<year>2016</year>
+				</publication_date>
+				<journal_volume>
+					<volume>5</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>Correction: Dosage compensation can buffer copy-number variation in wild yeast</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>James</given_name>
+						<surname>Hose</surname>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Chris Mun</given_name>
+						<surname>Yong</surname>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Maria</given_name>
+						<surname>Sardi</surname>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Zhishi</given_name>
+						<surname>Wang</surname>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Michael A</given_name>
+						<surname>Newton</surname>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Audrey P</given_name>
+						<surname>Gasch</surname>
+						<ORCID authenticated="true">http://orcid.org/0000-0002-8182-257X</ORCID>
+					</person_name>
+				</contributors>
+				<publication_date media_type="online">
+					<month>03</month>
+					<day>23</day>
+					<year>2016</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e15743</item_number>
+					<identifier id_type="doi">10.7554/eLife.15743</identifier>
+				</publisher_item>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.15743</doi>
+					<resource>https://elifesciences.org/articles/15743</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/15743/elife-15743-v1.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-16988-20170717071707.xml
+++ b/tests/test_data/elife-crossref-16988-20170717071707.xml
@@ -1,1 +1,838 @@
-<?xml version="1.0" encoding="utf-8"?><doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd"><head><doi_batch_id>elife-crossref-16988-20170717071707</doi_batch_id><timestamp>20170717071707</timestamp><depositor><depositor_name>eLife</depositor_name><email_address>production@elifesciences.org</email_address></depositor><registrant>eLife</registrant></head><body><journal><journal_metadata language="en"><full_title>eLife</full_title><issn media_type="electronic">2050-084X</issn></journal_metadata><journal_issue><publication_date media_type="online"><month>07</month><day>26</day><year>2016</year></publication_date><journal_volume><volume>5</volume></journal_volume></journal_issue><journal_article publication_type="full_text" reference_distribution_opts="any"><titles><title>A filter at the entrance of the Golgi that selects vesicles according to size and bulk lipid composition</title></titles><contributors><person_name contributor_role="author" sequence="first"><given_name>Maud</given_name><surname>Magdeleine</surname><affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Romain</given_name><surname>Gautier</surname><affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Pierre</given_name><surname>Gounon</surname><affiliation>Centre Commun de Microscopie Appliquée, Université Côte d'Azur, Nice, France</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Hélène</given_name><surname>Barelli</surname><affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation></person_name><person_name contributor_role="author" sequence="additional"><given_name>Stefano</given_name><surname>Vanni</surname><affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation><ORCID authenticated="true">http://orcid.org/0000-0003-2146-1140</ORCID></person_name><person_name contributor_role="author" sequence="additional"><given_name>Bruno</given_name><surname>Antonny</surname><affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation><ORCID authenticated="true">http://orcid.org/0000-0002-9166-8668</ORCID></person_name></contributors><jats:abstract><jats:p>When small phosphatidylcholine liposomes are added to perforated cells, they bind preferentially to the Golgi suggesting an exceptional avidity of this organelle for curved membranes without stereospecific interactions. We show that the cis golgin GMAP-210 accounts for this property. First, the liposome tethering properties of the Golgi resembles that of the amphipathic lipid-packing sensor (ALPS) motif of GMAP-210: both preferred small (radius &lt; 40 nm) liposomes made of monounsaturated but not saturated lipids. Second, reducing GMAP-210 levels or redirecting its ALPS motif to mitochondria decreased liposome capture by the Golgi. Extensive mutagenesis analysis suggests that GMAP-210 tethers authentic transport vesicles via the same mechanism whereby the ALPS motif senses lipid-packing defects at the vesicle surface through its regularly spaced hydrophobic residues. We conclude that the Golgi uses GMAP-210 as a filter to select transport vesicles according to their size and bulk lipid composition.</jats:p></jats:abstract><publication_date media_type="online"><month>07</month><day>26</day><year>2016</year></publication_date><publisher_item><item_number item_number_type="article_number">e16988</item_number><identifier id_type="doi">10.7554/eLife.16988</identifier></publisher_item><fr:program name="fundref"><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Agence Nationale de la Recherche<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100001665</fr:assertion></fr:assertion><fr:assertion name="award_number">ANR-11-LABX-0028-01</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">European Research Council<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000781</fr:assertion></fr:assertion><fr:assertion name="award_number">Advanced Grant 268 888</fr:assertion></fr:assertion><fr:assertion name="fundgroup"><fr:assertion name="funder_name">Conseil Départemental des Alpes Maritimes</fr:assertion><fr:assertion name="award_number">appel à projet santé CG06 2013-2014</fr:assertion></fr:assertion></fr:program><ai:program name="AccessIndicators"><ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref><ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref></ai:program><archive_locations><archive name="CLOCKSS"/></archive_locations><doi_data><doi>10.7554/eLife.16988</doi><resource>https://elifesciences.org/articles/16988</resource><collection property="text-mining"><item><resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/16988/elife-16988-v1.pdf</resource></item><item><resource mime_type="application/xml">https://cdn.elifesciences.org/articles/16988/elife-16988-v1.xml</resource></item></collection></doi_data><citation_list><citation key="bib1"><journal_title>The EMBO Journal</journal_title><author>Ambroggio</author><volume>29</volume><first_page>292</first_page><cYear>2010</cYear><article_title>ArfGAP1 generates an Arf1 gradient on continuous lipid membranes displaying flat and curved regions</article_title><doi>10.1038/emboj.2009.341</doi></citation><citation key="bib2"><journal_title>Annual Review of Biochemistry</journal_title><author>Antonny</author><volume>80</volume><first_page>101</first_page><cYear>2011</cYear><article_title>Mechanisms of membrane curvature sensing</article_title><doi>10.1146/annurev-biochem-052809-155121</doi></citation><citation key="bib3"><journal_title>Cell</journal_title><author>Barlowe</author><volume>77</volume><first_page>895</first_page><cYear>1994</cYear><article_title>COPII: a membrane coat formed by Sec proteins that drive vesicle budding from the endoplasmic reticulum</article_title><doi>10.1016/0092-8674(94)90138-4</doi></citation><citation key="bib4"><journal_title>Developmental Cell</journal_title><author>Bigay</author><volume>23</volume><first_page>886</first_page><cYear>2012</cYear><article_title>Curvature, lipid packing, and electrostatics of membrane organelles: defining cellular territories in determining specificity</article_title><doi>10.1016/j.devcel.2012.10.009</doi></citation><citation key="bib5"><journal_title>The EMBO Journal</journal_title><author>Bigay</author><volume>24</volume><first_page>2244</first_page><cYear>2005</cYear><article_title>ArfGAP1 responds to membrane curvature through the folding of a lipid packing sensor motif</article_title><doi>10.1038/sj.emboj.7600714</doi></citation><citation key="bib6"><journal_title>Nature</journal_title><author>Bigay</author><volume>426</volume><first_page>563</first_page><cYear>2003</cYear><article_title>Lipid packing sensed by ArfGAP1 couples COPI coat disassembly to membrane bilayer curvature</article_title><doi>10.1038/nature02108</doi></citation><citation key="bib7"><journal_title>Cell</journal_title><author>Bonifacino</author><volume>116</volume><first_page>153</first_page><cYear>2004</cYear><article_title>The mechanisms of vesicle budding and fusion</article_title><doi>10.1016/S0092-8674(03)01079-1</doi></citation><citation key="bib8"><journal_title>Molecular Membrane Biology</journal_title><author>Brown</author><volume>27</volume><first_page>457</first_page><cYear>2010</cYear><article_title>An update on transport vesicle tethering</article_title><doi>10.3109/09687688.2010.501765</doi></citation><citation key="bib9"><journal_title>Journal of Cell Biology</journal_title><author>Brügger</author><volume>151</volume><first_page>507</first_page><cYear>2000</cYear><article_title>Evidence for segregation of sphingomyelin and cholesterol during formation of COPI-coated vesicles</article_title><doi>10.1083/jcb.151.3.507</doi></citation><citation key="bib10"><journal_title>Developmental Cell</journal_title><author>Cai</author><volume>12</volume><first_page>671</first_page><cYear>2007</cYear><article_title>Coats, tethers, Rabs, and SNAREs work together to mediate the intracellular destination of a transport vesicle</article_title><doi>10.1016/j.devcel.2007.04.005</doi></citation><citation key="bib11"><journal_title>BMC Biology</journal_title><author>Cardenas</author><volume>7</volume><first_page>56</first_page><cYear>2009</cYear><article_title>Golgi localisation of GMAP210 requires two distinct cis-membrane binding mechanisms</article_title><doi>10.1186/1741-7007-7-56</doi></citation><citation key="bib12"><journal_title>Current Opinion in Structural Biology</journal_title><author>Cherfils</author><volume>29</volume><first_page>67</first_page><cYear>2014</cYear><article_title>Arf GTPases and their effectors: assembling multivalent membrane-binding platforms</article_title><doi>10.1016/j.sbi.2014.09.007</doi></citation><citation key="bib13"><journal_title>eLife</journal_title><author>Cheung</author><volume>4</volume><cYear>2015</cYear><article_title>Protein flexibility is required for vesicle tethering at the Golgi</article_title><doi>10.7554/eLife.12790</doi><elocation_id>e12790</elocation_id></citation><citation key="bib14"><journal_title>Biophysical Journal</journal_title><author>Cui</author><volume>100</volume><first_page>1271</first_page><cYear>2011</cYear><article_title>Mechanism of membrane curvature sensing by amphipathic helix containing proteins</article_title><doi>10.1016/j.bpj.2011.01.036</doi></citation><citation key="bib15"><journal_title>PLoS One</journal_title><author>Doucet</author><volume>10</volume><cYear>2015</cYear><article_title>Membrane curvature sensing by amphipathic helices Is modulated by the surrounding protein backbone</article_title><doi>10.1371/journal.pone.0137965</doi><elocation_id>e0137965</elocation_id></citation><citation key="bib16"><journal_title>FEBS Letters</journal_title><author>Drin</author><volume>584</volume><first_page>1840</first_page><cYear>2010</cYear><article_title>Amphipathic helices and membrane curvature</article_title><doi>10.1016/j.febslet.2009.10.022</doi></citation><citation key="bib17"><journal_title>Nature Structural &amp; Molecular Biology</journal_title><author>Drin</author><volume>14</volume><first_page>138</first_page><cYear>2007</cYear><article_title>A general amphipathic alpha-helical motif for sensing membrane curvature</article_title><doi>10.1038/nsmb1194</doi></citation><citation key="bib18"><journal_title>Science</journal_title><author>Drin</author><volume>320</volume><first_page>670</first_page><cYear>2008</cYear><article_title>Asymmetric tethering of flat and curved lipid membranes by a golgin</article_title><doi>10.1126/science.1155821</doi></citation><citation key="bib19"><journal_title>PLoS Genetics</journal_title><author>Follit</author><volume>4</volume><cYear>2008</cYear><article_title>The Golgin GMAP210/TRIP11 anchors IFT20 to the Golgi complex</article_title><doi>10.1371/journal.pgen.1000315</doi><elocation_id>e1000315</elocation_id></citation><citation key="bib20"><journal_title>Bioinformatics</journal_title><author>Gautier</author><volume>24</volume><first_page>2101</first_page><cYear>2008</cYear><article_title>HELIQUEST: a web server to screen sequences with specific -helical properties</article_title><doi>10.1093/bioinformatics/btn392</doi></citation><citation key="bib21"><journal_title>Trends in Cell Biology</journal_title><author>Gillingham</author><volume>26</volume><first_page>399</first_page><cYear>2016</cYear><article_title>Finding the Golgi: Golgin coiled-coil proteins show the way</article_title><doi>10.1016/j.tcb.2016.02.005</doi></citation><citation key="bib22"><journal_title>Journal of Cell Biology</journal_title><author>Gillingham</author><volume>167</volume><first_page>281</first_page><cYear>2004</cYear><article_title>The GTPase Arf1p and the ER to Golgi cargo receptor Erv14p cooperate to recruit the golgin Rud3p to the cis-Golgi</article_title><doi>10.1083/jcb.200407088</doi></citation><citation key="bib23"><journal_title>Biochimica Et Biophysica Acta</journal_title><author>González-Rubio</author><volume>1808</volume><first_page>2119</first_page><cYear>2011</cYear><article_title>Amphipathic-lipid-packing-sensor interactions with lipids assessed by atomistic molecular dynamics</article_title><doi>10.1016/j.bbamem.2011.05.006</doi></citation><citation key="bib24"><journal_title>Molecular Biology of the Cell</journal_title><author>Ho</author><volume>26</volume><first_page>2655</first_page><cYear>2015</cYear><article_title>The HOPS/class C Vps complex tethers membranes by binding to one Rab GTPase in each apposed membrane</article_title><doi>10.1091/mbc.E14-04-0922</doi></citation><citation key="bib25"><journal_title>PLoS One</journal_title><author>Horchani</author><volume>9</volume><cYear>2014</cYear><article_title>Interaction of the spo20 membrane-sensor motif with phosphatidic acid and other anionic lipids, and influence of the membrane environment</article_title><doi>10.1371/journal.pone.0113484</doi><elocation_id>e113484</elocation_id></citation><citation key="bib26"><journal_title>Journal of Molecular Biology</journal_title><author>Hristova</author><volume>290</volume><first_page>99</first_page><cYear>1999</cYear><article_title>An amphipathic alpha-helix at a membrane interface: a structural study using a novel X-ray diffraction method</article_title><doi>10.1006/jmbi.1999.2840</doi></citation><citation key="bib27"><journal_title>Journal of Cell Biology</journal_title><author>Infante</author><volume>145</volume><first_page>83</first_page><cYear>1999</cYear><article_title>GMAP-210, A cis-Golgi network-associated protein, is a minus end microtubule-binding protein</article_title><doi>10.1083/jcb.145.1.83</doi></citation><citation key="bib28"><journal_title>FEBS Journal</journal_title><author>Ishida</author><volume>282</volume><first_page>2232</first_page><cYear>2015</cYear><article_title>GM130 is a parallel tetramer with a flexible rod-like structure and N-terminally open (Y-shaped) and closed (I-shaped) conformations</article_title><doi>10.1111/febs.13271</doi></citation><citation key="bib29"><journal_title>Journal of Cell Biology</journal_title><author>Klemm</author><volume>185</volume><first_page>601</first_page><cYear>2009</cYear><article_title>Segregation of sphingolipids and sterols during formation of secretory vesicles at the trans-Golgi network</article_title><doi>10.1083/jcb.200901145</doi></citation><citation key="bib30"><journal_title>Cell</journal_title><author>Kobayashi</author><volume>55</volume><first_page>797</first_page><cYear>1988</cYear><article_title>ATP-dependent fusion of liposomes with the Golgi apparatus of perforated cells</article_title><doi>10.1016/0092-8674(88)90135-3</doi></citation><citation key="bib31"><journal_title>FEBS Letters</journal_title><author>Kuhlee</author><volume>589</volume><first_page>2487</first_page><cYear>2015</cYear><article_title>Functional homologies in vesicle tethering</article_title><doi>10.1016/j.febslet.2015.06.001</doi></citation><citation key="bib32"><journal_title>Journal of Cell Biology</journal_title><author>Ladinsky</author><volume>144</volume><first_page>1135</first_page><cYear>1999</cYear><article_title>Golgi structure in three dimensions: functional insights from the normal rat kidney cell</article_title><doi>10.1083/jcb.144.6.1135</doi></citation><citation key="bib33"><journal_title>Annual Review of Cell and Developmental Biology</journal_title><author>Malhotra</author><volume>31</volume><first_page>109</first_page><cYear>2015</cYear><article_title>The pathway of collagen secretion</article_title><doi>10.1146/annurev-cellbio-100913-013002</doi></citation><citation key="bib34"><journal_title>Cell</journal_title><author>Malhotra</author><volume>58</volume><first_page>329</first_page><cYear>1989</cYear><article_title>Purification of a novel class of coated vesicles mediating biosynthetic protein transport through the Golgi stack</article_title><doi>10.1016/0092-8674(89)90847-7</doi></citation><citation key="bib35"><journal_title>Science</journal_title><author>Malsam</author><volume>307</volume><first_page>1095</first_page><cYear>2005</cYear><article_title>Golgin tethers define subpopulations of COPI vesicles</article_title><doi>10.1126/science.1108061</doi></citation><citation key="bib36"><journal_title>PNAS</journal_title><author>Marsh</author><volume>98</volume><first_page>2399</first_page><cYear>2001</cYear><article_title>Organellar relationships in the Golgi region of the pancreatic beta cell line, HIT-T15, visualized by high resolution electron tomography</article_title><doi>10.1073/pnas.051631998</doi></citation><citation key="bib37"><journal_title>Biochemistry</journal_title><author>Mesmin</author><volume>46</volume><first_page>1779</first_page><cYear>2007</cYear><article_title>Two lipid-packing sensor motifs contribute to the sensitivity of ArfGAP1 to membrane curvature</article_title><doi>10.1021/bi062288w</doi></citation><citation key="bib38"><journal_title>Cold Spring Harbor Perspectives in Biology</journal_title><author>Munro</author><volume>3</volume><first_page>a005256</first_page><cYear>2011</cYear><article_title>The Golgin coiled-coil proteins of the Golgi apparatus</article_title><doi>10.1101/cshperspect.a005256</doi></citation><citation key="bib39"><journal_title>Nature</journal_title><author>Ohya</author><volume>459</volume><first_page>1091</first_page><cYear>2009</cYear><article_title>Reconstitution of Rab- and SNARE-dependent membrane fusion by synthetic endosomes</article_title><doi>10.1038/nature08107</doi></citation><citation key="bib40"><journal_title>Traffic</journal_title><author>Pernet-Gallay</author><volume>3</volume><first_page>822</first_page><cYear>2002</cYear><article_title>The overexpression of GMAP-210 blocks anterograde and retrograde transport between the ER and the Golgi apparatus</article_title><doi>10.1034/j.1600-0854.2002.31107.x</doi></citation><citation key="bib41"><journal_title>Journal of Cell Biology</journal_title><author>Pranke</author><volume>194</volume><first_page>89</first_page><cYear>2011</cYear><article_title>α-Synuclein and ALPS motifs are membrane curvature sensors whose contrasting chemistry mediates selective vesicle binding</article_title><doi>10.1083/jcb.201011118</doi></citation><citation key="bib42"><journal_title>Physical Chemistry Chemical Physics</journal_title><author>Risselada</author><volume>11</volume><first_page>2056</first_page><cYear>2009</cYear><article_title>Curvature effects on lipid packing and dynamics in liposomes revealed by coarse grained molecular dynamics simulations</article_title><doi>10.1039/b818782g</doi></citation><citation key="bib43"><journal_title>Journal of Cell Science</journal_title><author>Roboti</author><volume>128</volume><first_page>1595</first_page><cYear>2015</cYear><article_title>The golgin GMAP-210 is required for efficient membrane trafficking in the early secretory pathway</article_title><doi>10.1242/jcs.166710</doi></citation><citation key="bib44"><journal_title>Molecular Biology of the Cell</journal_title><author>Sato</author><volume>26</volume><first_page>537</first_page><cYear>2015</cYear><article_title>Coupling of vesicle tethering and Rab binding is required for in vivo functionality of the golgin GMAP-210</article_title><doi>10.1091/mbc.E14-10-1450</doi></citation><citation key="bib45"><journal_title>The EMBO Journal</journal_title><author>Simons</author><volume>6</volume><first_page>2241</first_page><cYear>1987</cYear><article_title>Perforated MDCK cells support intracellular transport</article_title></citation><citation key="bib46"><journal_title>Journal of Cell Biology</journal_title><author>Sinka</author><volume>183</volume><first_page>607</first_page><cYear>2008</cYear><article_title>Golgi coiled-coil proteins contain multiple binding sites for Rab family G proteins</article_title><doi>10.1083/jcb.200808018</doi></citation><citation key="bib47"><journal_title>New England Journal of Medicine</journal_title><author>Smits</author><volume>362</volume><first_page>206</first_page><cYear>2010</cYear><article_title>Lethal skeletal dysplasia in mice and humans lacking the Golgin GMAP-210</article_title><doi>10.1056/NEJMoa0900158</doi></citation><citation key="bib48"><journal_title>Biophysical Journal</journal_title><author>Vamparys</author><volume>104</volume><first_page>585</first_page><cYear>2013</cYear><article_title>Conical lipids in flat bilayers induce packing defects similar to that induced by positive curvature</article_title><doi>10.1016/j.bpj.2012.11.3836</doi></citation><citation key="bib49"><journal_title>Nature Reviews Molecular Cell Biology</journal_title><author>van Meer</author><volume>9</volume><first_page>112</first_page><cYear>2008</cYear><article_title>Membrane lipids: where they are and how they behave</article_title><doi>10.1038/nrm2330</doi></citation><citation key="bib50"><journal_title>Nature Communications</journal_title><author>Vanni</author><volume>5</volume><first_page>4916</first_page><cYear>2014</cYear><article_title>A sub-nanometre view of how membrane curvature and composition modulate lipid packing and protein recruitment</article_title><doi>10.1038/ncomms5916</doi></citation><citation key="bib51"><journal_title>Biophysical Journal</journal_title><author>Vanni</author><volume>104</volume><first_page>575</first_page><cYear>2013</cYear><article_title>Amphipathic lipid packing sensor motifs: probing bilayer defects with hydrophobic residues</article_title><doi>10.1016/j.bpj.2012.11.3837</doi></citation><citation key="bib52"><journal_title>Current Opinion in Cell Biology</journal_title><author>Verhey</author><volume>41</volume><first_page>109</first_page><cYear>2016</cYear><article_title>Permeability barriers for generating a unique ciliary protein and lipid composition</article_title><doi>10.1016/j.ceb.2016.05.004</doi></citation><citation key="bib53"><journal_title>Frontiers in Cell and Developmental Biology</journal_title><author>Witkos</author><volume>3</volume><cYear>2015</cYear><article_title>The Golgin family of coiled-coil tethering proteins</article_title><doi>10.3389/fcell.2015.00086</doi><elocation_id>86</elocation_id></citation><citation key="bib54"><journal_title>Science</journal_title><author>Wong</author><volume>346</volume><first_page>1256898</first_page><cYear>2014</cYear><article_title>Membrane trafficking. The specificity of vesicle traffic to the Golgi is encoded in the golgin coiled-coil proteins</article_title><doi>10.1126/science.1256898</doi></citation></citation_list><component_list><component parent_relation="isPartOf"><titles><title>Abstract</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.16988.001</doi><resource>https://elifesciences.org/articles/16988#abstract</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1. Preference of the Golgi for small unsaturated liposomes and biochemical properties of GMAP-210 ALPS motif.</title><subtitle>(A) Principles of the Kobayashi-Pagano experiment. (B) Typical observations. RPE1 cells stably expressing Rab6-GFP were perforated and incubated with DOPC liposomes (labeled with 1 mol% Rhod-PE). The liposomes were prepared by sonication or by extrusion through 200 nm (diameter) filters. The actual liposome radius (Rh) is indicated. Images were acquired with an epifluorescence microscope. (C, D) Experiments similar to that shown in (B) with liposomes of defined composition (C) or size (D). In (C) all liposomes were obtained by extrusion through 30 nm filters. In (D) all liposomes were used at a concentration of 250 µM lipids. The liposome fluorescence intensity in the Golgi area was determined. Each point corresponds to one cell from two to three independent experiments. (E) Domain organization of GMAP-210 and minimal model for membrane tethering (Drin et al., 2008). (F) Effects of membrane curvature and lipid unsaturation on the binding of the N-ter region of GMAP-210 to liposomes. Liposome binding was determined by monitoring the NBD fluorescence intensity. The plot shows the effect of liposome size and unsaturation from two independent experiments (triangles and inverted triangles). The fluorescence in solution was set at 1. Bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.002</doi><resource>https://elifesciences.org/articles/16988#fig1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 1. Liposome tethering properties of perforated cells.</title><subtitle>Large fields of RPE1 cells stably expressing Rab6-GFP after perforation and incubation with DOPC liposomes (extrusion 200 nm or 30 nm). Scale bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.003</doi><resource>https://elifesciences.org/articles/16988/figures#fig1s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 1—figure supplement 2. Cumulative effects of membrane curvature and lipid unsaturation on the binding of the N-ter region of GMAP-210 to liposomes.</title><subtitle>Fluorescence spectra of mixtures containing 0.125 µM NBD-labeled GMAP-210 (fragment [1–375]) and liposomes (150 µM lipids) of the indicated size and composition. The fluorescence intensity at 540 nm was measured to build the plot of Figure 1F.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.004</doi><resource>https://elifesciences.org/articles/16988/figures#fig1s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2. GMAP-210 is responsible for the ability of the Golgi to capture liposomes.</title><subtitle>(A) RPE1 cells were treated with siRNA against GMAP-210 or with control siRNA. After 72 hr, the cells were perforated and small DOPC liposomes (250 µM lipids), which were obtained by extrusion through 30 nm polycarbonate filters, were applied. Liposome capture was quantified as in Figure 1. The western blot shows the amount of GMAP-210 in the siRNA-treated cells. (B) Immunofluorescence characterization of RPE1 cells after treatment with anti GMAP-210 siRNA or control siRNA followed by perforation and incubation with small DOPC liposomes obtained by extrusion. The actual liposome radius is indicated. The images show one Z section as obtained in a confocal microscope. The profiles show the fluorescence intensity of the three markers along the horizontal lines as indicated in the merged images. Bars: 10 µm. Error bars: SEM (n = 4)</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.005</doi><resource>https://elifesciences.org/articles/16988#fig2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 2—figure supplement 1. GMAP-210 is responsible for the ability of the Golgi to capture liposomes.</title><subtitle>(A) RPE1 cells were treated with siRNA against GMAP-210 or with control siRNA. After 72 hr, the cells were perforated and small DOPC liposomes (250 µM lipids), which were obtained by extrusion through 30 nm polycarbonate filters, were applied. (B) Quantification of liposome capture from 4 independent experiments similar to (A). (C) Western blot analysis of the siRNA-treated cells. The data shown in (B) and (C) were used to build the bar plots shown in Figure 2A. Scale bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.006</doi><resource>https://elifesciences.org/articles/16988/figures#fig2s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3. Mitochondria-anchored GMAP-210 ALPS competes with Golgi mini stacks for the capture of small liposomes.</title><subtitle>(A) Scheme of the constructs and principle of the experiment. Cells expressing ALPS-ACC1-GFP-FKBP and Mito-FRB were treated with nocodazole to disperse the Golgi apparatus into mini stacks. Thereafter, the cells were either treated with rapamycin or not, perforated, and incubated with small DOPC liposomes (extrusion: 30 nm). (B) In the absence rapamycin, small liposomes (extrusion 30 nm) colocalize with ALPS-ACC1-GFP-FKBP and with the Golgi mini stacks (as stained by anti GM130 antibody). (C) In the presence rapamycin, the small liposomes and ALPS-ACC1-GFP-FKBP colocalize in many regions that are negative for GM130. All images were acquired with a confocal microscope and were analyzed using Volocity software. These experiments were repeated three times. Data show representative images. Scale bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.007</doi><resource>https://elifesciences.org/articles/16988#fig3</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 1. Competition between mitochondria-anchored GMAP-210 ALPS and Golgi mini stacks for liposome capture.</title><subtitle>Cells were treated with nocodazole to disperse the Golgi apparatus into mini stacks and then with rapamycin to attach ALPS-ACC1-GFP-FKBP to mitochondria through Mito-FRB. Thereafter, the cells were perforated and incubated with small DOPC liposomes (extrusion: 30 nm). The mitochondria were visualized with MitoTracker. Images were acquired with a confocal microscope. Note that cell perforation causes the mitochondria network to break into small circular elements, around which ALPS-ACC1-GFP-FKBP and small DOPC liposomes were found. These experiments were repeated three times. Data show representative images. Scale bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.008</doi><resource>https://elifesciences.org/articles/16988/figures#fig3s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 3—figure supplement 2. Mitochondria-anchored ALPS of GMAP-210 captures small but not large liposomes.</title><subtitle>Cells were treated with nocodazole to disperse the Golgi apparatus into mini stacks and with rapamycin to attach ALPS-ACC1-GFP-FKBP to mitochondria through Mito-FRB. Thereafter, the cells were perforated and incubated with small (extrusion: 30 nm) or large (extrusion: 200 nm) DOPC liposomes. After several washes, images were acquired with a confocal microscope and were analyzed using Volocity software. Note that only small liposomes are captured by the ALPS construct. These experiments were repeated three times. Data show representative images. Scare bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.009</doi><resource>https://elifesciences.org/articles/16988/figures#fig3s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4. The ALPS motif of GMAP-210 targets cis Golgi vesicles.</title><subtitle>(A) Scheme of the constructs. The first construct corresponds to the N-terminal region of GMAP-210 (aa 1–375; ALPS = 1–38) fused to a C-ter fluorophore (GFP or mCherry). Alternatively, the ALPS motif of GMAP-210 was introduced upstream of an artificial coiled-coil (ACC1). (B) Subcellular localization of GCC- and ACC-based constructs by confocal fluorescence microscopy. Golgi localization was preserved by replacing the coiled-coil region of GMAP-210 (GCC) by an artificial coiled-coil (ACC1), but was abolished by deletion of the ALPS motif. Immunofluorescence of cells expressing ALPS-ACC1-GFP shows low colocalization with TGN46, intermediate overlap with GM130, and high colocalization with endogenous GMAP-210. All images were acquired with a confocal microscope and were analyzed using Volocity software. Scale bars: 10 µm, Z plane. (C) Immunogold EM of RPE1 cells expressing ALPS-ACC1-GFP. Scale bars: 10 µm (B) 100 nm (C). These experiments were repeated at least three times, except EM, which was repeated twice. Data show representative images.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.010</doi><resource>https://elifesciences.org/articles/16988#fig4</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 1. GMAP-210 depletion by siRNA does not affect the Golgi targeting of ALPS-containing probes.</title><subtitle>(A) RPE1 cells stably expressing ArfGAP1(R50K mutant)-GFP were transfected with siGMAP-210#2 or control siRNA for 72 hr. (B) RPE1 cells were transfected with siGMAP-210#2 or with control siRNA for 72 hr and then with ALPS-ACC1-GFP for 7 hr. In A and B, cells were then fixed, immunostained with antibodies against GMAP-210 and the cis-Golgi marker GalNT2, and visualized by confocal microscopy. Z plane, scale bar: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.011</doi><resource>https://elifesciences.org/articles/16988/figures#fig4s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 4—figure supplement 2. ALPS-ACC1-GFP increases the liposome capture properties of cells.</title><subtitle>RPE1 cells were transitory transfected with ALPS-ACC1-GFP for 7 hr. Thereafter, the cells were perforated and 250 µM DOPC liposomes (extrusion 0.03 µm) were added for 5 min at 30°C. After several washes, images were acquired with a wide-field microscope and processed with ImageJ. Perforated cells are indicated by an asterisk. Those that express ALPS-ACC1-GFP show much higher liposome signal than those that do not express the construct. Scale bar: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.012</doi><resource>https://elifesciences.org/articles/16988/figures#fig4s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 5. Selective targeting of the ALPS motif of GMAP-210 to cis Golgi vesicles without stereospecific interactions.</title><subtitle>(A, B) Sequence comparison of the ALPS motif of GMAP-210 and the corresponding inverted motif (invALPS). The two sequences have low identity (≈ 25%; A), but helical wheel-representations (B) show that they display the same amphipathic character. Helical representations were made with Heliquest (Gautier et al., 2008).(C) A coiled-coil construct harboring an inverted ALPS motif (invALPS-ACC2-GFP) displays the same subcellular localization as a construct harboring the original ALPS motif (ALPS-ACC1-mCherry). (D) Pearson coefficient between the green and red channels for the constructs shown in (C) as well as for other combinations of constructs or endogenous proteins. 30 cells were examined from 3 independent experiments. The vertical black bars show the mean ± SD. All images were acquired with a confocal microscope and were analyzed using Volocity software. Scale bars: 10 µm, Z plane.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.013</doi><resource>https://elifesciences.org/articles/16988#fig5</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6. The ALPS motif of GMAP-210 interacts with Golgi vesicles as an amphipathic helix.</title><subtitle>(A) Effect of mutations disrupting the amphipathic character of the ALPS motif of GMAP-210. For each mutant, a helical plot made with Heliquest (Gautier et al., 2008) is shown. Mutation L12D introduces a negative charge in the hydrophobic face. Ins20AA corresponds to 2 alanines inserted in the middle of the ALPS sequence. G11P should rigidify the sequence. (B) Effect of gradual truncation of the ALPS sequence. All mutants shown in (A) and (B) were derived from ALPS-ACC1-GFP. (C) Quantification. For both (A) and (B), ten cells were analyzed for each mutant. Once the background was subtracted, two ROI with same area were applied in the Golgi and in the cytosol. The average fluorescence was determined in each ROI and the Golgi/cytosol ratio was then calculated. All images were acquired with a confocal microscope and were analyzed using Volocity software. Scale bars: 10 µm, Z projections. Scale bars: 10 µm. The figure shows one experiment where all constructed were transfected in parallel and ten cells were analyzed for each condition. The horizontal bars show the means. Other experiments were performed with subgroups of mutants and gave similar results.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.014</doi><resource>https://elifesciences.org/articles/16988#fig6</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 6—figure supplement 1. Effects of point mutations on the Golgi localization of the ALPS motif of GMAP-210.</title><subtitle>This figure shows different images of the subcellular localization of some mutants described in Figure 6. The mutants G11P and [1–6/29–38] have a clear Golgi localization. However, their cytosolic fluorescent signal is much higher than that of wild-type ALPS-ACC1-GFP, implying a lower Golgi/cytosol ratio (see Figure 6C). Scale bar: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.015</doi><resource>https://elifesciences.org/articles/16988/figures#fig6s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 7. The sparse distribution of hydrophobic residue in ALPS determines its selective cellular targeting and its sensitivity to membrane curvature.</title><subtitle>(A) Sequence comparison between the ALPS motif of GMAP-210 and the amphipathic helices of Arf1 and Sar1. Hydrophobic residues are shown in bold. In ALPS, most hydrophobic residues are sparse. In Arf1 and Sar, most hydrophobic residues are paired. By removing polar residues between sparse hydrophobic residues, the ALPS sequence was condensed (condALPS) to create hydrophobic pairs. (B) Localization of ALPS-ACC1-GFP, condALPS-ACC1-GFP, and Sar1-ACC1-GFP in RPE1 cells. Lipid droplets were revealed by lipidTox staining (red). Imaged were acquired from living cells using a spinning disk microscope. Z planes, scale bar: 10 µm. (C) Effect of adding hydrophobic residues in the ALPS 1–38 sequence or in the 8–30 truncated mutant. All mutants derived from the ALPS-ACC1-GFP construct. (D) Sensitivity of ALPS and condALPS peptides to membrane curvature. The peptides (1 µM) were incubated with liposomes (lipids 0.5 mM) of defined size. Tryptophan fluorescence was measured between 300 to 450 nm. The right plot shows the relative fluorescence at 340 nm as a function of liposome radius, setting the fluorescence in solution at 1. Error bars: SEM from four independent experiments. Scale bars: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.016</doi><resource>https://elifesciences.org/articles/16988#fig7</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 7—figure supplement 1. Subcellular localization of ALPS-ACC1-GFP, condALPS-ACC1-GFP, and Sar1-ACC1-GFP in RPE1 and U2OS cells.</title><subtitle>In RPE1 cells, condALPS-ACC1-GFP and Sar1-ACC1-GFP intensively labeled lipid droplets and to a lesser extent the ER and the nuclear envelope. In U2OS cells, the ER localization of condALPS-ACC1-GFP and Sar1-ACC1-GFP is more obvious given the reticular pattern of the ER in these cells. Imaged were acquired from living cells using a spinning disk microscope. Z planes, scale bar: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.017</doi><resource>https://elifesciences.org/articles/16988/figures#fig7s1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 7—figure supplement 2. The sparse distribution of hydrophobic residue in ALPS determines its selective cellular targeting.</title><subtitle>This figure shows the subcellular localization of the same constructs as shown in Figure 7 but in comparison with the cis Golgi marker GM130. Whereas wild-type ALPS displays Golgi localization, mutants with hydrophobic pairs bind to other organelles besides the Golgi (e.g. nuclear envelope, ER network, lipid droplets). Scale bar: 10 µm.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.018</doi><resource>https://elifesciences.org/articles/16988/figures#fig7s2</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Figure 8. Distribution of lipid packing defects in model cis Golgi membranes.</title><subtitle>(A) Typical coarse grained models of lipid bilayers with a lipid composition similar to that of COPI vesicles (Brügger et al., 2000) and with a flat, tubular or spherical geometry. (B) Lipid composition of the bilayers. (C) Lipid packing defect distribution. For comparison, the results from simulations with flat POPC or spherical DOPC membranes (Vanni et al., 2014) are also shown. The inset shows the ratio between the number of defects in the vesicle or in the tube as compared to the flat membrane.</subtitle></titles><format mime_type="image/tiff"/><doi_data><doi>10.7554/eLife.16988.019</doi><resource>https://elifesciences.org/articles/16988#fig8</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Decision letter</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.16988.020</doi><resource>https://elifesciences.org/articles/16988#SA1</resource></doi_data></component><component parent_relation="isPartOf"><titles><title>Author response</title></titles><format mime_type="text/plain"/><doi_data><doi>10.7554/eLife.16988.021</doi><resource>https://elifesciences.org/articles/16988#SA2</resource></doi_data></component></component_list></journal_article></journal></body></doi_batch>
+<?xml version="1.0" encoding="utf-8"?>
+<doi_batch version="4.4.1" xmlns="http://www.crossref.org/schema/4.4.1" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:ct="http://www.crossref.org/clinicaltrials.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schemas/crossref4.4.1.xsd">
+	<head>
+		<doi_batch_id>elife-crossref-16988-20170717071707</doi_batch_id>
+		<timestamp>20170717071707</timestamp>
+		<depositor>
+			<depositor_name>eLife</depositor_name>
+			<email_address>production@elifesciences.org</email_address>
+		</depositor>
+		<registrant>eLife</registrant>
+	</head>
+	<body>
+		<journal>
+			<journal_metadata language="en">
+				<full_title>eLife</full_title>
+				<issn media_type="electronic">2050-084X</issn>
+			</journal_metadata>
+			<journal_issue>
+				<publication_date media_type="online">
+					<month>07</month>
+					<day>26</day>
+					<year>2016</year>
+				</publication_date>
+				<journal_volume>
+					<volume>5</volume>
+				</journal_volume>
+			</journal_issue>
+			<journal_article publication_type="full_text" reference_distribution_opts="any">
+				<titles>
+					<title>A filter at the entrance of the Golgi that selects vesicles according to size and bulk lipid composition</title>
+				</titles>
+				<contributors>
+					<person_name contributor_role="author" sequence="first">
+						<given_name>Maud</given_name>
+						<surname>Magdeleine</surname>
+						<affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Romain</given_name>
+						<surname>Gautier</surname>
+						<affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Pierre</given_name>
+						<surname>Gounon</surname>
+						<affiliation>Centre Commun de Microscopie Appliquée, Université Côte d'Azur, Nice, France</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Hélène</given_name>
+						<surname>Barelli</surname>
+						<affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Stefano</given_name>
+						<surname>Vanni</surname>
+						<affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0003-2146-1140</ORCID>
+					</person_name>
+					<person_name contributor_role="author" sequence="additional">
+						<given_name>Bruno</given_name>
+						<surname>Antonny</surname>
+						<affiliation>CNRS, Institut de Pharmacologie Moléculaire et Cellulaire, Université Côte d'Azur, Valbonne, France</affiliation>
+						<ORCID authenticated="true">http://orcid.org/0000-0002-9166-8668</ORCID>
+					</person_name>
+				</contributors>
+				<jats:abstract>
+					<jats:p>When small phosphatidylcholine liposomes are added to perforated cells, they bind preferentially to the Golgi suggesting an exceptional avidity of this organelle for curved membranes without stereospecific interactions. We show that the cis golgin GMAP-210 accounts for this property. First, the liposome tethering properties of the Golgi resembles that of the amphipathic lipid-packing sensor (ALPS) motif of GMAP-210: both preferred small (radius &lt; 40 nm) liposomes made of monounsaturated but not saturated lipids. Second, reducing GMAP-210 levels or redirecting its ALPS motif to mitochondria decreased liposome capture by the Golgi. Extensive mutagenesis analysis suggests that GMAP-210 tethers authentic transport vesicles via the same mechanism whereby the ALPS motif senses lipid-packing defects at the vesicle surface through its regularly spaced hydrophobic residues. We conclude that the Golgi uses GMAP-210 as a filter to select transport vesicles according to their size and bulk lipid composition.</jats:p>
+				</jats:abstract>
+				<publication_date media_type="online">
+					<month>07</month>
+					<day>26</day>
+					<year>2016</year>
+				</publication_date>
+				<publisher_item>
+					<item_number item_number_type="article_number">e16988</item_number>
+					<identifier id_type="doi">10.7554/eLife.16988</identifier>
+				</publisher_item>
+				<fr:program name="fundref">
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							Agence Nationale de la Recherche
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100001665</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">ANR-11-LABX-0028-01</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">
+							European Research Council
+							<fr:assertion name="funder_identifier">http://dx.doi.org/10.13039/501100000781</fr:assertion>
+						</fr:assertion>
+						<fr:assertion name="award_number">Advanced Grant 268 888</fr:assertion>
+					</fr:assertion>
+					<fr:assertion name="fundgroup">
+						<fr:assertion name="funder_name">Conseil Départemental des Alpes Maritimes</fr:assertion>
+						<fr:assertion name="award_number">appel à projet santé CG06 2013-2014</fr:assertion>
+					</fr:assertion>
+				</fr:program>
+				<ai:program name="AccessIndicators">
+					<ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+					<ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+				</ai:program>
+				<archive_locations>
+					<archive name="CLOCKSS"/>
+				</archive_locations>
+				<doi_data>
+					<doi>10.7554/eLife.16988</doi>
+					<resource>https://elifesciences.org/articles/16988</resource>
+					<collection property="text-mining">
+						<item>
+							<resource mime_type="application/pdf">https://cdn.elifesciences.org/articles/16988/elife-16988-v1.pdf</resource>
+						</item>
+						<item>
+							<resource mime_type="application/xml">https://cdn.elifesciences.org/articles/16988/elife-16988-v1.xml</resource>
+						</item>
+					</collection>
+				</doi_data>
+				<citation_list>
+					<citation key="bib1">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Ambroggio</author>
+						<volume>29</volume>
+						<first_page>292</first_page>
+						<cYear>2010</cYear>
+						<article_title>ArfGAP1 generates an Arf1 gradient on continuous lipid membranes displaying flat and curved regions</article_title>
+						<doi>10.1038/emboj.2009.341</doi>
+					</citation>
+					<citation key="bib2">
+						<journal_title>Annual Review of Biochemistry</journal_title>
+						<author>Antonny</author>
+						<volume>80</volume>
+						<first_page>101</first_page>
+						<cYear>2011</cYear>
+						<article_title>Mechanisms of membrane curvature sensing</article_title>
+						<doi>10.1146/annurev-biochem-052809-155121</doi>
+					</citation>
+					<citation key="bib3">
+						<journal_title>Cell</journal_title>
+						<author>Barlowe</author>
+						<volume>77</volume>
+						<first_page>895</first_page>
+						<cYear>1994</cYear>
+						<article_title>COPII: a membrane coat formed by Sec proteins that drive vesicle budding from the endoplasmic reticulum</article_title>
+						<doi>10.1016/0092-8674(94)90138-4</doi>
+					</citation>
+					<citation key="bib4">
+						<journal_title>Developmental Cell</journal_title>
+						<author>Bigay</author>
+						<volume>23</volume>
+						<first_page>886</first_page>
+						<cYear>2012</cYear>
+						<article_title>Curvature, lipid packing, and electrostatics of membrane organelles: defining cellular territories in determining specificity</article_title>
+						<doi>10.1016/j.devcel.2012.10.009</doi>
+					</citation>
+					<citation key="bib5">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Bigay</author>
+						<volume>24</volume>
+						<first_page>2244</first_page>
+						<cYear>2005</cYear>
+						<article_title>ArfGAP1 responds to membrane curvature through the folding of a lipid packing sensor motif</article_title>
+						<doi>10.1038/sj.emboj.7600714</doi>
+					</citation>
+					<citation key="bib6">
+						<journal_title>Nature</journal_title>
+						<author>Bigay</author>
+						<volume>426</volume>
+						<first_page>563</first_page>
+						<cYear>2003</cYear>
+						<article_title>Lipid packing sensed by ArfGAP1 couples COPI coat disassembly to membrane bilayer curvature</article_title>
+						<doi>10.1038/nature02108</doi>
+					</citation>
+					<citation key="bib7">
+						<journal_title>Cell</journal_title>
+						<author>Bonifacino</author>
+						<volume>116</volume>
+						<first_page>153</first_page>
+						<cYear>2004</cYear>
+						<article_title>The mechanisms of vesicle budding and fusion</article_title>
+						<doi>10.1016/S0092-8674(03)01079-1</doi>
+					</citation>
+					<citation key="bib8">
+						<journal_title>Molecular Membrane Biology</journal_title>
+						<author>Brown</author>
+						<volume>27</volume>
+						<first_page>457</first_page>
+						<cYear>2010</cYear>
+						<article_title>An update on transport vesicle tethering</article_title>
+						<doi>10.3109/09687688.2010.501765</doi>
+					</citation>
+					<citation key="bib9">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Brügger</author>
+						<volume>151</volume>
+						<first_page>507</first_page>
+						<cYear>2000</cYear>
+						<article_title>Evidence for segregation of sphingomyelin and cholesterol during formation of COPI-coated vesicles</article_title>
+						<doi>10.1083/jcb.151.3.507</doi>
+					</citation>
+					<citation key="bib10">
+						<journal_title>Developmental Cell</journal_title>
+						<author>Cai</author>
+						<volume>12</volume>
+						<first_page>671</first_page>
+						<cYear>2007</cYear>
+						<article_title>Coats, tethers, Rabs, and SNAREs work together to mediate the intracellular destination of a transport vesicle</article_title>
+						<doi>10.1016/j.devcel.2007.04.005</doi>
+					</citation>
+					<citation key="bib11">
+						<journal_title>BMC Biology</journal_title>
+						<author>Cardenas</author>
+						<volume>7</volume>
+						<first_page>56</first_page>
+						<cYear>2009</cYear>
+						<article_title>Golgi localisation of GMAP210 requires two distinct cis-membrane binding mechanisms</article_title>
+						<doi>10.1186/1741-7007-7-56</doi>
+					</citation>
+					<citation key="bib12">
+						<journal_title>Current Opinion in Structural Biology</journal_title>
+						<author>Cherfils</author>
+						<volume>29</volume>
+						<first_page>67</first_page>
+						<cYear>2014</cYear>
+						<article_title>Arf GTPases and their effectors: assembling multivalent membrane-binding platforms</article_title>
+						<doi>10.1016/j.sbi.2014.09.007</doi>
+					</citation>
+					<citation key="bib13">
+						<journal_title>eLife</journal_title>
+						<author>Cheung</author>
+						<volume>4</volume>
+						<cYear>2015</cYear>
+						<article_title>Protein flexibility is required for vesicle tethering at the Golgi</article_title>
+						<doi>10.7554/eLife.12790</doi>
+						<elocation_id>e12790</elocation_id>
+					</citation>
+					<citation key="bib14">
+						<journal_title>Biophysical Journal</journal_title>
+						<author>Cui</author>
+						<volume>100</volume>
+						<first_page>1271</first_page>
+						<cYear>2011</cYear>
+						<article_title>Mechanism of membrane curvature sensing by amphipathic helix containing proteins</article_title>
+						<doi>10.1016/j.bpj.2011.01.036</doi>
+					</citation>
+					<citation key="bib15">
+						<journal_title>PLoS One</journal_title>
+						<author>Doucet</author>
+						<volume>10</volume>
+						<cYear>2015</cYear>
+						<article_title>Membrane curvature sensing by amphipathic helices Is modulated by the surrounding protein backbone</article_title>
+						<doi>10.1371/journal.pone.0137965</doi>
+						<elocation_id>e0137965</elocation_id>
+					</citation>
+					<citation key="bib16">
+						<journal_title>FEBS Letters</journal_title>
+						<author>Drin</author>
+						<volume>584</volume>
+						<first_page>1840</first_page>
+						<cYear>2010</cYear>
+						<article_title>Amphipathic helices and membrane curvature</article_title>
+						<doi>10.1016/j.febslet.2009.10.022</doi>
+					</citation>
+					<citation key="bib17">
+						<journal_title>Nature Structural &amp; Molecular Biology</journal_title>
+						<author>Drin</author>
+						<volume>14</volume>
+						<first_page>138</first_page>
+						<cYear>2007</cYear>
+						<article_title>A general amphipathic alpha-helical motif for sensing membrane curvature</article_title>
+						<doi>10.1038/nsmb1194</doi>
+					</citation>
+					<citation key="bib18">
+						<journal_title>Science</journal_title>
+						<author>Drin</author>
+						<volume>320</volume>
+						<first_page>670</first_page>
+						<cYear>2008</cYear>
+						<article_title>Asymmetric tethering of flat and curved lipid membranes by a golgin</article_title>
+						<doi>10.1126/science.1155821</doi>
+					</citation>
+					<citation key="bib19">
+						<journal_title>PLoS Genetics</journal_title>
+						<author>Follit</author>
+						<volume>4</volume>
+						<cYear>2008</cYear>
+						<article_title>The Golgin GMAP210/TRIP11 anchors IFT20 to the Golgi complex</article_title>
+						<doi>10.1371/journal.pgen.1000315</doi>
+						<elocation_id>e1000315</elocation_id>
+					</citation>
+					<citation key="bib20">
+						<journal_title>Bioinformatics</journal_title>
+						<author>Gautier</author>
+						<volume>24</volume>
+						<first_page>2101</first_page>
+						<cYear>2008</cYear>
+						<article_title>HELIQUEST: a web server to screen sequences with specific -helical properties</article_title>
+						<doi>10.1093/bioinformatics/btn392</doi>
+					</citation>
+					<citation key="bib21">
+						<journal_title>Trends in Cell Biology</journal_title>
+						<author>Gillingham</author>
+						<volume>26</volume>
+						<first_page>399</first_page>
+						<cYear>2016</cYear>
+						<article_title>Finding the Golgi: Golgin coiled-coil proteins show the way</article_title>
+						<doi>10.1016/j.tcb.2016.02.005</doi>
+					</citation>
+					<citation key="bib22">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Gillingham</author>
+						<volume>167</volume>
+						<first_page>281</first_page>
+						<cYear>2004</cYear>
+						<article_title>The GTPase Arf1p and the ER to Golgi cargo receptor Erv14p cooperate to recruit the golgin Rud3p to the cis-Golgi</article_title>
+						<doi>10.1083/jcb.200407088</doi>
+					</citation>
+					<citation key="bib23">
+						<journal_title>Biochimica Et Biophysica Acta</journal_title>
+						<author>González-Rubio</author>
+						<volume>1808</volume>
+						<first_page>2119</first_page>
+						<cYear>2011</cYear>
+						<article_title>Amphipathic-lipid-packing-sensor interactions with lipids assessed by atomistic molecular dynamics</article_title>
+						<doi>10.1016/j.bbamem.2011.05.006</doi>
+					</citation>
+					<citation key="bib24">
+						<journal_title>Molecular Biology of the Cell</journal_title>
+						<author>Ho</author>
+						<volume>26</volume>
+						<first_page>2655</first_page>
+						<cYear>2015</cYear>
+						<article_title>The HOPS/class C Vps complex tethers membranes by binding to one Rab GTPase in each apposed membrane</article_title>
+						<doi>10.1091/mbc.E14-04-0922</doi>
+					</citation>
+					<citation key="bib25">
+						<journal_title>PLoS One</journal_title>
+						<author>Horchani</author>
+						<volume>9</volume>
+						<cYear>2014</cYear>
+						<article_title>Interaction of the spo20 membrane-sensor motif with phosphatidic acid and other anionic lipids, and influence of the membrane environment</article_title>
+						<doi>10.1371/journal.pone.0113484</doi>
+						<elocation_id>e113484</elocation_id>
+					</citation>
+					<citation key="bib26">
+						<journal_title>Journal of Molecular Biology</journal_title>
+						<author>Hristova</author>
+						<volume>290</volume>
+						<first_page>99</first_page>
+						<cYear>1999</cYear>
+						<article_title>An amphipathic alpha-helix at a membrane interface: a structural study using a novel X-ray diffraction method</article_title>
+						<doi>10.1006/jmbi.1999.2840</doi>
+					</citation>
+					<citation key="bib27">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Infante</author>
+						<volume>145</volume>
+						<first_page>83</first_page>
+						<cYear>1999</cYear>
+						<article_title>GMAP-210, A cis-Golgi network-associated protein, is a minus end microtubule-binding protein</article_title>
+						<doi>10.1083/jcb.145.1.83</doi>
+					</citation>
+					<citation key="bib28">
+						<journal_title>FEBS Journal</journal_title>
+						<author>Ishida</author>
+						<volume>282</volume>
+						<first_page>2232</first_page>
+						<cYear>2015</cYear>
+						<article_title>GM130 is a parallel tetramer with a flexible rod-like structure and N-terminally open (Y-shaped) and closed (I-shaped) conformations</article_title>
+						<doi>10.1111/febs.13271</doi>
+					</citation>
+					<citation key="bib29">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Klemm</author>
+						<volume>185</volume>
+						<first_page>601</first_page>
+						<cYear>2009</cYear>
+						<article_title>Segregation of sphingolipids and sterols during formation of secretory vesicles at the trans-Golgi network</article_title>
+						<doi>10.1083/jcb.200901145</doi>
+					</citation>
+					<citation key="bib30">
+						<journal_title>Cell</journal_title>
+						<author>Kobayashi</author>
+						<volume>55</volume>
+						<first_page>797</first_page>
+						<cYear>1988</cYear>
+						<article_title>ATP-dependent fusion of liposomes with the Golgi apparatus of perforated cells</article_title>
+						<doi>10.1016/0092-8674(88)90135-3</doi>
+					</citation>
+					<citation key="bib31">
+						<journal_title>FEBS Letters</journal_title>
+						<author>Kuhlee</author>
+						<volume>589</volume>
+						<first_page>2487</first_page>
+						<cYear>2015</cYear>
+						<article_title>Functional homologies in vesicle tethering</article_title>
+						<doi>10.1016/j.febslet.2015.06.001</doi>
+					</citation>
+					<citation key="bib32">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Ladinsky</author>
+						<volume>144</volume>
+						<first_page>1135</first_page>
+						<cYear>1999</cYear>
+						<article_title>Golgi structure in three dimensions: functional insights from the normal rat kidney cell</article_title>
+						<doi>10.1083/jcb.144.6.1135</doi>
+					</citation>
+					<citation key="bib33">
+						<journal_title>Annual Review of Cell and Developmental Biology</journal_title>
+						<author>Malhotra</author>
+						<volume>31</volume>
+						<first_page>109</first_page>
+						<cYear>2015</cYear>
+						<article_title>The pathway of collagen secretion</article_title>
+						<doi>10.1146/annurev-cellbio-100913-013002</doi>
+					</citation>
+					<citation key="bib34">
+						<journal_title>Cell</journal_title>
+						<author>Malhotra</author>
+						<volume>58</volume>
+						<first_page>329</first_page>
+						<cYear>1989</cYear>
+						<article_title>Purification of a novel class of coated vesicles mediating biosynthetic protein transport through the Golgi stack</article_title>
+						<doi>10.1016/0092-8674(89)90847-7</doi>
+					</citation>
+					<citation key="bib35">
+						<journal_title>Science</journal_title>
+						<author>Malsam</author>
+						<volume>307</volume>
+						<first_page>1095</first_page>
+						<cYear>2005</cYear>
+						<article_title>Golgin tethers define subpopulations of COPI vesicles</article_title>
+						<doi>10.1126/science.1108061</doi>
+					</citation>
+					<citation key="bib36">
+						<journal_title>PNAS</journal_title>
+						<author>Marsh</author>
+						<volume>98</volume>
+						<first_page>2399</first_page>
+						<cYear>2001</cYear>
+						<article_title>Organellar relationships in the Golgi region of the pancreatic beta cell line, HIT-T15, visualized by high resolution electron tomography</article_title>
+						<doi>10.1073/pnas.051631998</doi>
+					</citation>
+					<citation key="bib37">
+						<journal_title>Biochemistry</journal_title>
+						<author>Mesmin</author>
+						<volume>46</volume>
+						<first_page>1779</first_page>
+						<cYear>2007</cYear>
+						<article_title>Two lipid-packing sensor motifs contribute to the sensitivity of ArfGAP1 to membrane curvature</article_title>
+						<doi>10.1021/bi062288w</doi>
+					</citation>
+					<citation key="bib38">
+						<journal_title>Cold Spring Harbor Perspectives in Biology</journal_title>
+						<author>Munro</author>
+						<volume>3</volume>
+						<first_page>a005256</first_page>
+						<cYear>2011</cYear>
+						<article_title>The Golgin coiled-coil proteins of the Golgi apparatus</article_title>
+						<doi>10.1101/cshperspect.a005256</doi>
+					</citation>
+					<citation key="bib39">
+						<journal_title>Nature</journal_title>
+						<author>Ohya</author>
+						<volume>459</volume>
+						<first_page>1091</first_page>
+						<cYear>2009</cYear>
+						<article_title>Reconstitution of Rab- and SNARE-dependent membrane fusion by synthetic endosomes</article_title>
+						<doi>10.1038/nature08107</doi>
+					</citation>
+					<citation key="bib40">
+						<journal_title>Traffic</journal_title>
+						<author>Pernet-Gallay</author>
+						<volume>3</volume>
+						<first_page>822</first_page>
+						<cYear>2002</cYear>
+						<article_title>The overexpression of GMAP-210 blocks anterograde and retrograde transport between the ER and the Golgi apparatus</article_title>
+						<doi>10.1034/j.1600-0854.2002.31107.x</doi>
+					</citation>
+					<citation key="bib41">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Pranke</author>
+						<volume>194</volume>
+						<first_page>89</first_page>
+						<cYear>2011</cYear>
+						<article_title>α-Synuclein and ALPS motifs are membrane curvature sensors whose contrasting chemistry mediates selective vesicle binding</article_title>
+						<doi>10.1083/jcb.201011118</doi>
+					</citation>
+					<citation key="bib42">
+						<journal_title>Physical Chemistry Chemical Physics</journal_title>
+						<author>Risselada</author>
+						<volume>11</volume>
+						<first_page>2056</first_page>
+						<cYear>2009</cYear>
+						<article_title>Curvature effects on lipid packing and dynamics in liposomes revealed by coarse grained molecular dynamics simulations</article_title>
+						<doi>10.1039/b818782g</doi>
+					</citation>
+					<citation key="bib43">
+						<journal_title>Journal of Cell Science</journal_title>
+						<author>Roboti</author>
+						<volume>128</volume>
+						<first_page>1595</first_page>
+						<cYear>2015</cYear>
+						<article_title>The golgin GMAP-210 is required for efficient membrane trafficking in the early secretory pathway</article_title>
+						<doi>10.1242/jcs.166710</doi>
+					</citation>
+					<citation key="bib44">
+						<journal_title>Molecular Biology of the Cell</journal_title>
+						<author>Sato</author>
+						<volume>26</volume>
+						<first_page>537</first_page>
+						<cYear>2015</cYear>
+						<article_title>Coupling of vesicle tethering and Rab binding is required for in vivo functionality of the golgin GMAP-210</article_title>
+						<doi>10.1091/mbc.E14-10-1450</doi>
+					</citation>
+					<citation key="bib45">
+						<journal_title>The EMBO Journal</journal_title>
+						<author>Simons</author>
+						<volume>6</volume>
+						<first_page>2241</first_page>
+						<cYear>1987</cYear>
+						<article_title>Perforated MDCK cells support intracellular transport</article_title>
+					</citation>
+					<citation key="bib46">
+						<journal_title>Journal of Cell Biology</journal_title>
+						<author>Sinka</author>
+						<volume>183</volume>
+						<first_page>607</first_page>
+						<cYear>2008</cYear>
+						<article_title>Golgi coiled-coil proteins contain multiple binding sites for Rab family G proteins</article_title>
+						<doi>10.1083/jcb.200808018</doi>
+					</citation>
+					<citation key="bib47">
+						<journal_title>New England Journal of Medicine</journal_title>
+						<author>Smits</author>
+						<volume>362</volume>
+						<first_page>206</first_page>
+						<cYear>2010</cYear>
+						<article_title>Lethal skeletal dysplasia in mice and humans lacking the Golgin GMAP-210</article_title>
+						<doi>10.1056/NEJMoa0900158</doi>
+					</citation>
+					<citation key="bib48">
+						<journal_title>Biophysical Journal</journal_title>
+						<author>Vamparys</author>
+						<volume>104</volume>
+						<first_page>585</first_page>
+						<cYear>2013</cYear>
+						<article_title>Conical lipids in flat bilayers induce packing defects similar to that induced by positive curvature</article_title>
+						<doi>10.1016/j.bpj.2012.11.3836</doi>
+					</citation>
+					<citation key="bib49">
+						<journal_title>Nature Reviews Molecular Cell Biology</journal_title>
+						<author>van Meer</author>
+						<volume>9</volume>
+						<first_page>112</first_page>
+						<cYear>2008</cYear>
+						<article_title>Membrane lipids: where they are and how they behave</article_title>
+						<doi>10.1038/nrm2330</doi>
+					</citation>
+					<citation key="bib50">
+						<journal_title>Nature Communications</journal_title>
+						<author>Vanni</author>
+						<volume>5</volume>
+						<first_page>4916</first_page>
+						<cYear>2014</cYear>
+						<article_title>A sub-nanometre view of how membrane curvature and composition modulate lipid packing and protein recruitment</article_title>
+						<doi>10.1038/ncomms5916</doi>
+					</citation>
+					<citation key="bib51">
+						<journal_title>Biophysical Journal</journal_title>
+						<author>Vanni</author>
+						<volume>104</volume>
+						<first_page>575</first_page>
+						<cYear>2013</cYear>
+						<article_title>Amphipathic lipid packing sensor motifs: probing bilayer defects with hydrophobic residues</article_title>
+						<doi>10.1016/j.bpj.2012.11.3837</doi>
+					</citation>
+					<citation key="bib52">
+						<journal_title>Current Opinion in Cell Biology</journal_title>
+						<author>Verhey</author>
+						<volume>41</volume>
+						<first_page>109</first_page>
+						<cYear>2016</cYear>
+						<article_title>Permeability barriers for generating a unique ciliary protein and lipid composition</article_title>
+						<doi>10.1016/j.ceb.2016.05.004</doi>
+					</citation>
+					<citation key="bib53">
+						<journal_title>Frontiers in Cell and Developmental Biology</journal_title>
+						<author>Witkos</author>
+						<volume>3</volume>
+						<cYear>2015</cYear>
+						<article_title>The Golgin family of coiled-coil tethering proteins</article_title>
+						<doi>10.3389/fcell.2015.00086</doi>
+						<elocation_id>86</elocation_id>
+					</citation>
+					<citation key="bib54">
+						<journal_title>Science</journal_title>
+						<author>Wong</author>
+						<volume>346</volume>
+						<first_page>1256898</first_page>
+						<cYear>2014</cYear>
+						<article_title>Membrane trafficking. The specificity of vesicle traffic to the Golgi is encoded in the golgin coiled-coil proteins</article_title>
+						<doi>10.1126/science.1256898</doi>
+					</citation>
+				</citation_list>
+				<component_list>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Abstract</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.001</doi>
+							<resource>https://elifesciences.org/articles/16988#abstract</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1. Preference of the Golgi for small unsaturated liposomes and biochemical properties of GMAP-210 ALPS motif.</title>
+							<subtitle>(A) Principles of the Kobayashi-Pagano experiment. (B) Typical observations. RPE1 cells stably expressing Rab6-GFP were perforated and incubated with DOPC liposomes (labeled with 1 mol% Rhod-PE). The liposomes were prepared by sonication or by extrusion through 200 nm (diameter) filters. The actual liposome radius (Rh) is indicated. Images were acquired with an epifluorescence microscope. (C, D) Experiments similar to that shown in (B) with liposomes of defined composition (C) or size (D). In (C) all liposomes were obtained by extrusion through 30 nm filters. In (D) all liposomes were used at a concentration of 250 µM lipids. The liposome fluorescence intensity in the Golgi area was determined. Each point corresponds to one cell from two to three independent experiments. (E) Domain organization of GMAP-210 and minimal model for membrane tethering (Drin et al., 2008). (F) Effects of membrane curvature and lipid unsaturation on the binding of the N-ter region of GMAP-210 to liposomes. Liposome binding was determined by monitoring the NBD fluorescence intensity. The plot shows the effect of liposome size and unsaturation from two independent experiments (triangles and inverted triangles). The fluorescence in solution was set at 1. Bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.002</doi>
+							<resource>https://elifesciences.org/articles/16988#fig1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 1. Liposome tethering properties of perforated cells.</title>
+							<subtitle>Large fields of RPE1 cells stably expressing Rab6-GFP after perforation and incubation with DOPC liposomes (extrusion 200 nm or 30 nm). Scale bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.003</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig1s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 1—figure supplement 2. Cumulative effects of membrane curvature and lipid unsaturation on the binding of the N-ter region of GMAP-210 to liposomes.</title>
+							<subtitle>Fluorescence spectra of mixtures containing 0.125 µM NBD-labeled GMAP-210 (fragment [1–375]) and liposomes (150 µM lipids) of the indicated size and composition. The fluorescence intensity at 540 nm was measured to build the plot of Figure 1F.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.004</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig1s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2. GMAP-210 is responsible for the ability of the Golgi to capture liposomes.</title>
+							<subtitle>(A) RPE1 cells were treated with siRNA against GMAP-210 or with control siRNA. After 72 hr, the cells were perforated and small DOPC liposomes (250 µM lipids), which were obtained by extrusion through 30 nm polycarbonate filters, were applied. Liposome capture was quantified as in Figure 1. The western blot shows the amount of GMAP-210 in the siRNA-treated cells. (B) Immunofluorescence characterization of RPE1 cells after treatment with anti GMAP-210 siRNA or control siRNA followed by perforation and incubation with small DOPC liposomes obtained by extrusion. The actual liposome radius is indicated. The images show one Z section as obtained in a confocal microscope. The profiles show the fluorescence intensity of the three markers along the horizontal lines as indicated in the merged images. Bars: 10 µm. Error bars: SEM (n = 4)</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.005</doi>
+							<resource>https://elifesciences.org/articles/16988#fig2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 2—figure supplement 1. GMAP-210 is responsible for the ability of the Golgi to capture liposomes.</title>
+							<subtitle>(A) RPE1 cells were treated with siRNA against GMAP-210 or with control siRNA. After 72 hr, the cells were perforated and small DOPC liposomes (250 µM lipids), which were obtained by extrusion through 30 nm polycarbonate filters, were applied. (B) Quantification of liposome capture from 4 independent experiments similar to (A). (C) Western blot analysis of the siRNA-treated cells. The data shown in (B) and (C) were used to build the bar plots shown in Figure 2A. Scale bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.006</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig2s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3. Mitochondria-anchored GMAP-210 ALPS competes with Golgi mini stacks for the capture of small liposomes.</title>
+							<subtitle>(A) Scheme of the constructs and principle of the experiment. Cells expressing ALPS-ACC1-GFP-FKBP and Mito-FRB were treated with nocodazole to disperse the Golgi apparatus into mini stacks. Thereafter, the cells were either treated with rapamycin or not, perforated, and incubated with small DOPC liposomes (extrusion: 30 nm). (B) In the absence rapamycin, small liposomes (extrusion 30 nm) colocalize with ALPS-ACC1-GFP-FKBP and with the Golgi mini stacks (as stained by anti GM130 antibody). (C) In the presence rapamycin, the small liposomes and ALPS-ACC1-GFP-FKBP colocalize in many regions that are negative for GM130. All images were acquired with a confocal microscope and were analyzed using Volocity software. These experiments were repeated three times. Data show representative images. Scale bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.007</doi>
+							<resource>https://elifesciences.org/articles/16988#fig3</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 1. Competition between mitochondria-anchored GMAP-210 ALPS and Golgi mini stacks for liposome capture.</title>
+							<subtitle>Cells were treated with nocodazole to disperse the Golgi apparatus into mini stacks and then with rapamycin to attach ALPS-ACC1-GFP-FKBP to mitochondria through Mito-FRB. Thereafter, the cells were perforated and incubated with small DOPC liposomes (extrusion: 30 nm). The mitochondria were visualized with MitoTracker. Images were acquired with a confocal microscope. Note that cell perforation causes the mitochondria network to break into small circular elements, around which ALPS-ACC1-GFP-FKBP and small DOPC liposomes were found. These experiments were repeated three times. Data show representative images. Scale bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.008</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig3s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 3—figure supplement 2. Mitochondria-anchored ALPS of GMAP-210 captures small but not large liposomes.</title>
+							<subtitle>Cells were treated with nocodazole to disperse the Golgi apparatus into mini stacks and with rapamycin to attach ALPS-ACC1-GFP-FKBP to mitochondria through Mito-FRB. Thereafter, the cells were perforated and incubated with small (extrusion: 30 nm) or large (extrusion: 200 nm) DOPC liposomes. After several washes, images were acquired with a confocal microscope and were analyzed using Volocity software. Note that only small liposomes are captured by the ALPS construct. These experiments were repeated three times. Data show representative images. Scare bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.009</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig3s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4. The ALPS motif of GMAP-210 targets cis Golgi vesicles.</title>
+							<subtitle>(A) Scheme of the constructs. The first construct corresponds to the N-terminal region of GMAP-210 (aa 1–375; ALPS = 1–38) fused to a C-ter fluorophore (GFP or mCherry). Alternatively, the ALPS motif of GMAP-210 was introduced upstream of an artificial coiled-coil (ACC1). (B) Subcellular localization of GCC- and ACC-based constructs by confocal fluorescence microscopy. Golgi localization was preserved by replacing the coiled-coil region of GMAP-210 (GCC) by an artificial coiled-coil (ACC1), but was abolished by deletion of the ALPS motif. Immunofluorescence of cells expressing ALPS-ACC1-GFP shows low colocalization with TGN46, intermediate overlap with GM130, and high colocalization with endogenous GMAP-210. All images were acquired with a confocal microscope and were analyzed using Volocity software. Scale bars: 10 µm, Z plane. (C) Immunogold EM of RPE1 cells expressing ALPS-ACC1-GFP. Scale bars: 10 µm (B) 100 nm (C). These experiments were repeated at least three times, except EM, which was repeated twice. Data show representative images.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.010</doi>
+							<resource>https://elifesciences.org/articles/16988#fig4</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 1. GMAP-210 depletion by siRNA does not affect the Golgi targeting of ALPS-containing probes.</title>
+							<subtitle>(A) RPE1 cells stably expressing ArfGAP1(R50K mutant)-GFP were transfected with siGMAP-210#2 or control siRNA for 72 hr. (B) RPE1 cells were transfected with siGMAP-210#2 or with control siRNA for 72 hr and then with ALPS-ACC1-GFP for 7 hr. In A and B, cells were then fixed, immunostained with antibodies against GMAP-210 and the cis-Golgi marker GalNT2, and visualized by confocal microscopy. Z plane, scale bar: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.011</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig4s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 4—figure supplement 2. ALPS-ACC1-GFP increases the liposome capture properties of cells.</title>
+							<subtitle>RPE1 cells were transitory transfected with ALPS-ACC1-GFP for 7 hr. Thereafter, the cells were perforated and 250 µM DOPC liposomes (extrusion 0.03 µm) were added for 5 min at 30°C. After several washes, images were acquired with a wide-field microscope and processed with ImageJ. Perforated cells are indicated by an asterisk. Those that express ALPS-ACC1-GFP show much higher liposome signal than those that do not express the construct. Scale bar: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.012</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig4s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 5. Selective targeting of the ALPS motif of GMAP-210 to cis Golgi vesicles without stereospecific interactions.</title>
+							<subtitle>(A, B) Sequence comparison of the ALPS motif of GMAP-210 and the corresponding inverted motif (invALPS). The two sequences have low identity (≈ 25%; A), but helical wheel-representations (B) show that they display the same amphipathic character. Helical representations were made with Heliquest (Gautier et al., 2008).(C) A coiled-coil construct harboring an inverted ALPS motif (invALPS-ACC2-GFP) displays the same subcellular localization as a construct harboring the original ALPS motif (ALPS-ACC1-mCherry). (D) Pearson coefficient between the green and red channels for the constructs shown in (C) as well as for other combinations of constructs or endogenous proteins. 30 cells were examined from 3 independent experiments. The vertical black bars show the mean ± SD. All images were acquired with a confocal microscope and were analyzed using Volocity software. Scale bars: 10 µm, Z plane.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.013</doi>
+							<resource>https://elifesciences.org/articles/16988#fig5</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6. The ALPS motif of GMAP-210 interacts with Golgi vesicles as an amphipathic helix.</title>
+							<subtitle>(A) Effect of mutations disrupting the amphipathic character of the ALPS motif of GMAP-210. For each mutant, a helical plot made with Heliquest (Gautier et al., 2008) is shown. Mutation L12D introduces a negative charge in the hydrophobic face. Ins20AA corresponds to 2 alanines inserted in the middle of the ALPS sequence. G11P should rigidify the sequence. (B) Effect of gradual truncation of the ALPS sequence. All mutants shown in (A) and (B) were derived from ALPS-ACC1-GFP. (C) Quantification. For both (A) and (B), ten cells were analyzed for each mutant. Once the background was subtracted, two ROI with same area were applied in the Golgi and in the cytosol. The average fluorescence was determined in each ROI and the Golgi/cytosol ratio was then calculated. All images were acquired with a confocal microscope and were analyzed using Volocity software. Scale bars: 10 µm, Z projections. Scale bars: 10 µm. The figure shows one experiment where all constructed were transfected in parallel and ten cells were analyzed for each condition. The horizontal bars show the means. Other experiments were performed with subgroups of mutants and gave similar results.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.014</doi>
+							<resource>https://elifesciences.org/articles/16988#fig6</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 6—figure supplement 1. Effects of point mutations on the Golgi localization of the ALPS motif of GMAP-210.</title>
+							<subtitle>This figure shows different images of the subcellular localization of some mutants described in Figure 6. The mutants G11P and [1–6/29–38] have a clear Golgi localization. However, their cytosolic fluorescent signal is much higher than that of wild-type ALPS-ACC1-GFP, implying a lower Golgi/cytosol ratio (see Figure 6C). Scale bar: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.015</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig6s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 7. The sparse distribution of hydrophobic residue in ALPS determines its selective cellular targeting and its sensitivity to membrane curvature.</title>
+							<subtitle>(A) Sequence comparison between the ALPS motif of GMAP-210 and the amphipathic helices of Arf1 and Sar1. Hydrophobic residues are shown in bold. In ALPS, most hydrophobic residues are sparse. In Arf1 and Sar, most hydrophobic residues are paired. By removing polar residues between sparse hydrophobic residues, the ALPS sequence was condensed (condALPS) to create hydrophobic pairs. (B) Localization of ALPS-ACC1-GFP, condALPS-ACC1-GFP, and Sar1-ACC1-GFP in RPE1 cells. Lipid droplets were revealed by lipidTox staining (red). Imaged were acquired from living cells using a spinning disk microscope. Z planes, scale bar: 10 µm. (C) Effect of adding hydrophobic residues in the ALPS 1–38 sequence or in the 8–30 truncated mutant. All mutants derived from the ALPS-ACC1-GFP construct. (D) Sensitivity of ALPS and condALPS peptides to membrane curvature. The peptides (1 µM) were incubated with liposomes (lipids 0.5 mM) of defined size. Tryptophan fluorescence was measured between 300 to 450 nm. The right plot shows the relative fluorescence at 340 nm as a function of liposome radius, setting the fluorescence in solution at 1. Error bars: SEM from four independent experiments. Scale bars: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.016</doi>
+							<resource>https://elifesciences.org/articles/16988#fig7</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 7—figure supplement 1. Subcellular localization of ALPS-ACC1-GFP, condALPS-ACC1-GFP, and Sar1-ACC1-GFP in RPE1 and U2OS cells.</title>
+							<subtitle>In RPE1 cells, condALPS-ACC1-GFP and Sar1-ACC1-GFP intensively labeled lipid droplets and to a lesser extent the ER and the nuclear envelope. In U2OS cells, the ER localization of condALPS-ACC1-GFP and Sar1-ACC1-GFP is more obvious given the reticular pattern of the ER in these cells. Imaged were acquired from living cells using a spinning disk microscope. Z planes, scale bar: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.017</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig7s1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 7—figure supplement 2. The sparse distribution of hydrophobic residue in ALPS determines its selective cellular targeting.</title>
+							<subtitle>This figure shows the subcellular localization of the same constructs as shown in Figure 7 but in comparison with the cis Golgi marker GM130. Whereas wild-type ALPS displays Golgi localization, mutants with hydrophobic pairs bind to other organelles besides the Golgi (e.g. nuclear envelope, ER network, lipid droplets). Scale bar: 10 µm.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.018</doi>
+							<resource>https://elifesciences.org/articles/16988/figures#fig7s2</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Figure 8. Distribution of lipid packing defects in model cis Golgi membranes.</title>
+							<subtitle>(A) Typical coarse grained models of lipid bilayers with a lipid composition similar to that of COPI vesicles (Brügger et al., 2000) and with a flat, tubular or spherical geometry. (B) Lipid composition of the bilayers. (C) Lipid packing defect distribution. For comparison, the results from simulations with flat POPC or spherical DOPC membranes (Vanni et al., 2014) are also shown. The inset shows the ratio between the number of defects in the vesicle or in the tube as compared to the flat membrane.</subtitle>
+						</titles>
+						<format mime_type="image/tiff"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.019</doi>
+							<resource>https://elifesciences.org/articles/16988#fig8</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Decision letter</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.020</doi>
+							<resource>https://elifesciences.org/articles/16988#SA1</resource>
+						</doi_data>
+					</component>
+					<component parent_relation="isPartOf">
+						<titles>
+							<title>Author response</title>
+						</titles>
+						<format mime_type="text/plain"/>
+						<doi_data>
+							<doi>10.7554/eLife.16988.021</doi>
+							<resource>https://elifesciences.org/articles/16988#SA2</resource>
+						</doi_data>
+					</component>
+				</component_list>
+			</journal_article>
+		</journal>
+	</body>
+</doi_batch>

--- a/tests/test_data/elife-crossref-16988-20170717071707.xml
+++ b/tests/test_data/elife-crossref-16988-20170717071707.xml
@@ -811,26 +811,6 @@
 							<resource>https://elifesciences.org/articles/16988#fig8</resource>
 						</doi_data>
 					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Decision letter</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.16988.020</doi>
-							<resource>https://elifesciences.org/articles/16988#SA1</resource>
-						</doi_data>
-					</component>
-					<component parent_relation="isPartOf">
-						<titles>
-							<title>Author response</title>
-						</titles>
-						<format mime_type="text/plain"/>
-						<doi_data>
-							<doi>10.7554/eLife.16988.021</doi>
-							<resource>https://elifesciences.org/articles/16988#SA2</resource>
-						</doi_data>
-					</component>
 				</component_list>
 			</journal_article>
 		</journal>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -68,7 +68,9 @@ class TestGenerate(unittest.TestCase):
             crossref_config = None
             if config_section:
                 crossref_config = parse_raw_config(raw_config(config_section))
-            crossref_xml = generate.crossref_xml(articles, crossref_config, pub_date, False)
+            # generate pretty XML
+            crossref_xml = generate.crossref_xml(
+                articles, crossref_config, pub_date, False, pretty=True, indent="\t")
             model_crossref_xml = read_file_content(TEST_DATA_PATH + crossref_xml_file)
             self.assertEqual(crossref_xml, model_crossref_xml.decode('utf-8'),
                              'Failed parse test on file %s' % article_xml_file)
@@ -76,7 +78,6 @@ class TestGenerate(unittest.TestCase):
     def test_parse_do_no_pass_pub_date(self):
         """
         For test coverage build a crossrefXML object without passing in a pub_date
-        and also test pretty output too for coverage
         """
         article_xml_file = 'elife_poa_e02725.xml'
         file_path = TEST_DATA_PATH + article_xml_file
@@ -87,7 +88,7 @@ class TestGenerate(unittest.TestCase):
         self.assertIsNotNone(crossref_object.pub_date)
         self.assertIsNotNone(crossref_object.generated)
         self.assertIsNotNone([tag for tag in crossref_object.root.iter() if tag is Comment])
-        self.assertIsNotNone(crossref_object.output_xml(pretty=True, indent='\t'))
+        self.assertIsNotNone(crossref_object.output_xml())
 
     def test_generate_jats_abstract_face_markup(self):
         """
@@ -123,7 +124,8 @@ class TestGenerate(unittest.TestCase):
         # build the article object
         articles = generate.build_articles_for_crossref([file_path])
         # generate and write to disk
-        generate.crossref_xml_to_disk(articles, crossref_config, pub_date, False)
+        generate.crossref_xml_to_disk(
+            articles, crossref_config, pub_date, False, "journal", pretty=True, indent="\t")
         # check the output matches
         expected_output = read_file_content(TEST_DATA_PATH + crossref_xml_file)
         generated_output = read_file_content(generate.TMP_DIR + crossref_xml_file)


### PR DESCRIPTION
Related to issue https://github.com/elifesciences/elife-crossref-feed/issues/141

New configuration value of `component_exclude_types`, is optional, the default is to not exclude any if missing, and makes this backwards compatible. To enable it, the `crossref.cfg` file used in production systems needs to be updated to be a non-empty list of component types.

The test fixtures are changed to be pretty XML for readability.