### PR TITLE
Use remove_tag functions from latest elifetools.

### DIFF
--- a/elifecrossref/abstract.py
+++ b/elifecrossref/abstract.py
@@ -45,14 +45,14 @@ def replace_jats_tag(from_tag_name, to_tag_name, string):
 def convert_sec_tags(string):
     # convert section title tags to paragraphs
     string = replace_jats_tag('title', 'jats:p', string)
-    return utils.remove_tag('sec', string)
+    return etoolsutils.remove_tag('sec', string)
 
 
 def get_basic_abstract(abstract):
     # Strip inline tags, keep the p tags
-    abstract = utils.remove_tag_and_text('object-id', abstract)
-    abstract = utils.remove_tag('related-object', abstract)
-    abstract = utils.remove_tag('abstract', abstract)
+    abstract = etoolsutils.remove_tag_and_text('object-id', abstract)
+    abstract = etoolsutils.remove_tag('related-object', abstract)
+    abstract = etoolsutils.remove_tag('abstract', abstract)
     abstract = utils_html.remove_comment_tags(abstract)
     abstract = etoolsutils.escape_ampersand(abstract)
     abstract = etoolsutils.escape_unmatched_angle_brackets(abstract, utils.allowed_tags())
@@ -64,8 +64,8 @@ def get_basic_abstract(abstract):
 
 def get_jats_abstract(abstract):
     # Convert the abstract to jats abstract tags
-    abstract = utils.remove_tag_and_text('object-id', abstract)
-    abstract = utils.remove_tag('abstract', abstract)
+    abstract = etoolsutils.remove_tag_and_text('object-id', abstract)
+    abstract = etoolsutils.remove_tag('abstract', abstract)
     abstract = utils_html.remove_comment_tags(abstract)
     abstract = etoolsutils.escape_ampersand(abstract)
     abstract = etoolsutils.escape_unmatched_angle_brackets(abstract, utils.allowed_tags())

--- a/elifecrossref/utils.py
+++ b/elifecrossref/utils.py
@@ -26,13 +26,3 @@ def clean_string(string):
     if string:
         return re.sub(r'[^a-zA-Z0-9_\-]', '', str(string))
     return None
-
-
-def remove_tag(tag_name, string):
-    pattern = r'\s*</?%s.*?>\s*' % tag_name
-    return re.sub(pattern, '', string)
-
-
-def remove_tag_and_text(tag_name, string):
-    pattern = r'\s*<%s.*?>.*?</%s>\s*' % (tag_name, tag_name)
-    return re.sub(pattern, '', string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@ffa1e5e8f25544c9d111e410728f6f3282f7be5c#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@a5b93afbe4db7852bf1aa12265090d60140fca8e#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@efb0f8c02b149c9f307e64be23470ae1989f540e#egg=elifearticle
 GitPython==3.1.2
 configparser==3.5.0


### PR DESCRIPTION
The functions `remove_tag()` and `remove_tag_and_text()` were altered a little and added to the https://github.com/elifesciences/elife-tools library for re-use with other Python libraries. This change uses those and removes the locally defined functions from this particular library.