### PR TITLE
Refactor setting update tag in crossmark module.

### DIFF
--- a/elifecrossref/crossmark.py
+++ b/elifecrossref/crossmark.py
@@ -70,8 +70,17 @@ def set_updates(parent, poa_article, crossref_config):
     default_pub_date = None
 
     updates = SubElement(parent, 'updates')
-    update = SubElement(updates, 'update')
-    update.set('type', poa_article.article_type)
-    update.set('date', dates.iso_date_string(
-        dates.get_pub_date(poa_article, crossref_config, default_pub_date)))
-    update.text = poa_article.related_articles[0].xlink_href
+    if poa_article.article_type in UPDATES_ARTICLE_TYPES:
+        set_update(
+            updates,
+            poa_article.article_type,
+            dates.iso_date_string(
+                dates.get_pub_date(poa_article, crossref_config, default_pub_date)),
+            poa_article.related_articles[0].xlink_href)
+
+
+def set_update(parent, article_type, date, doi):
+    update = SubElement(parent, 'update')
+    update.set('type', article_type)
+    update.set('date', date)
+    update.text = doi


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-crossref-feed/issues/147

Adding in-situ updates and corrections data in the Crossmark program is blocked for now, pending more discussion and clarity about article version history specifics.

Here is a little code change that can be salvaged from the code that was in development. This should make it easier to set the `<update>` tag content separately for corrections, retractions, and in-situ updates, when those are possible to add.