### PR TITLE
Use reparsed_tag() from elifetools library.

### DIFF
--- a/elifecrossref/abstract.py
+++ b/elifecrossref/abstract.py
@@ -1,4 +1,5 @@
 from elifearticle import utils as eautils
+from elifetools import xmlio
 from elifetools import utils as etoolsutils
 from elifecrossref import tags, utils
 
@@ -65,6 +66,6 @@ def set_abstract_tag(parent, abstract, abstract_type=None, jats_abstract=False):
     else:
         tag_converted_abstract = get_basic_abstract(abstract)
 
-    minidom_tag = tags.reparsed_tag(tag_name, tag_converted_abstract,
+    minidom_tag = xmlio.reparsed_tag(tag_name, tag_converted_abstract,
                                     attributes_text=attributes_text)
     tags.append_tag(parent, minidom_tag, attributes=attributes)

--- a/elifecrossref/tags.py
+++ b/elifecrossref/tags.py
@@ -37,7 +37,7 @@ def add_clean_tag(parent, tag_name, original_string,
     tag_converted_string = etoolsutils.escape_ampersand(tag_converted_string)
     tag_converted_string = etoolsutils.escape_unmatched_angle_brackets(
         tag_converted_string)
-    minidom_tag = reparsed_tag(tag_name, tag_converted_string, namespaces, attributes_text)
+    minidom_tag = xmlio.reparsed_tag(tag_name, tag_converted_string, namespaces, attributes_text)
     append_tag(parent, minidom_tag, attributes=attributes)
 
 
@@ -45,15 +45,8 @@ def add_inline_tag(parent, tag_name, original_string,
                    namespaces=REPARSING_NAMESPACES, attributes=None, attributes_text=''):
     """replace inline tags found in the original_string and then add a tag the parent"""
     tag_converted_string = convert_inline_tags(original_string)
-    minidom_tag = reparsed_tag(tag_name, tag_converted_string, namespaces, attributes_text)
+    minidom_tag = xmlio.reparsed_tag(tag_name, tag_converted_string, namespaces, attributes_text)
     append_tag(parent, minidom_tag, attributes=attributes)
-
-
-def reparsed_tag(tag_name, tag_string, namespaces=REPARSING_NAMESPACES, attributes_text=''):
-    """given final tag content and attributes, reparse to a minidom tag"""
-    tagged_string = ('<' + tag_name + namespaces + attributes_text + '>' +
-                     tag_string + '</' + tag_name + '>')
-    return minidom.parseString(tagged_string.encode('utf-8'))
 
 
 def append_tag(parent, minidom_tag, attributes=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@7f6f7d6210a731ec62c26ccbe92e86212e8f982e#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@a4a3e5921a3458b0e281eb5fcd730100ce690747#egg=elifearticle
 GitPython==2.1.7
 configparser==3.5.0


### PR DESCRIPTION
The `reparsed_tag()` function so moved over to the `elifetools` library. This refactor uses it and reduces the code duplication.

This should not be used in a project that is also using the latest `elifetools` release, otherwise the function isn't available.