### PR TITLE
Drop py27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "2.7"
+  - "3.5"
 # command to install dependencies
 install: ./travis-install.sh
 script: ./travis-test.sh

--- a/elifecrossref/generate.py
+++ b/elifecrossref/generate.py
@@ -133,10 +133,7 @@ def crossref_xml_to_disk(poa_articles, crossref_config=None, pub_date=None, add_
     # Write to file
     filename = TMP_DIR + os.sep + c_xml.batch_id + '.xml'
     with open(filename, "wb") as open_file:
-        try:
-            open_file.write(xml_string.encode('utf-8'))
-        except UnicodeDecodeError:  # pragma: no cover
-            open_file.write(xml_string)
+        open_file.write(xml_string.encode('utf-8'))
 
 
 def build_articles_for_crossref(article_xmls, detail='full', build_parts=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@a4a3e5921a3458b0e281eb5fcd730100ce690747#egg=elifearticle
+git+https://github.com/elifesciences/elife-tools.git@1ca1de40c9747a2ba25559ec5c5f52f00c1fd85e#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@158d5d9484aeb22bfb5109a79db3615f8fbe8ab0#egg=elifearticle
 GitPython==2.1.7
 configparser==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         ]
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py35
 [testenv]
 deps = -rrequirements.txt
 commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-crossref-xml-generation/issues/81

Outside of the regular `py27` changes, there was just one piece of exception handling that could also be removed regarding the writing of unicode file names.