### PR TITLE
Abstract XML namespaces change and remove @rid attributes

### DIFF
--- a/elifecrossref/abstract.py
+++ b/elifecrossref/abstract.py
@@ -1,4 +1,5 @@
 import re
+from xml.dom import minidom
 from elifearticle import utils as eautils
 from elifetools import utils_html
 from elifetools import xmlio
@@ -103,14 +104,52 @@ def set_abstract_tag(parent, abstract, abstract_type=None, jats_abstract=False):
 
     tag_converted_abstract = re.sub('>\n', '>', tag_converted_abstract)
 
-    # add extra namespace attributes if applicable
-    for namespace in XML_NAMESPACES:
-        tag_match = '<%s' % namespace.get('prefix')
-        attribute_match = ' %s' % namespace.get('prefix')
-        if (tag_match not in attributes and
-                (tag_match in tag_converted_abstract or attribute_match in tag_converted_abstract)):
-            attributes.append(namespace.get('attribute'))
-
     minidom_tag = xmlio.reparsed_tag(
         tag_name, tag_converted_abstract, attributes_text=attributes_text)
+
+    # add extra namespace attributes to jats:p tags if applicable
+    for p_tag in minidom_tag.getElementsByTagName('jats:p'):
+        if p_tag.hasChildNodes():
+            attributes_added = add_namespace_attributes(p_tag)
+            for attribute in attributes_added:
+                if attribute not in attributes:
+                    attributes.append(attribute)
+
     tags.append_tag(parent, minidom_tag, attributes=attributes)
+
+
+def add_namespace_attributes(minidom_element):
+    "add namespace attributes to the minidom Element if it contains namespaced tags or attributes"
+    attributes = []
+    tag_names, attribute_names = child_element_value_names(minidom_element)
+    for namespace in XML_NAMESPACES:
+        for tag_name in set.union(tag_names, attribute_names):
+            if tag_name.startswith(namespace.get('prefix')):
+                minidom_element.setAttributeNS(
+                    namespace.get('uri'), namespace.get('attribute'), namespace.get('uri'))
+                attributes.append(namespace.get('attribute'))
+    return attributes
+
+
+def child_element_value_names(minidom_tag, tag_names=None, attribute_names=None):
+    "recursively get a list of all child element tag names and attribute names"
+
+    if tag_names is None:
+        tag_names = set()
+
+    if attribute_names is None:
+        attribute_names = set()
+
+    # process the Element nodes only
+    for child_element in [child for child in minidom_tag.childNodes
+                          if isinstance(child, minidom.Element)]:
+        tag_names.add(child_element.tagName)
+        for i in range(0, child_element.attributes.length):
+            attribute_names.add(child_element.attributes.item(i).name)
+
+        if child_element.hasChildNodes():
+            # call again recursively for all other child nodes
+            tag_names, attribute_names = child_element_value_names(
+                child_element, tag_names, attribute_names)
+
+    return tag_names, attribute_names

--- a/elifecrossref/abstract.py
+++ b/elifecrossref/abstract.py
@@ -43,6 +43,11 @@ def replace_jats_tag(from_tag_name, to_tag_name, string):
     return string
 
 
+def remove_tag_attr(attr_name, string):
+    pattern_from = r'\s+%s=".*?"' % attr_name
+    return re.sub(pattern_from, '', string)
+
+
 def convert_sec_tags(string):
     # convert section title tags to paragraphs
     string = replace_jats_tag('title', 'jats:p', string)
@@ -86,6 +91,9 @@ def get_jats_abstract(abstract):
     abstract = replace_jats_tag('inline-formula', 'jats:inline-formula', abstract)
     abstract = replace_jats_tag('ext-link', 'jats:ext-link', abstract)
     abstract = replace_jats_tag('xref', 'jats:xref', abstract)
+
+    # remove rid attributes
+    abstract = remove_tag_attr('rid', abstract)
 
     return abstract
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,4 +1,6 @@
 import unittest
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
 from elifecrossref import abstract
 
 
@@ -38,4 +40,95 @@ class TestGetJatsAbstract(unittest.TestCase):
             '<jats:ext-link ext-link-type="doi" xlink:href="10.7554/eLife.15272.001">'
             'https://doi.org/10.7554/eLife.15272.001</jats:ext-link></jats:p>')
         self.assertEqual(abstract.get_jats_abstract(string), expected)
- 
+
+
+class TestSetAbstractTag(unittest.TestCase):
+
+    def test_set_abstract_tag(self):
+        parent = Element('root')
+        string = (
+            '<abstract>'
+            '<sec id="s1"><title content-type="sub">Section title:</title>'
+            '<p>Paragraph.</p></sec>'
+            '</abstract>')
+        jats_abstract = False
+        expected = (
+            b'<?xml version=\'1.0\' encoding=\'utf8\'?>\n'
+            b'<root>'
+            b'<jats:abstract>'
+            b'<jats:p content-type="sub">Section title:</jats:p>'
+            b'<jats:p>Paragraph.</jats:p>'
+            b'</jats:abstract>'
+            b'</root>')
+        abstract.set_abstract_tag(parent, string, jats_abstract=jats_abstract)
+        parent_string = ElementTree.tostring(parent, 'utf8')
+        self.assertEqual(parent_string, expected)
+
+    def test_set_abstract_tag_jats(self):
+        parent = Element('root')
+        string = (
+            '<abstract>'
+            '<sec id="s1"><title content-type="sub">Section title:</title>'
+            '<p>Paragraph.</p></sec>'
+            '</abstract>')
+        jats_abstract = True
+        expected = (
+            b'<?xml version=\'1.0\' encoding=\'utf8\'?>\n'
+            b'<root>'
+            b'<jats:abstract>'
+            b'<jats:sec id="s1">'
+            b'<jats:title content-type="sub">Section title:</jats:title>'
+            b'<jats:p>Paragraph.</jats:p>'
+            b'</jats:sec>'
+            b'</jats:abstract>'
+            b'</root>')
+        abstract.set_abstract_tag(parent, string, jats_abstract=jats_abstract)
+        parent_string = ElementTree.tostring(parent, 'utf8')
+        self.assertEqual(parent_string, expected)
+
+    def test_set_abstract_tag_mathml(self):
+        parent = Element('root')
+        string = (
+            '<abstract>'
+            '<p>This is the abstract.'
+            '<inline-formula><mml:math><mml:mn>0</mml:mn></mml:math></inline-formula>'
+            '</p></abstract>')
+        jats_abstract = False
+        expected = (
+            b'<?xml version=\'1.0\' encoding=\'utf8\'?>\n'
+            b'<root>'
+            b'<jats:abstract xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            b'<jats:p xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            b'This is the abstract.'
+            b'<mml:math><mml:mn>0</mml:mn></mml:math>'
+            b'</jats:p>'
+            b'</jats:abstract>'
+            b'</root>')
+        abstract.set_abstract_tag(parent, string, jats_abstract=jats_abstract)
+        parent_string = ElementTree.tostring(parent, 'utf8')
+        self.assertEqual(parent_string, expected)
+
+    def test_set_abstract_tag_nested_ext_link(self):
+        parent = Element('root')
+        string = (
+            '<abstract>'
+            '<p>Paragraph</p>'
+            '<p><bold>'
+            '<ext-link ext-link-type="doi" xlink:href="10.7554/eLife.15272.001">'
+            'https://doi.org/10.7554/eLife.15272.001</ext-link></bold></p>'
+            '</abstract>')
+        jats_abstract = True
+        expected = (
+            b'<?xml version=\'1.0\' encoding=\'utf8\'?>\n'
+            b'<root>'
+            b'<jats:abstract xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b'<jats:p>Paragraph</jats:p>'
+            b'<jats:p xmlns:xlink="http://www.w3.org/1999/xlink"><jats:bold>'
+            b'<jats:ext-link ext-link-type="doi" xlink:href="10.7554/eLife.15272.001">'
+            b'https://doi.org/10.7554/eLife.15272.001</jats:ext-link>'
+            b'</jats:bold></jats:p>'
+            b'</jats:abstract>'
+            b'</root>')
+        abstract.set_abstract_tag(parent, string, jats_abstract=jats_abstract)
+        parent_string = ElementTree.tostring(parent, 'utf8')
+        self.assertEqual(parent_string, expected)

--- a/tests/test_data/elife-crossref-00666-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00666-20170717071707.xml
@@ -47,7 +47,7 @@
 					<organization contributor_role="author" sequence="additional">for the eLife Staff Team</organization>
 				</contributors>
 				<jats:abstract xmlns:mml="http://www.w3.org/1998/Math/MathML">
-					<jats:p>
+					<jats:p xmlns:mml="http://www.w3.org/1998/Math/MathML">
 						This is the abstract. This article will describe the eLife article and the process.
                     An abstract can contain any formatting, such as italics,
                         bold, superscript, subscript or small caps. MathML is

--- a/tests/test_data/elife-crossref-02043-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02043-20170717071707.xml
@@ -42,7 +42,7 @@
 					</person_name>
 				</contributors>
 				<jats:abstract xmlns:mml="http://www.w3.org/1998/Math/MathML">
-					<jats:p>
+					<jats:p xmlns:mml="http://www.w3.org/1998/Math/MathML">
 						Cyanobacteria are photosynthetic bacteria with a unique CO2 concentrating mechanism (CCM), enhancing carbon fixation. Understanding the CCM requires a systems level perspective of how molecular components work together to enhance CO2 fixation. We present a mathematical model of the cyanobacterial CCM, giving the parameter regime (expression levels, catalytic rates, permeability of carboxysome shell) for efficient carbon fixation. Efficiency requires saturating the RuBisCO reaction, staying below saturation for carbonic anhydrase, and avoiding wasteful oxygenation reactions. We find selectivity at the carboxysome shell is not necessary; there is an optimal non-specific carboxysome shell permeability. We compare the efficacy of facilitated CO2 uptake, CO2 scavenging, and 
 						<mml:math id="inf1">
 							<mml:mrow>

--- a/tests/test_generate_abstract.py
+++ b/tests/test_generate_abstract.py
@@ -56,9 +56,7 @@ class TestGenerateAbstract(unittest.TestCase):
         # generate
         raw_config_object = raw_config('elife')
         jats_abstract = raw_config_object.get('jats_abstract')
-        face_markup = raw_config_object.get('face_markup')
         raw_config_object['jats_abstract'] = 'true'
-        raw_config_object['face_markup'] = 'true'
         crossref_config = parse_raw_config(raw_config_object)
         crossref_object = generate.CrossrefXML([article], crossref_config, None, True)
         crossref_xml_string = crossref_object.output_xml()
@@ -66,4 +64,3 @@ class TestGenerateAbstract(unittest.TestCase):
         self.assertTrue(expected_contains in crossref_xml_string)
         # now set the config back to normal
         raw_config_object['jats_abstract'] = jats_abstract
-        raw_config_object['face_markup'] = face_markup

--- a/tests/test_generate_abstract.py
+++ b/tests/test_generate_abstract.py
@@ -45,10 +45,12 @@ class TestGenerateAbstract(unittest.TestCase):
         article.abstract_xml = self.abstract_xml
         expected_contains = (
             '<jats:abstract xmlns:xlink="http://www.w3.org/1999/xlink">'
-            '<jats:p><jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>An abstract. '
+            '<jats:p xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>'
+            'An abstract. '
             '<jats:ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1601/nm.3602">'
-            'Desulfocapsa sulfexigens</jats:ext-link>.</jats:sup></jats:sub>'
-            '</jats:underline></jats:italic></jats:bold> '
+            'Desulfocapsa sulfexigens</jats:ext-link>.'
+            '</jats:sup></jats:sub></jats:underline></jats:italic></jats:bold> '
             '<jats:xref ref-type="bibr" rid="bib18">Stock and Wise (1990)</jats:xref>.'
             '</jats:p></jats:abstract>')
         # generate

--- a/tests/test_generate_abstract.py
+++ b/tests/test_generate_abstract.py
@@ -51,7 +51,7 @@ class TestGenerateAbstract(unittest.TestCase):
             '<jats:ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1601/nm.3602">'
             'Desulfocapsa sulfexigens</jats:ext-link>.'
             '</jats:sup></jats:sub></jats:underline></jats:italic></jats:bold> '
-            '<jats:xref ref-type="bibr" rid="bib18">Stock and Wise (1990)</jats:xref>.'
+            '<jats:xref ref-type="bibr">Stock and Wise (1990)</jats:xref>.'
             '</jats:p></jats:abstract>')
         # generate
         raw_config_object = raw_config('elife')

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -313,37 +313,6 @@ class TestGenerateAbstract(unittest.TestCase):
         # test assertion
         self.assertTrue(expected_contains in crossref_xml_string)
 
-    def test_set_abstract_jats_abstract_format(self):
-        """test the abstract using jats abstract format set to true"""
-        doi = "10.7554/eLife.00666"
-        title = "Test article"
-        article = Article(doi, title)
-        article.abstract = self.abstract
-        expected_contains = (
-            '<jats:abstract xmlns:xlink="http://www.w3.org/1999/xlink">'
-            '<jats:p xmlns:xlink="http://www.w3.org/1999/xlink">'
-            '<jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>'
-            'An abstract. '
-            '<jats:ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1601/nm.3602">'
-            'Desulfocapsa sulfexigens</jats:ext-link>.'
-            '</jats:sup></jats:sub></jats:underline></jats:italic></jats:bold> '
-            '<jats:xref ref-type="bibr" rid="bib18">Stock and Wise (1990)</jats:xref>.'
-            '</jats:p></jats:abstract>')
-        # generate
-        raw_config_object = raw_config('elife')
-        jats_abstract = raw_config_object.get('jats_abstract')
-        face_markup = raw_config_object.get('face_markup')
-        raw_config_object['jats_abstract'] = 'true'
-        raw_config_object['face_markup'] = 'true'
-        crossref_config = parse_raw_config(raw_config_object)
-        crossref_object = generate.CrossrefXML([article], crossref_config, None, True)
-        crossref_xml_string = crossref_object.output_xml()
-        # test assertion
-        self.assertTrue(expected_contains in crossref_xml_string)
-        # now set the config back to normal
-        raw_config_object['jats_abstract'] = jats_abstract
-        raw_config_object['face_markup'] = face_markup
-
 
 class TestGenerateTitles(unittest.TestCase):
 

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -321,11 +321,14 @@ class TestGenerateAbstract(unittest.TestCase):
         article.abstract = self.abstract
         expected_contains = (
             '<jats:abstract xmlns:xlink="http://www.w3.org/1999/xlink">'
-            '<jats:p><jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>An abstract. '
+            '<jats:p xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<jats:bold><jats:italic><jats:underline><jats:sub><jats:sup>'
+            'An abstract. '
             '<jats:ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1601/nm.3602">'
-            'Desulfocapsa sulfexigens</jats:ext-link>.</jats:sup></jats:sub></jats:underline>'
-            '</jats:italic></jats:bold> <jats:xref ref-type="bibr" rid="bib18">'
-            'Stock and Wise (1990)</jats:xref>.</jats:p></jats:abstract>')
+            'Desulfocapsa sulfexigens</jats:ext-link>.'
+            '</jats:sup></jats:sub></jats:underline></jats:italic></jats:bold> '
+            '<jats:xref ref-type="bibr" rid="bib18">Stock and Wise (1990)</jats:xref>.'
+            '</jats:p></jats:abstract>')
         # generate
         raw_config_object = raw_config('elife')
         jats_abstract = raw_config_object.get('jats_abstract')


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5743

As a result of viewing some JATS abstracts in the Crossref API, the `<jats:abstract>` tag is not included in their output. That would make the addition of XML namespaces on that tag to have no effect for any end users, since those namespaces would be stripped away by Crossref.

This code change will additionally add the XML namespaces to `<jats:p>` tags, when applicable. Traversing the minidom tree of elements, it collects names of tags and attributes of those tags, which are later assessed for whether they are part of a namespace, and if so, it adds the XML namespace attributes to that `<jats:p>` tag.

Another improvement is to strip away any `@rid` attributes from tags, in case those would cause XML parsing issues when trying to use the abstract value from Crossref's API.