### PR TITLE
Strip xref tags from abstract.

### DIFF
--- a/elifecrossref/abstract.py
+++ b/elifecrossref/abstract.py
@@ -51,6 +51,7 @@ def get_jats_abstract(abstract):
     abstract = eautils.replace_tags(abstract, 'sc', 'jats:sc')
     abstract = eautils.remove_tag('inline-formula', abstract)
     abstract = eautils.remove_tag('ext-link', abstract)
+    abstract = eautils.remove_tag('xref', abstract)
     return abstract
 
 

--- a/elifecrossref/utils.py
+++ b/elifecrossref/utils.py
@@ -14,6 +14,7 @@ def allowed_tags():
         '<inline-formula>', '</inline-formula>',
         '<mml:', '</mml:',
         '<ext-link', '</ext-link>',
+        '<xref', '</xref>',
     )
 
 

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -295,7 +295,8 @@ class TestGenerateAbstract(unittest.TestCase):
         self.abstract = (
             '<p><bold><italic><underline><sub><sup>An abstract. <ext-link ext-link-type="uri" ' +
             'xlink:href="http://dx.doi.org/10.1601/nm.3602">Desulfocapsa sulfexigens</ext-link>.' +
-            '</sup></sub></underline></italic></bold></p>')
+            '</sup></sub></underline></italic></bold>' +
+            ' <xref ref-type="bibr" rid="bib18">Stock and Wise (1990)</xref>.</p>')
 
     def test_set_abstract(self):
         """test stripping unwanted tags from abstract"""
@@ -305,7 +306,7 @@ class TestGenerateAbstract(unittest.TestCase):
         article.abstract = self.abstract
         expected_contains = (
             '<jats:abstract><jats:p>An abstract. Desulfocapsa sulfexigens.' +
-            '</jats:p></jats:abstract>')
+            ' Stock and Wise (1990).</jats:p></jats:abstract>')
         # generate
         crossref_object = generate.build_crossref_xml([article])
         crossref_xml_string = crossref_object.output_xml()
@@ -321,7 +322,7 @@ class TestGenerateAbstract(unittest.TestCase):
         expected_contains = (
             '<jats:abstract><jats:p><jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>' +
             'An abstract. Desulfocapsa sulfexigens.</jats:sup></jats:sub></jats:underline>' +
-            '</jats:italic></jats:bold></jats:p></jats:abstract>')
+            '</jats:italic></jats:bold> Stock and Wise (1990).</jats:p></jats:abstract>')
         # generate
         raw_config_object = raw_config('elife')
         jats_abstract = raw_config_object.get('jats_abstract')


### PR DESCRIPTION
Observed in June when testing Crossref deposit output from an IJMicrosim XML article, the abstract contained `<xref>` tags, and the tags ended up in the Crossref deposit file as tag escaped strings.

This will strip away `<xref>` and `</xref>` tags from the abstract. This is achieved by first adding them to the `utils.allowed_tags()` list -- which retains them in tagged form (i.e. does not escape the `<` characters into `&lt;` chars, etc.), and then later they are explicity stripped from JATS abstracts. In plain text abstracts, all tags are stripped by default.

I will merge this if tests are green. This change has no impact on the way eLife uses the library.