### PR TITLE
Add clinical trials data to Crossmark custom_data

### DIFF
--- a/crossref.cfg
+++ b/crossref.cfg
@@ -25,6 +25,7 @@ pub_date_types: ["pub", "publication", "epub", "epub-ppub"]
 reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:
+clinical_trials_registries: https://doi.org/10.18810/registries
 
 [elife]
 registrant: eLife

--- a/elifecrossref/clinical_trials.py
+++ b/elifecrossref/clinical_trials.py
@@ -1,0 +1,50 @@
+from collections import OrderedDict
+from xml.etree import ElementTree
+from xml.etree.ElementTree import SubElement
+import requests
+
+
+def do_clinical_trials(poa_article):
+    return bool(
+        hasattr(poa_article, 'clinical_trials')
+        and poa_article.clinical_trials)
+
+
+def parse_registries_xml(registries_xml):
+    """convert registries XML into a name to doi map"""
+    name_to_doi_map = OrderedDict()
+    tree = ElementTree.fromstring(registries_xml)
+    # simplified namespace name for easier finding
+    namespaces = {'xschema': 'http://www.crossref.org/xschema/1.1'}
+    for component in tree.findall('.//xschema:component_list/xschema:component', namespaces):
+        name_tag = component.find('.//xschema:titles/xschema:subtitle', namespaces)
+        doi_tag = component.find('.//xschema:doi_data/xschema:doi', namespaces)
+        name_to_doi_map[name_tag.text] = doi_tag.text
+    return name_to_doi_map
+
+
+def registry_name_to_doi_map(registry_url):
+    """get XML for clinical trials registries and turn into a name to doi map"""
+    response = requests.get(registry_url)
+    return parse_registries_xml(response.content)
+
+
+def set_clinical_trials(parent, poa_article, crossref_config):
+    if do_clinical_trials(poa_article):
+        # get a map of name to registry DOI
+        name_to_doi_map = (
+            registry_name_to_doi_map(crossref_config.get('clinical_trials_registries')) if
+            crossref_config.get('clinical_trials_registries') else None)
+        ai_program_tag = set_ct_program(parent)
+        for clinical_trial in poa_article.clinical_trials:
+            clinical_trial_number = SubElement(ai_program_tag, 'ct:clinical-trial-number')
+            clinical_trial_number.set(
+                'registry', clinical_trial.get_registry_doi(name_to_doi_map))
+            if clinical_trial.content_type:
+                clinical_trial_number.set('type', clinical_trial.content_type)
+            clinical_trial_number.text = clinical_trial.document_id
+
+
+def set_ct_program(parent):
+    ct_program_tag = SubElement(parent, 'ct:program')
+    return ct_program_tag

--- a/elifecrossref/clinical_trials.py
+++ b/elifecrossref/clinical_trials.py
@@ -4,6 +4,16 @@ from xml.etree.ElementTree import SubElement
 import requests
 
 
+# to convert to Crossref type values they accept
+CONTENT_TYPE_MAP = {
+    'pre-results': 'preResults',
+    'preResults': 'preResults',
+    'results': 'results',
+    'post-results': 'postResults',
+    'postResults': 'postResults',
+}
+
+
 def do_clinical_trials(poa_article):
     return bool(
         hasattr(poa_article, 'clinical_trials')
@@ -40,8 +50,9 @@ def set_clinical_trials(parent, poa_article, crossref_config):
             clinical_trial_number = SubElement(ai_program_tag, 'ct:clinical-trial-number')
             clinical_trial_number.set(
                 'registry', clinical_trial.get_registry_doi(name_to_doi_map))
-            if clinical_trial.content_type:
-                clinical_trial_number.set('type', clinical_trial.content_type)
+            if clinical_trial.content_type and clinical_trial.content_type in CONTENT_TYPE_MAP:
+                clinical_trial_number.set(
+                    'type', CONTENT_TYPE_MAP.get(clinical_trial.content_type))
             clinical_trial_number.text = clinical_trial.document_id
 
 

--- a/elifecrossref/crossmark.py
+++ b/elifecrossref/crossmark.py
@@ -1,5 +1,5 @@
 from xml.etree.ElementTree import SubElement
-from elifecrossref import access_indicators, dates, funding
+from elifecrossref import access_indicators, clinical_trials, dates, funding
 
 
 # article types currently supported for depositing simple updates via Crossmark
@@ -48,7 +48,8 @@ def set_crossmark(parent, poa_article, crossref_config):
 def do_custom_metadata(poa_article, crossref_config):
     return bool(
         access_indicators.do_access_indicators(poa_article, crossref_config)
-        or funding.do_funding(poa_article))
+        or funding.do_funding(poa_article)
+        or clinical_trials.do_clinical_trials(poa_article))
 
 
 def set_custom_metadata(parent, poa_article, crossref_config):
@@ -56,6 +57,7 @@ def set_custom_metadata(parent, poa_article, crossref_config):
         custom_metadata = SubElement(parent, 'custom_metadata')
         funding.set_fundref(custom_metadata, poa_article)
         access_indicators.set_access_indicators(custom_metadata, poa_article, crossref_config)
+        clinical_trials.set_clinical_trials(custom_metadata, poa_article, crossref_config)
 
 
 def do_updates(poa_article):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@230de0696fc43913558fbbb16e2a0c44fc04123f#egg=elifearticle
+git+https://github.com/elifesciences/elife-tools.git@141ccae952165238c94c46609b5608b190cead0e#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@e8f97a98e517718da4f3ff0e0145486e3a6dfe08#egg=elifearticle
 GitPython==3.1.2
 configparser==3.5.0
+requests==2.24.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         "elifetools",
         "elifearticle",
         "GitPython",
-        "configparser"
+        "configparser",
+        "requests"
     ],
     url='https://github.com/elifesciences/elife-crossref-xml-generation',
     maintainer='eLife Sciences Publications Ltd.',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@ from elifecrossref.conf import raw_config, parse_raw_config
 
 TEST_BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + os.sep
 TEST_DATA_PATH = TEST_BASE_PATH + "test_data" + os.sep
+FIXTURES_PATH = TEST_BASE_PATH + "fixtures" + os.sep
 
 
 def read_file_content(file_name):

--- a/tests/fixtures/clinical_trial_registries.xml
+++ b/tests/fixtures/clinical_trial_registries.xml
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crossref_result xmlns="http://www.crossref.org/qrschema/3.0" version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/qrschema/3.0 http://www.crossref.org/schemas/crossref_query_output3.0.xsd">
+  <query_result>
+    <head>
+      <doi_batch_id>none</doi_batch_id>
+    </head>
+    <body>
+      <query status="resolved">
+        <doi type="database_title">10.18810/registries</doi>
+        <crm-item name="citation-id" type="number">79733956</crm-item>
+        <crm-item name="book-id" type="number">2072611</crm-item>
+        <crm-item name="deposit-timestamp" type="number">202001710801</crm-item>
+        <crm-item name="owner-prefix" type="string">10.18810</crm-item>
+        <crm-item name="last-update" type="date">2020-04-07T11:31:23Z</crm-item>
+        <crm-item name="created" type="date">2016-01-04T18:36:51Z</crm-item>
+        <crm-item name="citedby-count" type="number">0</crm-item>
+        <doi_record>
+          <crossref xmlns="http://www.crossref.org/xschema/1.1" xsi:schemaLocation="http://www.crossref.org/xschema/1.1 http://doi.crossref.org/schemas/unixref1.1.xsd">
+            <database>
+              <database_metadata language="en">
+                <titles>
+                  <title>CrossRef clinical trials registries</title>
+                </titles>
+                <doi_data>
+                  <doi>10.18810/registries</doi>
+                  <resource>http://api.crossref.org/works/10.18810/registries.xml</resource>
+                </doi_data>
+              </database_metadata>
+              <component_list>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Uniform Trial Number</title>
+                    <subtitle>UTN</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Uniform Trial Number</description>
+                  <format mime_type="application/regex.clinical-trial-number">u[\d-]+</format>
+                  <doi_data>
+                    <doi>10.18810/utn</doi>
+                    <resource>http://api.crossref.org/works/10.18810/utn.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.who.int/ictrp/unambiguous_identification/en/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>ClinicalTrials.gov</title>
+                    <subtitle>ClinicalTrials.gov</subtitle>
+                    <!--  ??? same name and short???  -->
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>ClinicalTrials.gov</description>
+                  <format mime_type="application/regex.clinical-trial-number">nct\d+</format>
+                  <doi_data>
+                    <doi>10.18810/clinical-trials-gov</doi>
+                    <resource>http://api.crossref.org/works/10.18810/clinical-trials-gov.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.clinicaltrials.gov/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>ISRCTN.org</title>
+                    <subtitle>ISRCTN</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>ISRCTN.org</description>
+                  <format mime_type="application/regex.clinical-trial-number">isrctn\d+</format>
+                  <doi_data>
+                    <doi>10.18810/isrctn</doi>
+                    <resource>http://api.crossref.org/works/10.18810/isrctn.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.isrctn.com/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Australian New Zealand Clinical Trials Registry</title>
+                    <subtitle>ANZCTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Australian New Zealand Clinical Trials Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number">actrn\d+</format>
+                  <doi_data>
+                    <doi>10.18810/anzctr</doi>
+                    <resource>http://api.crossref.org/works/10.18810/anzctr.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.anzctr.org.au/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>German Clinical Trials Register</title>
+                    <subtitle>DRKS</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>German Clinical Trials Register</description>
+                  <format mime_type="application/regex.clinical-trial-number">drks\d+</format>
+                  <doi_data>
+                    <doi>10.18810/drks</doi>
+                    <resource>http://api.crossref.org/works/10.18810/drks.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>https://drks-neu.uniklinik-freiburg.de/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Chinese Clinical Trial Registry</title>
+                    <subtitle>ChiCTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Chinese Clinical Trial Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number">(?i)chictr[-a-z]*\d+</format>
+                  <doi_data>
+                    <doi>10.18810/chictr</doi>
+                    <resource>http://api.crossref.org/works/10.18810/chictr.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.chictr.org/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Brazilian Clinical Trials Registry / Registro Brasileiro de Ensaios Clínicos</title>
+                    <subtitle>ReBec</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Brazilian Clinical Trials Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number">rbr\d+</format>
+                  <doi_data>
+                    <doi>10.18810/rebec</doi>
+                    <resource>http://api.crossref.org/works/10.18810/rebec.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.ensaiosclinicos.gov.br/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Netherlands National Trial Register</title>
+                    <subtitle>NTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>etherlands National Trial Register</description>
+                  <format mime_type="application/regex.clinical-trial-number">ntr[-0-9]+</format>
+                  <doi_data>
+                    <doi>10.18810/dutch-trial-register</doi>
+                    <resource>http://api.crossref.org/works/10.18810/dutch-trial-register.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.trialregister.nl</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Clinical Trials Registry India</title>
+                    <subtitle>CTRI</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Clinical Trials Registry India</description>
+                  <format mime_type="application/regex.clinical-trial-number">ctri[\d/]+</format>
+                  <doi_data>
+                    <doi>10.18810/clinical-trial-registry-india</doi>
+                    <resource>http://api.crossref.org/works/10.18810/clinical-trial-registry-india.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.ctri.nic.in/Clinicaltrials</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>UMIN Japan</title>
+                    <subtitle>UMIN</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>UMIN Japan</description>
+                  <format mime_type="application/regex.clinical-trial-number">umin\d+</format>
+                  <doi_data>
+                    <doi>10.18810/umin-japan</doi>
+                    <resource>http://api.crossref.org/works/10.18810/umin-japan.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.umin.ac.jp/english/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Pan African Clinical Trial Registry</title>
+                    <subtitle>PACTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Pan African Clinical Trial Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number">pactr\d+</format>
+                  <doi_data>
+                    <doi>10.18810/pactr</doi>
+                    <resource>http://api.crossref.org/works/10.18810/pactr.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.pactr.org/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Sri Lanka Clinical Trials Registry</title>
+                    <subtitle>SLCTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Sri Lanka Clinical Trials Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number">slctr[\d/]+</format>
+                  <doi_data>
+                    <doi>10.18810/slctr</doi>
+                    <resource>http://api.crossref.org/works/10.18810/slctr.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://slctr.lk/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Japan Medical Association Clinical Trial Registry</title>
+                    <subtitle>JMACCT</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Japan Medical Association Clinical Trial Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number" />
+                  <doi_data>
+                    <doi>10.18810/jma</doi>
+                    <resource>http://api.crossref.org/works/10.18810/jma.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://www.jmacct.med.or.jp/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Iranian Registry of Clinical Trials</title>
+                    <subtitle>IRCT</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Iranian Registry of Clinical Trials</description>
+                  <format mime_type="application/regex.clinical-trial-number">irct[0-9a-z]+</format>
+                  <doi_data>
+                    <doi>10.18810/irct</doi>
+                    <resource>http://api.crossref.org/works/10.18810/irct.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://irct.ir/</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Clinical Research Information Service, Republic of Korea</title>
+                    <subtitle>CRiS</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Clinical Research Information Service, Republic of Korea</description>
+                  <format mime_type="application/regex.clinical-trial-number">kct\d+</format>
+                  <doi_data>
+                    <doi>10.18810/cris</doi>
+                    <resource>http://api.crossref.org/works/10.18810/cris.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>https://cris.nih.go.kr</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Cuban Public Registry of Clinical Trials</title>
+                    <subtitle>RPCEC</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Cuban Public Registry of Clinical Trials</description>
+                  <format mime_type="application/regex.clinical-trial-number">rpcec\d+</format>
+                  <doi_data>
+                    <doi>10.18810/rpec</doi>
+                    <resource>http://api.crossref.org/works/10.18810/rpec.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://registroclinico.sld.cu</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>EU Clinical Trials Register</title>
+                    <subtitle>EU-CTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>EU Clinical Trials Register</description>
+                  <format mime_type="application/regex.clinical-trial-number">\d{4}-\d+-\d+</format>
+                  <doi_data>
+                    <doi>10.18810/euctr</doi>
+                    <resource>http://api.crossref.org/works/10.18810/euctr.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>https://www.clinicaltrialsregister.eu</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Japan Primary Registries Network</title>
+                    <subtitle>JPRN</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Japan Primary Registries Network</description>
+                  <format mime_type="application/regex.clinical-trial-number" />
+                  <doi_data>
+                    <doi>10.18810/jprn</doi>
+                    <resource>http://api.crossref.org/works/10.18810/jprn.xml</resource>
+                    <collection property="unspecified">
+                      <item>
+                        <resource>http://rctportal.niph.go.jp</resource>
+                      </item>
+                    </collection>
+                  </doi_data>
+                </component>
+                <component parent_relation="isPartOf">
+                  <titles>
+                    <title>Thai Clinical Trials Registry</title>
+                    <subtitle>TCTR</subtitle>
+                  </titles>
+                  <publication_date>
+                    <month>10</month>
+                    <day>13</day>
+                    <year>2015</year>
+                  </publication_date>
+                  <description>Thai Clinical Trials Registry</description>
+                  <format mime_type="application/regex.clinical-trial-number">tctr\d+</format>
+                  <doi_data>
+                    <doi>10.18810/tctr</doi>
+                    <resource>http://api.crossref.org/works/10.18810/tctr.xml</resource>
+                  </doi_data>
+                </component>
+              </component_list>
+            </database>
+          </crossref>
+        </doi_record>
+      </query>
+    </body>
+  </query_result>
+</crossref_result>

--- a/tests/test_clinical_trials.py
+++ b/tests/test_clinical_trials.py
@@ -53,6 +53,33 @@ class TestSetClinicalTrials(unittest.TestCase):
         rough_string = ElementTree.tostring(parent).decode('utf-8')
         self.assertEqual(rough_string, expected)
 
+    @patch.object(clinical_trials, 'registry_name_to_doi_map')
+    def test_set_clinical_trials_edge_case(self, fake_name_map):
+        """test edge case of crossref-doi type and alternate content-type value"""
+        fake_name_map.return_value = OrderedDict([
+            ('ClinicalTrials.gov', '10.18810/clinical-trials-gov')
+        ])
+        parent = Element('custom_metadata')
+        article = Article('10.7554/eLife.00666')
+        clinical_trial = ClinicalTrial()
+        clinical_trial.source_id = '10.18810/clinical-trials-gov'
+        clinical_trial.source_id_type = 'crossref-doi'
+        clinical_trial.document_id = 'TEST999'
+        clinical_trial.content_type = 'post-results'
+        article.clinical_trials = [clinical_trial]
+        expected = (
+            '<custom_metadata>'
+            '<ct:program>'
+            '<ct:clinical-trial-number registry="10.18810/clinical-trials-gov" type="postResults">'
+            'TEST999'
+            '</ct:clinical-trial-number>'
+            '</ct:program>'
+            '</custom_metadata>')
+        clinical_trials.set_clinical_trials(
+            parent, article, {'clinical_trials_registries': 'https://doi.org/10.18810/registries'})
+        rough_string = ElementTree.tostring(parent).decode('utf-8')
+        self.assertEqual(rough_string, expected)
+
 
 class TestRegistryNameMap(unittest.TestCase):
 

--- a/tests/test_clinical_trials.py
+++ b/tests/test_clinical_trials.py
@@ -1,0 +1,99 @@
+import os
+import unittest
+from unittest.mock import patch
+from collections import OrderedDict
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+import requests
+from elifearticle.article import Article, ClinicalTrial
+from elifecrossref import clinical_trials
+from tests import FIXTURES_PATH, read_file_content
+
+
+class FakeResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+        self.content = None
+
+
+class TestDoClinicalTrials(unittest.TestCase):
+
+    def test_do_clinical_trials(self):
+        article = Article('10.7554/eLife.00666')
+        article.clinical_trials = [ClinicalTrial()]
+        do_result = clinical_trials.do_clinical_trials(article)
+        self.assertTrue(do_result)
+
+
+class TestSetClinicalTrials(unittest.TestCase):
+
+    @patch.object(clinical_trials, 'registry_name_to_doi_map')
+    def test_set_clinical_trials(self, fake_name_map):
+        fake_name_map.return_value = OrderedDict([
+            ('ClinicalTrials.gov', '10.18810/clinical-trials-gov')
+        ])
+        parent = Element('custom_metadata')
+        article = Article('10.7554/eLife.00666')
+        clinical_trial = ClinicalTrial()
+        clinical_trial.source_id = 'ClinicalTrials.gov'
+        clinical_trial.source_id_type = 'registry-name'
+        clinical_trial.document_id = 'TEST999'
+        clinical_trial.content_type = 'preResults'
+        article.clinical_trials = [clinical_trial]
+        expected = (
+            '<custom_metadata>'
+            '<ct:program>'
+            '<ct:clinical-trial-number registry="10.18810/clinical-trials-gov" type="preResults">'
+            'TEST999'
+            '</ct:clinical-trial-number>'
+            '</ct:program>'
+            '</custom_metadata>')
+        clinical_trials.set_clinical_trials(
+            parent, article, {'clinical_trials_registries': 'https://doi.org/10.18810/registries'})
+        rough_string = ElementTree.tostring(parent).decode('utf-8')
+        self.assertEqual(rough_string, expected)
+
+
+class TestRegistryNameMap(unittest.TestCase):
+
+    @patch.object(requests, 'get')
+    def test_registry_name_to_doi_map(self, fake_get):
+        registries_response = FakeResponse()
+        registries_response.content = '<xml />'
+        fake_get.return_value = registries_response
+        # expected value
+        expected = OrderedDict()
+        # issue call for the registries XML
+        registry_url = 'https://example.org'
+        name_map = clinical_trials.registry_name_to_doi_map(registry_url)
+        # assertions
+        self.assertEqual(name_map, expected)
+
+
+class TestParseRegistriesXml(unittest.TestCase):
+
+    def test_parse_registries_xml(self):
+        expected = OrderedDict([
+            ('UTN', '10.18810/utn'),
+            ('ClinicalTrials.gov', '10.18810/clinical-trials-gov'),
+            ('ISRCTN', '10.18810/isrctn'),
+            ('ANZCTR', '10.18810/anzctr'),
+            ('DRKS', '10.18810/drks'),
+            ('ChiCTR', '10.18810/chictr'),
+            ('ReBec', '10.18810/rebec'),
+            ('NTR', '10.18810/dutch-trial-register'),
+            ('CTRI', '10.18810/clinical-trial-registry-india'),
+            ('UMIN', '10.18810/umin-japan'),
+            ('PACTR', '10.18810/pactr'),
+            ('SLCTR', '10.18810/slctr'),
+            ('JMACCT', '10.18810/jma'),
+            ('IRCT', '10.18810/irct'),
+            ('CRiS', '10.18810/cris'),
+            ('RPCEC', '10.18810/rpec'),
+            ('EU-CTR', '10.18810/euctr'),
+            ('JPRN', '10.18810/jprn'),
+            ('TCTR', '10.18810/tctr')
+            ])
+        name_map = clinical_trials.parse_registries_xml(read_file_content(
+            os.path.join(FIXTURES_PATH, 'clinical_trial_registries.xml')))
+        self.assertEqual(name_map, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-crossref-feed/issues/146

CrossMark program, if the depositor is participating, can also accept clinical trial data in the `<custom_meta>` tag of the Crossref deposit.

The `ClinicalTrial` object will be populated when article XML is parsed.

The `elifecrossref/clinical_trials.py` module is new, which includes
- deciding whether to add clinical trials to the Crossref deposit
- parse the Crossref clinical trials registries XML file
- download the Crossref registries XML from them
- set the XML tags in the Crossref deposit to hold the clinical trials data

In order to download the registries XML from Crossref, `requests` library is now a requirement for this library.

The hook to add clinical trials is added to the `elifecrossref/crossmark.py` module.

There are tests to cover
- adding a clinical trial where the DOI needs to by looked up by name
- adding a clinical trial where the DOI was specified directly in the article XML file (when it is `crossref-doi` as its `source_id_type`)
- tests for parsing the registries XML file into a name to DOI map