### PR TITLE
Add given_name only if non-empty.

### DIFF
--- a/elifecrossref/contributor.py
+++ b/elifecrossref/contributor.py
@@ -64,8 +64,9 @@ def set_person_name(parent, contributor, contributor_role, sequence):
     person_name_tag.set("contributor_role", contributor_role)
     person_name_tag.set("sequence", sequence)
 
-    given_name_tag = SubElement(person_name_tag, "given_name")
-    given_name_tag.text = contributor.given_name
+    if contributor.given_name:
+        given_name_tag = SubElement(person_name_tag, "given_name")
+        given_name_tag.text = contributor.given_name
 
     surname_tag = SubElement(person_name_tag, "surname")
     surname_tag.text = contributor.surname

--- a/tests/test_contributor.py
+++ b/tests/test_contributor.py
@@ -1,0 +1,47 @@
+import unittest
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+from elifearticle.article import Contributor
+from elifecrossref import contributor
+
+
+class TestSetPersonName(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_set_person_name(self):
+        """all person name fields"""
+        contributor_object = Contributor(None, 'Aardvark', 'Adam')
+        contributor_object.suffix = 'Jr.'
+        contributor_role = 'author'
+        sequence = 'first'
+        parent_tag = Element('person_name')
+        expected = (
+            '<person_name contributor_role="author" sequence="first">'
+            '<given_name>Adam</given_name>'
+            '<surname>Aardvark</surname><suffix>Jr.</suffix></person_name>'
+        )
+        person_name_element = contributor.set_person_name(
+            parent_tag, contributor_object, contributor_role, sequence)
+        rough_string = ElementTree.tostring(person_name_element).decode('utf-8')
+        self.assertEqual(rough_string, expected)
+
+    def test_set_person_name_no_given_name(self):
+        """all person name fields"""
+        contributor_object = Contributor(None, 'Aardvark', '')
+        contributor_role = 'author'
+        sequence = 'first'
+        parent_tag = Element('person_name')
+        expected = (
+            '<person_name contributor_role="author" sequence="first">'
+            '<surname>Aardvark</surname></person_name>'
+        )
+        person_name_element = contributor.set_person_name(
+            parent_tag, contributor_object, contributor_role, sequence)
+        rough_string = ElementTree.tostring(person_name_element).decode('utf-8')
+        self.assertEqual(rough_string, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-crossref-xml-generation/issues/79

Simple fix, with no expected backwards-compatibiltiy issues. Without this change there is the potential to create invalid Crossref deposit XML. Here we do not add an empty `<given_name/>` tag when a contributor has no given name specified.