### PR TITLE
Change elife reference_distribution_opts in default crossref.cfg

### DIFF
--- a/crossref.cfg
+++ b/crossref.cfg
@@ -48,7 +48,7 @@ elife_style_component_doi: true
 year_of_first_volume: 2012
 elocation_id: true
 access_indicators_applies_to: ["vor", "am", "tdm"]
-reference_distribution_opts: any
+reference_distribution_opts: 
 text_mining_xml_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.xml
 text_mining_pdf_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.pdf
 iparadigms_poa_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.pdf

--- a/tests/test_data/elife-crossref-00508-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00508-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>2</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Imaging-based chemical screening reveals activity-dependent neural differentiation of pluripotent stem cells</title>
 				</titles>

--- a/tests/test_data/elife-crossref-00666-20170717071707.xml
+++ b/tests/test_data/elife-crossref-00666-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>5</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>The eLife research article</title>
 				</titles>
@@ -40,7 +40,7 @@
 								<institution_place>Cambridge, United Kingdom</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0003-3523-4408</ORCID>
+						<ORCID>http://orcid.org/0000-0003-3523-4408</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="first">
 						<given_name>James F</given_name>

--- a/tests/test_data/elife-crossref-02020-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02020-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>3</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Diagnostically relevant facial gestalt information from ordinary photos</title>
 				</titles>

--- a/tests/test_data/elife-crossref-02043-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02043-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>3</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Systems analysis of the CO2 concentrating mechanism in cyanobacteria</title>
 				</titles>

--- a/tests/test_data/elife-crossref-02725-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02725-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>6</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Mismatch repair deficiency endows tumors with a unique mutation signature and sensitivity to DNA double-strand breaks</title>
 				</titles>
@@ -49,7 +49,7 @@
 								<institution_place>Leuven, Belgium</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0002-8772-6845</ORCID>
+						<ORCID>http://orcid.org/0000-0002-8772-6845</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="additional">
 						<given_name>Betül Tuba</given_name>
@@ -70,7 +70,7 @@
 								<institution_place>Leuven, Belgium</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0001-8880-9311</ORCID>
+						<ORCID>http://orcid.org/0000-0001-8880-9311</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="additional">
 						<given_name>Joke</given_name>

--- a/tests/test_data/elife-crossref-02935-20170717071707.xml
+++ b/tests/test_data/elife-crossref-02935-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>3</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Origins and functional consequences of somatic mitochondrial DNA mutations in human cancer</title>
 				</titles>

--- a/tests/test_data/elife-crossref-04637-20170717071707.xml
+++ b/tests/test_data/elife-crossref-04637-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>4</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Non-crossover gene conversions show strong GC bias and unexpected clustering in humans</title>
 				</titles>

--- a/tests/test_data/elife-crossref-08206-20170717071707.xml
+++ b/tests/test_data/elife-crossref-08206-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>4</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Extracellular space preservation aids the connectomic analysis of neural circuits</title>
 				</titles>
@@ -39,7 +39,7 @@
 								<institution_place>Bethesda, United States</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0001-7694-0398</ORCID>
+						<ORCID>http://orcid.org/0000-0001-7694-0398</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="first">
 						<given_name>Paul V</given_name>

--- a/tests/test_data/elife-crossref-11134-20170717071707.xml
+++ b/tests/test_data/elife-crossref-11134-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>4</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>cryo-EM structures of the E. coli replicative DNA polymerase reveal its dynamic interactions with the DNA sliding clamp, exonuclease and τ</title>
 				</titles>
@@ -39,7 +39,7 @@
 								<institution_place>Cambridge, United Kingdom</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0002-7941-0357</ORCID>
+						<ORCID>http://orcid.org/0000-0002-7941-0357</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="first">
 						<given_name>Julian</given_name>
@@ -60,7 +60,7 @@
 								<institution_place>Cambridge, United Kingdom</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0002-0462-6540</ORCID>
+						<ORCID>http://orcid.org/0000-0002-0462-6540</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="additional">
 						<given_name>Meindert H</given_name>

--- a/tests/test_data/elife-crossref-12444-20170717071707.xml
+++ b/tests/test_data/elife-crossref-12444-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>5</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>The autophagy gene Atg16l1 differentially regulates Treg and TH2 cells to control intestinal inflammation</title>
 				</titles>
@@ -171,7 +171,7 @@
 								<institution_place>Oxford, United Kingdom</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0001-5795-7688</ORCID>
+						<ORCID>http://orcid.org/0000-0001-5795-7688</ORCID>
 					</person_name>
 				</contributors>
 				<jats:abstract>

--- a/tests/test_data/elife-crossref-15743-20170717071707.xml
+++ b/tests/test_data/elife-crossref-15743-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>5</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>Correction: Dosage compensation can buffer copy-number variation in wild yeast</title>
 				</titles>
@@ -53,7 +53,7 @@
 					<person_name contributor_role="author" sequence="additional">
 						<given_name>Audrey P</given_name>
 						<surname>Gasch</surname>
-						<ORCID authenticated="true">http://orcid.org/0000-0002-8182-257X</ORCID>
+						<ORCID>http://orcid.org/0000-0002-8182-257X</ORCID>
 					</person_name>
 				</contributors>
 				<publication_date media_type="online">

--- a/tests/test_data/elife-crossref-16988-20170717071707.xml
+++ b/tests/test_data/elife-crossref-16988-20170717071707.xml
@@ -25,7 +25,7 @@
 					<volume>5</volume>
 				</journal_volume>
 			</journal_issue>
-			<journal_article publication_type="full_text" reference_distribution_opts="any">
+			<journal_article publication_type="full_text">
 				<titles>
 					<title>A filter at the entrance of the Golgi that selects vesicles according to size and bulk lipid composition</title>
 				</titles>
@@ -79,7 +79,7 @@
 								<institution_place>Valbonne, France</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0003-2146-1140</ORCID>
+						<ORCID>http://orcid.org/0000-0003-2146-1140</ORCID>
 					</person_name>
 					<person_name contributor_role="author" sequence="additional">
 						<given_name>Bruno</given_name>
@@ -90,7 +90,7 @@
 								<institution_place>Valbonne, France</institution_place>
 							</institution>
 						</affiliations>
-						<ORCID authenticated="true">http://orcid.org/0000-0002-9166-8668</ORCID>
+						<ORCID>http://orcid.org/0000-0002-9166-8668</ORCID>
 					</person_name>
 				</contributors>
 				<jats:abstract>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/9240

Change the `crossref.cfg` option to reflect valid output for Crossref version 5.4.0